### PR TITLE
Add tilde expansion support for searchPaths configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -529,11 +529,12 @@ Users can then install or update via `dnf upgrade` (Fedora), `curl -fsSL .../get
 - `.incus-spawn/images/*.yaml` -- project-local template definitions
 - `.incus-spawn/tools/*.yaml` -- project-local tool definitions
 
-The `config.yaml` also supports git remote auto-management via `host-path` and `repo-paths` (see [Git Remotes](#git-remotes)), and a `searchPaths` list for loading templates and tools from external directories. Each directory should contain `images/` and/or `tools/` subdirectories following the same YAML schema as the built-in definitions:
+The `config.yaml` also supports git remote auto-management via `host-path` and `repo-paths` (see [Git Remotes](#git-remotes)), and a `searchPaths` list for loading templates and tools from external directories. Each directory should contain `images/` and/or `tools/` subdirectories following the same YAML schema as the built-in definitions. Tilde (`~`) expansion is supported for all path settings:
 
 ```yaml
 searchPaths:
-  - /home/user/my-templates
+  - ~/my-templates
+  - /absolute/path/to/templates
 ```
 
 ```

--- a/src/main/java/dev/incusspawn/command/InitCommand.java
+++ b/src/main/java/dev/incusspawn/command/InitCommand.java
@@ -620,7 +620,8 @@ public class InitCommand implements Runnable {
             var input = console.readLine().strip();
             if (input.isEmpty()) break;
 
-            var path = java.nio.file.Path.of(input);
+            var expanded = dev.incusspawn.config.HostResourceSetup.expandHostTilde(input);
+            var path = java.nio.file.Path.of(expanded);
             if (!java.nio.file.Files.isDirectory(path)) {
                 System.out.println("  Warning: '" + input + "' is not an existing directory. Adding anyway.");
             }

--- a/src/main/java/dev/incusspawn/config/ImageDef.java
+++ b/src/main/java/dev/incusspawn/config/ImageDef.java
@@ -268,7 +268,8 @@ public class ImageDef {
         loadBuiltins(defs);
         loadUserDefined(defs);
         for (var searchPath : searchPaths) {
-            loadFromDirectory(Path.of(searchPath).resolve("images"), defs);
+            var expandedPath = HostResourceSetup.expandHostTilde(searchPath);
+            loadFromDirectory(Path.of(expandedPath).resolve("images"), defs);
         }
         loadFromDirectory(PROJECT_IMAGES_DIR, defs);
         return defs;

--- a/src/main/java/dev/incusspawn/tool/ToolDefLoader.java
+++ b/src/main/java/dev/incusspawn/tool/ToolDefLoader.java
@@ -76,7 +76,8 @@ public class ToolDefLoader {
             loadFromDirectory(userToolsDir());
             var paths = searchPaths != null ? searchPaths : SpawnConfig.load().getSearchPaths();
             for (var searchPath : paths) {
-                loadFromDirectory(Path.of(searchPath).resolve("tools"));
+                var expandedPath = dev.incusspawn.config.HostResourceSetup.expandHostTilde(searchPath);
+                loadFromDirectory(Path.of(expandedPath).resolve("tools"));
             }
             loadFromDirectory(projectToolsDir);
         }

--- a/src/main/java/dev/incusspawn/tool/ToolDefLoader.java
+++ b/src/main/java/dev/incusspawn/tool/ToolDefLoader.java
@@ -1,5 +1,6 @@
 package dev.incusspawn.tool;
 
+import dev.incusspawn.config.HostResourceSetup;
 import dev.incusspawn.config.SpawnConfig;
 import jakarta.enterprise.context.Dependent;
 
@@ -76,7 +77,7 @@ public class ToolDefLoader {
             loadFromDirectory(userToolsDir());
             var paths = searchPaths != null ? searchPaths : SpawnConfig.load().getSearchPaths();
             for (var searchPath : paths) {
-                var expandedPath = dev.incusspawn.config.HostResourceSetup.expandHostTilde(searchPath);
+                var expandedPath = HostResourceSetup.expandHostTilde(searchPath);
                 loadFromDirectory(Path.of(expandedPath).resolve("tools"));
             }
             loadFromDirectory(projectToolsDir);

--- a/src/test/java/dev/incusspawn/config/ImageDefTest.java
+++ b/src/test/java/dev/incusspawn/config/ImageDefTest.java
@@ -310,6 +310,22 @@ class ImageDefTest {
         assertNotNull(defs.get("tpl-minimal"));
     }
 
+    @Test
+    void searchPathExpandsTilde() {
+        var originalHome = System.getProperty("user.home");
+        try {
+            var testResources = Path.of("src/test/resources").toAbsolutePath();
+            System.setProperty("user.home", testResources.toString());
+
+            var defs = ImageDef.loadAll(List.of("~/searchpaths-test"));
+
+            assertNotNull(defs.get("tpl-tilde-test"), "Should load image from ~/searchpaths-test");
+            assertEquals("Test tilde expansion", defs.get("tpl-tilde-test").getDescription());
+        } finally {
+            System.setProperty("user.home", originalHome);
+        }
+    }
+
     // --- contentFingerprint tests ---
 
     @Test

--- a/src/test/java/dev/incusspawn/config/SpawnConfigTest.java
+++ b/src/test/java/dev/incusspawn/config/SpawnConfigTest.java
@@ -55,4 +55,18 @@ class SpawnConfigTest {
         config.setRepoPaths(null);
         assertTrue(config.getRepoPaths().isEmpty());
     }
+
+    @Test
+    void deserializeSearchPaths() throws Exception {
+        var yaml = """
+                searchPaths:
+                  - ~/my-templates
+                  - /absolute/path
+                """;
+        var config = YAML.readValue(yaml, SpawnConfig.class);
+        var paths = config.getSearchPaths();
+        assertEquals(2, paths.size());
+        assertEquals("~/my-templates", paths.get(0));
+        assertEquals("/absolute/path", paths.get(1));
+    }
 }

--- a/src/test/java/dev/incusspawn/tool/ToolDefLoaderTest.java
+++ b/src/test/java/dev/incusspawn/tool/ToolDefLoaderTest.java
@@ -258,4 +258,22 @@ class ToolDefLoaderTest {
         assertDoesNotThrow(() -> loader.addFallbacks(null));
         assertNotNull(loader.find("podman"));
     }
+
+    @Test
+    void searchPathExpandsTilde() {
+        var originalHome = System.getProperty("user.home");
+        try {
+            var testResources = Path.of("src/test/resources").toAbsolutePath();
+            System.setProperty("user.home", testResources.toString());
+
+            var loader = new ToolDefLoader();
+            loader.setSearchPaths(java.util.List.of("~/searchpaths-test"));
+
+            var tool = loader.find("tilde-tool");
+            assertNotNull(tool, "Should load tool from ~/searchpaths-test");
+            assertEquals("tilde-tool", tool.name());
+        } finally {
+            System.setProperty("user.home", originalHome);
+        }
+    }
 }

--- a/src/test/resources/searchpaths-test/images/tilde-test.yaml
+++ b/src/test/resources/searchpaths-test/images/tilde-test.yaml
@@ -1,0 +1,5 @@
+name: tpl-tilde-test
+description: Test tilde expansion
+parent: tpl-dev
+tools:
+  - gradle

--- a/src/test/resources/searchpaths-test/tools/tilde-tool.yaml
+++ b/src/test/resources/searchpaths-test/tools/tilde-tool.yaml
@@ -1,0 +1,4 @@
+name: tilde-tool
+description: Test tilde expansion
+run:
+  - echo test


### PR DESCRIPTION
Users can now use ~ in searchPaths to reference their home directory, matching the existing behavior for host-path and repo-paths. The expansion happens at the point of use in ImageDef and ToolDefLoader using the existing HostResourceSetup.expandHostTilde() utility.

Assisted-By: Claude Sonnet 4.5 <noreply@anthropic.com>