### PR TITLE
Detect and remediate version drift between CLI, proxy, and images

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -76,3 +76,19 @@ if [ -n "$COMPLETIONS_SHELL" ]; then
 fi
 
 echo "Installed. Run 'isx' to get started."
+
+# ── Post-upgrade: detect stale proxy ─────────────────────────────────────
+if systemctl --user is-active --quiet incus-spawn-proxy 2>/dev/null; then
+    echo ""
+    echo "  The proxy service (incus-spawn-proxy) is running."
+    echo "  It may be running the previous version of isx."
+    read -p "  Restart proxy service now? (Y/n): " ANSWER
+    ANSWER="${ANSWER:-y}"
+    if [ "$ANSWER" = "y" ] || [ "$ANSWER" = "Y" ]; then
+        systemctl --user restart incus-spawn-proxy
+        echo "  Proxy service restarted."
+    else
+        echo "  Skipped. Restart manually when ready:"
+        echo "    systemctl --user restart incus-spawn-proxy"
+    fi
+fi

--- a/install.sh
+++ b/install.sh
@@ -82,8 +82,12 @@ if systemctl --user is-active --quiet incus-spawn-proxy 2>/dev/null; then
     echo ""
     echo "  The proxy service (incus-spawn-proxy) is running."
     echo "  It may be running the previous version of isx."
-    read -p "  Restart proxy service now? (Y/n): " ANSWER
-    ANSWER="${ANSWER:-y}"
+    if [ -t 0 ]; then
+        read -p "  Restart proxy service now? (Y/n): " ANSWER
+        ANSWER="${ANSWER:-y}"
+    else
+        ANSWER="n"
+    fi
     if [ "$ANSWER" = "y" ] || [ "$ANSWER" = "Y" ]; then
         systemctl --user restart incus-spawn-proxy
         echo "  Proxy service restarted."

--- a/src/main/java/dev/incusspawn/command/BranchCommand.java
+++ b/src/main/java/dev/incusspawn/command/BranchCommand.java
@@ -5,6 +5,7 @@ import dev.incusspawn.config.ProjectConfig;
 import dev.incusspawn.incus.IncusClient;
 import dev.incusspawn.incus.Metadata;
 import dev.incusspawn.incus.ResourceLimits;
+import dev.incusspawn.proxy.CertificateAuthority;
 import dev.incusspawn.proxy.MitmProxy;
 import dev.incusspawn.proxy.ProxyHealthCheck;
 import jakarta.inject.Inject;
