### PR TITLE
Use Maven's archive dist link for the maven-3 tool

### DIFF
--- a/src/main/resources/tools/maven-3.yaml
+++ b/src/main/resources/tools/maven-3.yaml
@@ -1,14 +1,14 @@
 name: maven-3
-description: Apache Maven 3.9.14
+description: Apache Maven 3.9.15
 
 downloads:
-  - url: https://dlcdn.apache.org/maven/maven-3/3.9.14/binaries/apache-maven-3.9.14-bin.tar.gz
-    sha256: 126ed3233e569bd0add9e889d226139acd3de9005876a01fe6108fbf4246f515
+  - url: https://archive.apache.org/dist/maven/maven-3/3.9.15/binaries/apache-maven-3.9.15-bin.tar.gz
+    sha256: 36182f85e91128cd5c4608462ac92194e7a30638f65034de66f4e1b00600a6fc
     extract: /opt
     links:
-      /opt/apache-maven-3.9.14/bin/mvn: /usr/local/bin/mvn
+      /opt/apache-maven-3.9.15/bin/mvn: /usr/local/bin/mvn
 
 env:
-  - export MAVEN_HOME=/opt/apache-maven-3.9.14
+  - export MAVEN_HOME=/opt/apache-maven-3.9.15
 
 verify: mvn --version


### PR DESCRIPTION
Run into tpl-java image build failing as it was unable to pull maven ... 

Seems that the `dlcdn.apache.org` only keeps the latest version, while `archive.apache.org/dist` keeps the old one available as well.. Let's switch to the archive one and while at it bump to the 3.9.15 ? 🙂 