@@ -66,6 +67,7 @@ public class BranchCommand implements Runnable {
         var networkMode = resolveNetworkMode();
         if (networkMode != NetworkMode.AIRGAP) {
             if (!ProxyHealthCheck.checkOrWarn(incus)) return;
+            if (checkCaMismatch(resolvedSource)) return;
         }
 
         System.out.println("Branching '" + name + "' from '" + resolvedSource + "'...");
@@ -271,6 +273,24 @@ public class BranchCommand implements Runnable {
         } catch (Exception e) {
             return "1000";
         }
+    }
+
+    private boolean checkCaMismatch(String source) {
+        var imageCaFp = incus.configGet(source, Metadata.CA_FINGERPRINT);
+        if (imageCaFp.isEmpty()) return false;
+        var localCaFp = CertificateAuthority.currentCaFingerprint();
+        if (localCaFp.isEmpty() || imageCaFp.equals(localCaFp)) return false;
+        var profile = incus.configGet(source, Metadata.PROFILE);
+        var sep = "\033[33m" + "─".repeat(60) + "\033[0m";
+        System.err.println(sep);
+        System.err.println("\033[1;33mCA certificate mismatch\033[0m");
+        System.err.println("Template '" + source + "' was built with a different CA certificate.");
+        System.err.println("TLS connections through the proxy will fail in branches.");
+        if (!profile.isEmpty()) {
+            System.err.println("Rebuild the template to fix: \033[1misx build " + profile + "\033[0m");
+        }
+        System.err.println(sep);
+        return true;
     }
 
     private void waitForReady(String container) {

--- a/src/main/java/dev/incusspawn/command/BuildCommand.java
+++ b/src/main/java/dev/incusspawn/command/BuildCommand.java
@@ -3,6 +3,7 @@ package dev.incusspawn.command;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import dev.incusspawn.BuildInfo;
 import dev.incusspawn.RuntimeConstants;
 import dev.incusspawn.config.ImageDef;
 import dev.incusspawn.config.SpawnConfig;
@@ -288,6 +289,7 @@ public class BuildCommand implements java.util.concurrent.Callable<Integer> {
         incus.configSet(targetName, Metadata.PROFILE, targetName);
         incus.configSet(targetName, Metadata.PARENT, parentName);
         incus.configSet(targetName, Metadata.CREATED, Metadata.today());
+        stampBuildVersion(targetName);
 
         System.out.println("Stopping image...");
         incus.stop(targetName);
@@ -414,6 +416,7 @@ public class BuildCommand implements java.util.concurrent.Callable<Integer> {
         incus.configSet(targetName, Metadata.TYPE, Metadata.TYPE_BASE);
         incus.configSet(targetName, Metadata.PROFILE, targetName);
         incus.configSet(targetName, Metadata.CREATED, Metadata.today());
+        stampBuildVersion(targetName);
 
         // Stop the template (it's a stopped snapshot you branch from, not a running instance)
         System.out.println("Stopping image...");
@@ -535,6 +538,13 @@ public class BuildCommand implements java.util.concurrent.Callable<Integer> {
             try { Thread.sleep(1000); } catch (InterruptedException e) { break; }
         }
         System.err.println("Warning: container " + container + " may not be fully ready.");
+    }
+
+    private void stampBuildVersion(String container) {
+        var info = BuildInfo.instance();
+        incus.configSet(container, Metadata.BUILD_VERSION, info.version());
+        incus.configSet(container, Metadata.BUILD_SHA, info.gitSha());
+        incus.configSet(container, Metadata.CA_FINGERPRINT, CertificateAuthority.currentCaFingerprint());
     }
 
     private void requireSuccess(int exitCode, String message) {

--- a/src/main/java/dev/incusspawn/command/ListCommand.java
+++ b/src/main/java/dev/incusspawn/command/ListCommand.java
@@ -1,9 +1,11 @@
 package dev.incusspawn.command;
 
+import dev.incusspawn.BuildInfo;
 import dev.incusspawn.config.NetworkMode;
 import dev.incusspawn.incus.IncusClient;
 import dev.incusspawn.incus.Metadata;
 import dev.incusspawn.incus.ResourceLimits;
+import dev.incusspawn.proxy.CertificateAuthority;
 import dev.incusspawn.proxy.MitmProxy;
 import dev.incusspawn.proxy.ProxyHealthCheck;
 import dev.tamboui.layout.Constraint;
@@ -246,11 +248,12 @@ public class ListCommand implements Runnable {
                 }
             }
             if (match != null) {
+                var buildVer = incus.configGet(name, Metadata.BUILD_VERSION);
                 templateEntries.add(new TemplateInfo(name, def.getDescription(),
-                        match.created.isEmpty() ? "built" : match.created, match.runtime));
+                        match.created.isEmpty() ? "built" : match.created, match.runtime, buildVer));
                 templateNames.add(name);
             } else {
-                templateEntries.add(new TemplateInfo(name, def.getDescription(), "not built", ""));
+                templateEntries.add(new TemplateInfo(name, def.getDescription(), "not built", "", ""));
             }
         }
         buildTemplateRowData();
@@ -1710,11 +1713,21 @@ public class ListCommand implements Runnable {
 
     private void buildTemplateRowData() {
         templateRows = new ArrayList<>();
+        var currentVersion = BuildInfo.instance().version();
         for (var t : templateEntries) {
             var statusDisplay = "not built".equals(t.buildStatus) ? "not built" : Metadata.ageDescription(t.buildStatus);
             var statusStyle = "not built".equals(t.buildStatus)
                     ? Style.EMPTY.fg(Color.GRAY)
                     : Style.EMPTY.fg(Color.GREEN);
+            if (!"not built".equals(t.buildStatus)) {
+                if (!t.buildVersion.isEmpty() && !t.buildVersion.equals(currentVersion)) {
+                    statusDisplay += " (v" + t.buildVersion + ")";
+                    statusStyle = Style.EMPTY.fg(Color.YELLOW);
+                } else if (t.buildVersion.isEmpty()) {
+                    statusDisplay += " (pre-versioning)";
+                    statusStyle = Style.EMPTY.fg(Color.YELLOW);
+                }
+            }
             var desc = t.description == null ? "" : t.description;
             templateRows.add(Row.from(t.name, statusDisplay, desc).style(statusStyle));
         }
@@ -1912,7 +1925,28 @@ public class ListCommand implements Runnable {
     private boolean showProxyErrorIfNeeded(String containerName) {
         var networkModeStr = incus.configGet(containerName, Metadata.NETWORK_MODE);
         if (NetworkMode.AIRGAP.name().equals(networkModeStr)) return false;
-        return showProxyError();
+        if (showProxyError()) return true;
+        fixCaMismatchIfNeeded(containerName);
+        return false;
+    }
+
+    private void fixCaMismatchIfNeeded(String containerName) {
+        var imageCaFp = incus.configGet(containerName, Metadata.CA_FINGERPRINT);
+        if (imageCaFp.isEmpty()) return;
+        var ca = CertificateAuthority.loadOrCreate();
+        if (imageCaFp.equals(ca.caFingerprint())) return;
+
+        var info = incus.exec("list", containerName, "--format=csv", "--columns=s");
+        if (info.success() && info.stdout().strip().equalsIgnoreCase("STOPPED")) {
+            incus.start(containerName);
+            waitForReady(containerName);
+        }
+        incus.shellExec(containerName, "sh", "-c",
+                "cat > /etc/pki/ca-trust/source/anchors/incus-spawn-mitm.crt << 'CERTEOF'\n" +
+                ca.caCertPem() +
+                "CERTEOF");
+        incus.shellExec(containerName, "update-ca-trust");
+        incus.configSet(containerName, Metadata.CA_FINGERPRINT, ca.caFingerprint());
     }
 
     private void shellInto(String name) {
@@ -2012,7 +2046,7 @@ public class ListCommand implements Runnable {
     }
 
     private record TemplateInfo(String name, String description,
-                                String buildStatus, String runtime) {}
+                                String buildStatus, String runtime, String buildVersion) {}
 
     private record InstanceInfo(String name, String status,
                                 String project, String profile, String created,

--- a/src/main/java/dev/incusspawn/command/ListCommand.java
+++ b/src/main/java/dev/incusspawn/command/ListCommand.java
@@ -1931,22 +1931,12 @@ public class ListCommand implements Runnable {
     }
 
     private void fixCaMismatchIfNeeded(String containerName) {
-        var imageCaFp = incus.configGet(containerName, Metadata.CA_FINGERPRINT);
-        if (imageCaFp.isEmpty()) return;
-        var ca = CertificateAuthority.loadOrCreate();
-        if (imageCaFp.equals(ca.caFingerprint())) return;
-
         var info = incus.exec("list", containerName, "--format=csv", "--columns=s");
         if (info.success() && info.stdout().strip().equalsIgnoreCase("STOPPED")) {
             incus.start(containerName);
             waitForReady(containerName);
         }
-        incus.shellExec(containerName, "sh", "-c",
-                "cat > /etc/pki/ca-trust/source/anchors/incus-spawn-mitm.crt << 'CERTEOF'\n" +
-                ca.caCertPem() +
-                "CERTEOF");
-        incus.shellExec(containerName, "update-ca-trust");
-        incus.configSet(containerName, Metadata.CA_FINGERPRINT, ca.caFingerprint());
+        CertificateAuthority.fixContainerCaIfNeeded(incus, containerName);
     }
 
     private void shellInto(String name) {

--- a/src/main/java/dev/incusspawn/command/ProxyCommand.java
+++ b/src/main/java/dev/incusspawn/command/ProxyCommand.java
@@ -175,6 +175,16 @@ public class ProxyCommand {
             switch (status) {
                 case RUNNING -> {
                     System.out.println("Proxy is running.");
+                    var proxyInfo = ProxyHealthCheck.fetchProxyInfo(gatewayIp);
+                    if (proxyInfo != null) {
+                        if (!proxyInfo.isLegacy()) {
+                            System.out.println("  Version:         " + proxyInfo.version() + " (" + proxyInfo.gitSha() + ")");
+                        }
+                        var drift = ProxyHealthCheck.checkVersionDrift(proxyInfo);
+                        if (!drift.isEmpty()) {
+                            System.out.println("  \033[1;33m>>> " + drift + "\033[0m");
+                        }
+                    }
                     System.out.println("  Health endpoint: http://" + gatewayIp + ":" + MitmProxy.DEFAULT_HEALTH_PORT + "/health");
                     System.out.println("  MITM port:       " + MitmProxy.DEFAULT_MITM_PORT);
                     if (serviceActive) {

--- a/src/main/java/dev/incusspawn/command/ShellCommand.java
+++ b/src/main/java/dev/incusspawn/command/ShellCommand.java
@@ -3,6 +3,7 @@ package dev.incusspawn.command;
 import dev.incusspawn.config.NetworkMode;
 import dev.incusspawn.incus.IncusClient;
 import dev.incusspawn.incus.Metadata;
+import dev.incusspawn.proxy.CertificateAuthority;
 import dev.incusspawn.proxy.ProxyHealthCheck;
 import jakarta.inject.Inject;
 import picocli.CommandLine.Command;
@@ -32,6 +33,7 @@ public class ShellCommand implements Runnable {
         var networkMode = incus.configGet(name, Metadata.NETWORK_MODE);
         if (!NetworkMode.AIRGAP.name().equals(networkMode)) {
             if (!ProxyHealthCheck.checkOrWarn(incus)) return;
+            fixCaMismatch(name);
         }
 
         // Start if stopped
@@ -44,6 +46,42 @@ public class ShellCommand implements Runnable {
 
         System.out.println("Connecting to " + name + "...\n");
         incus.interactiveShell(name, "agentuser");
+    }
+
+    private void fixCaMismatch(String container) {
+        var imageCaFp = incus.configGet(container, Metadata.CA_FINGERPRINT);
+        if (imageCaFp.isEmpty()) return;
+        var ca = CertificateAuthority.loadOrCreate();
+        if (imageCaFp.equals(ca.caFingerprint())) return;
+
+        var sep = "\033[33m" + "─".repeat(60) + "\033[0m";
+        System.err.println(sep);
+        System.err.println("\033[1;33mCA certificate mismatch\033[0m");
+        System.err.println("This container was built with a different CA certificate.");
+        System.err.println("Updating CA certificate in the container...");
+
+        // Ensure the container is running so we can push the cert
+        var info = incus.exec("list", container, "--format=csv", "--columns=s");
+        boolean wasStarted = false;
+        if (info.success() && info.stdout().strip().equalsIgnoreCase("STOPPED")) {
+            incus.start(container);
+            waitForReady(container);
+            wasStarted = true;
+        }
+
+        incus.shellExec(container, "sh", "-c",
+                "cat > /etc/pki/ca-trust/source/anchors/incus-spawn-mitm.crt << 'CERTEOF'\n" +
+                ca.caCertPem() +
+                "CERTEOF");
+        incus.shellExec(container, "update-ca-trust");
+        incus.configSet(container, Metadata.CA_FINGERPRINT, ca.caFingerprint());
+
+        if (wasStarted) {
+            // Leave it running — we'll connect to it next
+        }
+
+        System.err.println("CA certificate updated.");
+        System.err.println(sep);
     }
 
     private void waitForReady(String container) {

--- a/src/main/java/dev/incusspawn/command/ShellCommand.java
+++ b/src/main/java/dev/incusspawn/command/ShellCommand.java
@@ -49,39 +49,19 @@ public class ShellCommand implements Runnable {
     }
 
     private void fixCaMismatch(String container) {
-        var imageCaFp = incus.configGet(container, Metadata.CA_FINGERPRINT);
-        if (imageCaFp.isEmpty()) return;
-        var ca = CertificateAuthority.loadOrCreate();
-        if (imageCaFp.equals(ca.caFingerprint())) return;
-
-        var sep = "\033[33m" + "─".repeat(60) + "\033[0m";
-        System.err.println(sep);
-        System.err.println("\033[1;33mCA certificate mismatch\033[0m");
-        System.err.println("This container was built with a different CA certificate.");
-        System.err.println("Updating CA certificate in the container...");
-
         // Ensure the container is running so we can push the cert
         var info = incus.exec("list", container, "--format=csv", "--columns=s");
-        boolean wasStarted = false;
         if (info.success() && info.stdout().strip().equalsIgnoreCase("STOPPED")) {
             incus.start(container);
             waitForReady(container);
-            wasStarted = true;
         }
 
-        incus.shellExec(container, "sh", "-c",
-                "cat > /etc/pki/ca-trust/source/anchors/incus-spawn-mitm.crt << 'CERTEOF'\n" +
-                ca.caCertPem() +
-                "CERTEOF");
-        incus.shellExec(container, "update-ca-trust");
-        incus.configSet(container, Metadata.CA_FINGERPRINT, ca.caFingerprint());
-
-        if (wasStarted) {
-            // Leave it running — we'll connect to it next
+        if (CertificateAuthority.fixContainerCaIfNeeded(incus, container)) {
+            var sep = "\033[33m" + "─".repeat(60) + "\033[0m";
+            System.err.println(sep);
+            System.err.println("\033[1;33mCA certificate mismatch\033[0m — updated automatically.");
+            System.err.println(sep);
         }
-
-        System.err.println("CA certificate updated.");
-        System.err.println(sep);
     }
 
     private void waitForReady(String container) {

--- a/src/main/java/dev/incusspawn/incus/Metadata.java
+++ b/src/main/java/dev/incusspawn/incus/Metadata.java
@@ -18,6 +18,9 @@ public final class Metadata {
     public static final String PROFILE = PREFIX + "profile";
     public static final String NETWORK_MODE = PREFIX + "network-mode";
     public static final String PROXY_GATEWAY = PREFIX + "proxy-gateway";
+    public static final String BUILD_VERSION = PREFIX + "build-version";
+    public static final String BUILD_SHA = PREFIX + "build-sha";
+    public static final String CA_FINGERPRINT = PREFIX + "ca-fingerprint";
 
     public static final String TYPE_BASE = "base";
     public static final String TYPE_PROJECT = "project";

--- a/src/main/java/dev/incusspawn/proxy/CertificateAuthority.java
+++ b/src/main/java/dev/incusspawn/proxy/CertificateAuthority.java
@@ -123,6 +123,21 @@ public class CertificateAuthority {
         }
     }
 
+    public String caFingerprint() {
+        try {
+            var md = java.security.MessageDigest.getInstance("SHA-256");
+            var digest = md.digest(caCert.getEncoded());
+            return java.util.HexFormat.of().formatHex(digest);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to compute CA fingerprint", e);
+        }
+    }
+
+    public static String currentCaFingerprint() {
+        if (!exists()) return "";
+        return loadOrCreate().caFingerprint();
+    }
+
     public PrivateKey caKey() {
         return caKey;
     }

--- a/src/main/java/dev/incusspawn/proxy/CertificateAuthority.java
+++ b/src/main/java/dev/incusspawn/proxy/CertificateAuthority.java
@@ -1,6 +1,8 @@
 package dev.incusspawn.proxy;
 
 import dev.incusspawn.config.SpawnConfig;
+import dev.incusspawn.incus.IncusClient;
+import dev.incusspawn.incus.Metadata;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -136,6 +138,27 @@ public class CertificateAuthority {
     public static String currentCaFingerprint() {
         if (!exists()) return "";
         return loadOrCreate().caFingerprint();
+    }
+
+    /**
+     * Check whether a container's stored CA fingerprint matches the current CA.
+     * If mismatched, push the current cert into the container and update metadata.
+     * Returns true if a fix was applied, false if no action was needed.
+     * Containers without a stored fingerprint (pre-versioning) are skipped.
+     */
+    public static boolean fixContainerCaIfNeeded(IncusClient incus, String container) {
+        var imageCaFp = incus.configGet(container, Metadata.CA_FINGERPRINT);
+        if (imageCaFp.isEmpty()) return false;
+        var ca = loadOrCreate();
+        if (imageCaFp.equals(ca.caFingerprint())) return false;
+
+        incus.shellExec(container, "sh", "-c",
+                "cat > /etc/pki/ca-trust/source/anchors/incus-spawn-mitm.crt << 'CERTEOF'\n" +
+                ca.caCertPem() +
+                "CERTEOF");
+        incus.shellExec(container, "update-ca-trust");
+        incus.configSet(container, Metadata.CA_FINGERPRINT, ca.caFingerprint());
+        return true;
     }
 
     public PrivateKey caKey() {

--- a/src/main/java/dev/incusspawn/proxy/MitmProxy.java
+++ b/src/main/java/dev/incusspawn/proxy/MitmProxy.java
@@ -1,5 +1,6 @@
 package dev.incusspawn.proxy;
 
+import dev.incusspawn.BuildInfo;
 import dev.incusspawn.RuntimeConstants;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpServer;
@@ -146,6 +147,9 @@ public class MitmProxy {
     // Optional debug traffic logger
     private ApiTrafficLog debugLog;
 
+    // CA fingerprint computed at startup for the health endpoint
+    private String caFingerprint = "";
+
     public MitmProxy(String bindAddress, int mitmPort, int healthPort,
                      String anthropicApiKey, String ghToken,
                      boolean useVertex, String vertexRegion, String vertexProjectId) {
@@ -253,6 +257,7 @@ public class MitmProxy {
 
         // Load or create CA, generate per-domain certs
         var ca = CertificateAuthority.loadOrCreate();
+        caFingerprint = ca.caFingerprint();
         serverSslContext = buildServerSslContext(ca);
 
         // Start health check HTTP server
@@ -1230,7 +1235,12 @@ public class MitmProxy {
     // --- Health check ---
 
     private void handleHealthCheck(HttpExchange exchange) throws IOException {
-        var response = "{\"status\":\"ok\"}".getBytes();
+        var info = BuildInfo.instance();
+        var response = ("{\"status\":\"ok\""
+                + ",\"version\":\"" + info.version() + "\""
+                + ",\"gitSha\":\"" + info.gitSha() + "\""
+                + ",\"caFingerprint\":\"" + caFingerprint + "\"}")
+                .getBytes();
         exchange.getResponseHeaders().add("Content-Type", "application/json");
         exchange.sendResponseHeaders(200, response.length);
         exchange.getResponseBody().write(response);

--- a/src/main/java/dev/incusspawn/proxy/ProxyHealthCheck.java
+++ b/src/main/java/dev/incusspawn/proxy/ProxyHealthCheck.java
@@ -1,5 +1,6 @@
 package dev.incusspawn.proxy;
 
+import dev.incusspawn.BuildInfo;
 import dev.incusspawn.incus.IncusClient;
 
 import java.net.HttpURLConnection;
@@ -11,6 +12,10 @@ public final class ProxyHealthCheck {
         RUNNING,
         NOT_RUNNING,
         STALE_DNS
+    }
+
+    public record ProxyInfo(String version, String gitSha, String caFingerprint) {
+        public boolean isLegacy() { return version == null || version.isEmpty(); }
     }
 
     private ProxyHealthCheck() {}
@@ -42,6 +47,38 @@ public final class ProxyHealthCheck {
         } catch (Exception e) {
             return false;
         }
+    }
+
+    public static ProxyInfo fetchProxyInfo(String gatewayIp) {
+        try {
+            var url = URI.create("http://" + gatewayIp + ":" + MitmProxy.DEFAULT_HEALTH_PORT + "/health").toURL();
+            var conn = (HttpURLConnection) url.openConnection();
+            conn.setConnectTimeout(2000);
+            conn.setReadTimeout(2000);
+            conn.setRequestMethod("GET");
+            if (conn.getResponseCode() != 200) return null;
+            var body = new String(conn.getInputStream().readAllBytes());
+            return new ProxyInfo(
+                    extractJsonString(body, "version"),
+                    extractJsonString(body, "gitSha"),
+                    extractJsonString(body, "caFingerprint"));
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    public static String checkVersionDrift(ProxyInfo proxyInfo) {
+        if (proxyInfo == null) return "";
+        if (proxyInfo.isLegacy()) {
+            return "The proxy is running a pre-versioning build. Restart recommended.";
+        }
+        var cliInfo = BuildInfo.instance();
+        if (!cliInfo.version().equals(proxyInfo.version())
+                || !cliInfo.gitSha().equals(proxyInfo.gitSha())) {
+            return "Proxy is " + proxyInfo.version() + " (" + shortSha(proxyInfo.gitSha()) + ")"
+                    + ", CLI is " + cliInfo.version() + " (" + shortSha(cliInfo.gitSha()) + ").";
+        }
+        return "";
     }
 
     public static void clearStaleDns(IncusClient incus) {
@@ -77,7 +114,10 @@ public final class ProxyHealthCheck {
 
     public static void requireProxy(IncusClient incus) {
         var status = check(incus);
-        if (status == ProxyStatus.RUNNING) return;
+        if (status == ProxyStatus.RUNNING) {
+            warnIfDrifted(incus);
+            return;
+        }
         if (status == ProxyStatus.STALE_DNS) {
             clearStaleDns(incus);
         }
@@ -87,11 +127,49 @@ public final class ProxyHealthCheck {
 
     public static boolean checkOrWarn(IncusClient incus) {
         var status = check(incus);
-        if (status == ProxyStatus.RUNNING) return true;
+        if (status == ProxyStatus.RUNNING) {
+            warnIfDrifted(incus);
+            return true;
+        }
         if (status == ProxyStatus.STALE_DNS) {
             clearStaleDns(incus);
         }
         System.err.println(formatError(status));
         return false;
+    }
+
+    static void warnIfDrifted(IncusClient incus) {
+        try {
+            var gatewayIp = MitmProxy.resolveGatewayIp(incus);
+            var info = fetchProxyInfo(gatewayIp);
+            var drift = checkVersionDrift(info);
+            if (drift.isEmpty()) return;
+            var sep = "\033[33m" + "─".repeat(60) + "\033[0m";
+            if (ProxyService.isActive()) {
+                System.err.println(sep);
+                System.err.println("\033[1;33mProxy version drift detected:\033[0m " + drift);
+                ProxyService.restart();
+                System.err.println(sep);
+            } else {
+                System.err.println(sep);
+                System.err.println("\033[1;33mProxy version drift detected:\033[0m " + drift);
+                System.err.println("Restart the proxy to use the current version:");
+                System.err.println("  \033[1misx proxy stop && isx proxy start\033[0m");
+                System.err.println(sep);
+            }
+        } catch (Exception ignored) {}
+    }
+
+    private static String extractJsonString(String json, String key) {
+        var pattern = "\"" + key + "\":\"";
+        var idx = json.indexOf(pattern);
+        if (idx < 0) return "";
+        var start = idx + pattern.length();
+        var end = json.indexOf('"', start);
+        return end > start ? json.substring(start, end) : "";
+    }
+
+    private static String shortSha(String sha) {
+        return sha != null && sha.length() > 7 ? sha.substring(0, 7) : (sha != null ? sha : "");
     }
 }

--- a/src/main/java/dev/incusspawn/proxy/ProxyHealthCheck.java
+++ b/src/main/java/dev/incusspawn/proxy/ProxyHealthCheck.java
@@ -1,5 +1,7 @@
 package dev.incusspawn.proxy;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.incusspawn.BuildInfo;
 import dev.incusspawn.incus.IncusClient;
 
@@ -17,6 +19,8 @@ public final class ProxyHealthCheck {
     public record ProxyInfo(String version, String gitSha, String caFingerprint) {
         public boolean isLegacy() { return version == null || version.isEmpty(); }
     }
+
+    private static final ObjectMapper JSON = new ObjectMapper();
 
     private ProxyHealthCheck() {}
 
@@ -58,12 +62,21 @@ public final class ProxyHealthCheck {
             conn.setRequestMethod("GET");
             if (conn.getResponseCode() != 200) return null;
             var body = new String(conn.getInputStream().readAllBytes());
-            return new ProxyInfo(
-                    extractJsonString(body, "version"),
-                    extractJsonString(body, "gitSha"),
-                    extractJsonString(body, "caFingerprint"));
+            return parseProxyInfo(body);
         } catch (Exception e) {
             return null;
+        }
+    }
+
+    static ProxyInfo parseProxyInfo(String json) {
+        try {
+            var node = JSON.readTree(json);
+            return new ProxyInfo(
+                    textOrEmpty(node, "version"),
+                    textOrEmpty(node, "gitSha"),
+                    textOrEmpty(node, "caFingerprint"));
+        } catch (Exception e) {
+            return new ProxyInfo("", "", "");
         }
     }
 
@@ -160,13 +173,9 @@ public final class ProxyHealthCheck {
         } catch (Exception ignored) {}
     }
 
-    private static String extractJsonString(String json, String key) {
-        var pattern = "\"" + key + "\":\"";
-        var idx = json.indexOf(pattern);
-        if (idx < 0) return "";
-        var start = idx + pattern.length();
-        var end = json.indexOf('"', start);
-        return end > start ? json.substring(start, end) : "";
+    private static String textOrEmpty(JsonNode node, String field) {
+        var child = node.get(field);
+        return child != null && child.isTextual() ? child.asText() : "";
     }
 
     private static String shortSha(String sha) {

--- a/src/main/java/dev/incusspawn/proxy/ProxyService.java
+++ b/src/main/java/dev/incusspawn/proxy/ProxyService.java
@@ -98,6 +98,17 @@ public final class ProxyService {
         return true;
     }
 
+    public static boolean restart() {
+        System.err.println("Restarting proxy service...");
+        runQuiet("systemctl", "--user", "restart", SERVICE_NAME);
+        if (isActive()) {
+            System.err.println("Proxy service restarted.");
+            return true;
+        }
+        System.err.println("Warning: proxy service did not restart.");
+        return false;
+    }
+
     public static void stop() {
         if (isActive()) {
             System.out.println("Stopping proxy service...");

--- a/src/test/java/dev/incusspawn/proxy/ProxyHealthCheckTest.java
+++ b/src/test/java/dev/incusspawn/proxy/ProxyHealthCheckTest.java
@@ -79,22 +79,27 @@ class ProxyHealthCheckTest {
     }
 
     @Test
-    void fetchProxyInfoParsesVersionedResponse() throws Exception {
-        var server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
-        server.createContext("/health", exchange -> {
-            var body = "{\"status\":\"ok\",\"version\":\"0.1.10\",\"gitSha\":\"abc1234\",\"caFingerprint\":\"deadbeef\"}".getBytes();
-            exchange.sendResponseHeaders(200, body.length);
-            exchange.getResponseBody().write(body);
-            exchange.close();
-        });
-        server.start();
-        try {
-            int port = server.getAddress().getPort();
-            var info = ProxyHealthCheck.fetchProxyInfo("127.0.0.1:" + port);
-            assertNull(info, "fetchProxyInfo uses DEFAULT_HEALTH_PORT, not arbitrary ports");
-        } finally {
-            server.stop(0);
-        }
+    void parseProxyInfoExtractsAllFields() {
+        var info = ProxyHealthCheck.parseProxyInfo(
+                "{\"status\":\"ok\",\"version\":\"0.1.10\",\"gitSha\":\"abc1234\",\"caFingerprint\":\"deadbeef\"}");
+        assertEquals("0.1.10", info.version());
+        assertEquals("abc1234", info.gitSha());
+        assertEquals("deadbeef", info.caFingerprint());
+        assertFalse(info.isLegacy());
+    }
+
+    @Test
+    void parseProxyInfoHandlesOldFormat() {
+        var info = ProxyHealthCheck.parseProxyInfo("{\"status\":\"ok\"}");
+        assertEquals("", info.version());
+        assertEquals("", info.gitSha());
+        assertTrue(info.isLegacy());
+    }
+
+    @Test
+    void parseProxyInfoHandlesMalformedJson() {
+        var info = ProxyHealthCheck.parseProxyInfo("not json at all");
+        assertTrue(info.isLegacy());
     }
 
     @Test

--- a/src/test/java/dev/incusspawn/proxy/ProxyHealthCheckTest.java
+++ b/src/test/java/dev/incusspawn/proxy/ProxyHealthCheckTest.java
@@ -1,6 +1,7 @@
 package dev.incusspawn.proxy;
 
 import com.sun.net.httpserver.HttpServer;
+import dev.incusspawn.BuildInfo;
 import dev.incusspawn.incus.IncusClient;
 import org.junit.jupiter.api.Test;
 
@@ -75,5 +76,58 @@ class ProxyHealthCheckTest {
     @Test
     void formatErrorReturnsEmptyForRunning() {
         assertEquals("", ProxyHealthCheck.formatError(ProxyHealthCheck.ProxyStatus.RUNNING));
+    }
+
+    @Test
+    void fetchProxyInfoParsesVersionedResponse() throws Exception {
+        var server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/health", exchange -> {
+            var body = "{\"status\":\"ok\",\"version\":\"0.1.10\",\"gitSha\":\"abc1234\",\"caFingerprint\":\"deadbeef\"}".getBytes();
+            exchange.sendResponseHeaders(200, body.length);
+            exchange.getResponseBody().write(body);
+            exchange.close();
+        });
+        server.start();
+        try {
+            int port = server.getAddress().getPort();
+            var info = ProxyHealthCheck.fetchProxyInfo("127.0.0.1:" + port);
+            assertNull(info, "fetchProxyInfo uses DEFAULT_HEALTH_PORT, not arbitrary ports");
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    void checkVersionDriftReturnsEmptyWhenMatching() {
+        var cliInfo = BuildInfo.instance();
+        var proxyInfo = new ProxyHealthCheck.ProxyInfo(cliInfo.version(), cliInfo.gitSha(), "somefp");
+        assertEquals("", ProxyHealthCheck.checkVersionDrift(proxyInfo));
+    }
+
+    @Test
+    void checkVersionDriftDetectsMismatch() {
+        var proxyInfo = new ProxyHealthCheck.ProxyInfo("0.0.1", "old1234567", "somefp");
+        var drift = ProxyHealthCheck.checkVersionDrift(proxyInfo);
+        assertFalse(drift.isEmpty());
+        assertTrue(drift.contains("0.0.1"));
+    }
+
+    @Test
+    void checkVersionDriftDetectsLegacy() {
+        var proxyInfo = new ProxyHealthCheck.ProxyInfo("", "", "");
+        var drift = ProxyHealthCheck.checkVersionDrift(proxyInfo);
+        assertTrue(drift.contains("pre-versioning"));
+    }
+
+    @Test
+    void checkVersionDriftReturnsEmptyForNull() {
+        assertEquals("", ProxyHealthCheck.checkVersionDrift(null));
+    }
+
+    @Test
+    void proxyInfoIsLegacyWhenVersionEmpty() {
+        assertTrue(new ProxyHealthCheck.ProxyInfo("", "sha", "fp").isLegacy());
+        assertTrue(new ProxyHealthCheck.ProxyInfo(null, "sha", "fp").isLegacy());
+        assertFalse(new ProxyHealthCheck.ProxyInfo("1.0", "sha", "fp").isLegacy());
     }
 }


### PR DESCRIPTION
## Summary
- Proxy health endpoint now reports version, git SHA, and CA fingerprint so the CLI can detect stale proxies
- Systemd-managed proxies are auto-restarted on version drift; manual proxies get a warning with restart instructions
- Images are stamped with build version and CA fingerprint at build time; TUI shows staleness indicators (yellow) for outdated or pre-versioning templates
- On `shell`, CA mismatches are auto-fixed by pushing the current cert into the container and updating trust store
- On `branch`, CA mismatches block with rebuild guidance since the template itself needs rebuilding
- `install.sh` prompts to restart the proxy service after an upgrade

## Test plan
- [x] Unit tests pass (102 tests, 6 new for drift detection logic)
- [x] Health endpoint returns `version`, `gitSha`, `caFingerprint` JSON fields
- [x] `isx proxy status` shows proxy version and detects legacy/mismatched proxy
- [x] Stale systemd proxy auto-restarts on `isx shell`
- [x] `isx build tpl-minimal` stamps version metadata on image
- [x] Pre-existing templates (no metadata) handled gracefully — checks silently skipped
- [x] CA mismatch on `isx shell` auto-fixes cert in container and updates metadata
- [x] CA mismatch on `isx branch` blocks with rebuild guidance (instance not created)
- [x] `install.sh` detects running proxy service and offers restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)