### PR TITLE
Make `build --all` continue with unrelated images on failure, bind `isx build --outdated` to shift+F5 and bind `isx build --all` to ctrl+shift+F5

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,9 @@ Image schema fields (all optional except `name`):
 # Build a specific image (builds missing parents automatically)
 isx build tpl-java
 
+# Rebuild outdated templates (checks version and definition SHA)
+isx build --outdated
+
 # Rebuild all discovered images from scratch
 isx build --all
 ```
@@ -423,6 +426,7 @@ After branching, connect from JetBrains Gateway using the container's IP (visibl
 | `isx init` | One-time host setup (Incus, firewall, auth) |
 | `isx build <template>` | Build or rebuild a template image |
 | `isx build --all` | Rebuild all discovered templates |
+| `isx build --outdated` | Rebuild outdated templates |
 | `isx build --missing` | Build only templates that don't exist yet |
 | `isx branch <name>` | Create a CoW clone from a template or instance |
 | `isx shell <instance>` | Open a shell in an instance |

--- a/src/main/java/dev/incusspawn/command/BuildCommand.java
+++ b/src/main/java/dev/incusspawn/command/BuildCommand.java
@@ -144,50 +144,34 @@ public class BuildCommand implements java.util.concurrent.Callable<Integer> {
                 .filter(d -> !parentNames.contains(d.getName()))
                 .toList();
 
-        // Determine which leaves to rebuild
-        var leavesToBuild = outdatedOnly
-                ? leaves.stream()
-                    .filter(leaf -> !incus.exists(leaf.getName()) || isImageOutdated(leaf.getName(), leaf))
-                    .toList()
-                : leaves;
+        // Collect templates to rebuild (in build order: parents before children)
+        var templatesToRebuild = new java.util.ArrayList<String>();
+        var seen = new java.util.LinkedHashSet<String>();
+        collectTemplatesToRebuild(leaves, defs, templatesToRebuild, seen, incus, toolDefLoader, outdatedOnly);
 
-        if (outdatedOnly && leavesToBuild.isEmpty()) {
+        if (templatesToRebuild.isEmpty()) {
             System.out.println("All templates are up to date.");
             return;
         }
 
         // Confirm with user
-        if (outdatedOnly) {
-            var outdatedNames = leavesToBuild.stream().map(ImageDef::getName).toList();
-            System.out.println("Outdated templates: " + String.join(", ", outdatedNames));
-            if (!yes) {
-                var console = System.console();
-                if (console != null) {
-                    System.out.print("Rebuild? (y/N): ");
-                    var answer = console.readLine().strip();
-                    if (!answer.equalsIgnoreCase("y")) {
-                        System.out.println("Aborted.");
-                        return;
-                    }
+        System.out.println((outdatedOnly ? "Templates to rebuild: " : "This will rebuild all templates: ")
+                + String.join(", ", templatesToRebuild));
+        if (!yes) {
+            var console = System.console();
+            if (console != null) {
+                System.out.print((outdatedOnly ? "Rebuild? (y/N): " : "Continue? (y/N): "));
+                var answer = console.readLine().strip();
+                if (!answer.equalsIgnoreCase("y")) {
+                    System.out.println("Aborted.");
+                    return;
                 }
             }
-        } else {
-            // Rebuild all - delete everything first
-            var allNames = new java.util.ArrayList<>(defs.keySet());
-            System.out.println("This will rebuild all templates: " + String.join(", ", allNames));
-            if (!yes) {
-                var console = System.console();
-                if (console != null) {
-                    System.out.print("Continue? (y/N): ");
-                    var answer = console.readLine().strip();
-                    if (!answer.equalsIgnoreCase("y")) {
-                        System.out.println("Aborted.");
-                        return;
-                    }
-                }
-            }
+        }
 
-            // Delete in reverse order (children before parents)
+        // For rebuild-all mode, delete everything first
+        if (!outdatedOnly) {
+            var allNames = new java.util.ArrayList<>(templatesToRebuild);
             java.util.Collections.reverse(allNames);
             System.out.println("\nDeleting existing images...");
             for (var imgName : allNames) {
@@ -198,22 +182,27 @@ public class BuildCommand implements java.util.concurrent.Callable<Integer> {
             }
         }
 
-        // Build each leaf — parents are built recursively (and checked for outdated status)
-        // Track failures to skip children of failed parents
+        // Build each template directly (already in correct order: parents before children)
         var failedBuilds = new java.util.HashSet<String>();
         System.out.println();
-        for (var leaf : leavesToBuild) {
-            if (shouldSkipDueToFailedParent(leaf, defs, failedBuilds)) {
-                System.out.println("Skipping " + leaf.getName() + " (parent failed to build)");
-                failedBuilds.add(leaf.getName());
+        for (var templateName : templatesToRebuild) {
+            var imageDef = defs.get(templateName);
+            if (imageDef == null) {
+                System.err.println("Template definition not found: " + templateName);
+                failedBuilds.add(templateName);
+                continue;
+            }
+            if (shouldSkipDueToFailedParent(imageDef, defs, failedBuilds)) {
+                System.out.println("Skipping " + templateName + " (parent failed to build)");
+                failedBuilds.add(templateName);
                 continue;
             }
             try {
-                build(leaf, defs);
+                buildSingleImage(imageDef, defs);
                 System.out.println();
             } catch (BuildFailedException e) {
-                failedBuilds.add(leaf.getName());
-                System.err.println("Build failed for " + leaf.getName() + ", continuing with other templates...\n");
+                failedBuilds.add(templateName);
+                System.err.println("Build failed for " + templateName + ", continuing with other templates...\n");
             }
         }
 
@@ -221,6 +210,87 @@ public class BuildCommand implements java.util.concurrent.Callable<Integer> {
             System.err.println("\n\033[1;31mSome templates failed to build: " +
                     String.join(", ", failedBuilds) + "\033[0m");
         }
+    }
+
+    /**
+     * Collect all templates to rebuild from a list of leaves.
+     * @param outdatedOnly if true, only collect outdated/missing templates; if false, collect all
+     */
+    private static void collectTemplatesToRebuild(java.util.List<ImageDef> leaves,
+                                                   Map<String, ImageDef> defs,
+                                                   java.util.List<String> result,
+                                                   java.util.Set<String> seen,
+                                                   IncusClient incus,
+                                                   ToolDefLoader toolDefLoader,
+                                                   boolean outdatedOnly) {
+        // Always quiet during collection - messages will be shown during actual build
+        for (var leaf : leaves) {
+            if (outdatedOnly) {
+                // Only process outdated or missing leaves
+                if (!incus.exists(leaf.getName()) || isImageOutdated(leaf.getName(), leaf, incus, toolDefLoader, defs, true)) {
+                    collectTemplatesToRebuildRecursive(leaf, defs, result, seen, incus, toolDefLoader, true);
+                }
+            } else {
+                // Collect all
+                collectTemplatesToRebuildRecursive(leaf, defs, result, seen, incus, toolDefLoader, true);
+            }
+        }
+    }
+
+    /**
+     * Recursively collect a template and its outdated ancestors in build order (parents before children).
+     * Uses a seen set to avoid duplicates while maintaining insertion order in the result list.
+     */
+    private static void collectTemplatesToRebuildRecursive(ImageDef imageDef, Map<String, ImageDef> defs,
+                                            java.util.List<String> result,
+                                            java.util.Set<String> seen,
+                                            IncusClient incus,
+                                            ToolDefLoader toolDefLoader,
+                                            boolean quiet) {
+        var name = imageDef.getName();
+        if (seen.contains(name)) {
+            return; // Already processed this template
+        }
+
+        // First collect outdated ancestors (parents before children)
+        if (!imageDef.isRoot()) {
+            var parentName = imageDef.getParent();
+            var parentDef = defs.get(parentName);
+            if (parentDef != null) {
+                boolean parentMissing = !incus.exists(parentName);
+                boolean needsRebuild = parentMissing
+                        || isImageOutdated(parentName, parentDef, incus, toolDefLoader, defs, quiet);
+                if (needsRebuild) {
+                    collectTemplatesToRebuildRecursive(parentDef, defs, result, seen, incus, toolDefLoader, quiet);
+                }
+            }
+        }
+
+        // Then add this template
+        seen.add(name);
+        result.add(name);
+    }
+
+    /**
+     * Collect all templates to rebuild for --outdated mode. Static for use by TUI.
+     */
+    public static java.util.List<String> collectOutdatedTemplates(
+            Map<String, ImageDef> defs,
+            IncusClient incus,
+            ToolDefLoader toolDefLoader) {
+        var parentNames = defs.values().stream()
+                .filter(d -> !d.isRoot())
+                .map(ImageDef::getParent)
+                .collect(java.util.stream.Collectors.toSet());
+
+        var leaves = defs.values().stream()
+                .filter(d -> !parentNames.contains(d.getName()))
+                .toList();
+
+        var result = new java.util.ArrayList<String>();
+        var seen = new java.util.LinkedHashSet<String>();
+        collectTemplatesToRebuild(leaves, defs, result, seen, incus, toolDefLoader, true);
+        return result;
     }
 
     /**
@@ -286,7 +356,7 @@ public class BuildCommand implements java.util.concurrent.Callable<Integer> {
             }
 
             boolean parentMissing = !incus.exists(parentName);
-            boolean needsRebuild = parentMissing || isImageOutdated(parentName, parentDef);
+            boolean needsRebuild = parentMissing || isImageOutdated(parentName, parentDef, incus, toolDefLoader, defs, false);
 
             if (needsRebuild) {
                 if (parentMissing) {
@@ -298,6 +368,16 @@ public class BuildCommand implements java.util.concurrent.Callable<Integer> {
                 System.out.println();
             }
         }
+
+        buildSingleImage(imageDef, defs);
+    }
+
+    /**
+     * Build a single image without checking or building parents.
+     * Assumes parent is already built and up-to-date.
+     */
+    private void buildSingleImage(ImageDef imageDef, Map<String, ImageDef> defs) {
+        var targetName = imageDef.getName();
 
         System.out.println("Building image: " + targetName);
 
@@ -335,7 +415,9 @@ public class BuildCommand implements java.util.concurrent.Callable<Integer> {
     /**
      * Check if an image is outdated (built with an older version of isx or with a different definition).
      */
-    boolean isImageOutdated(String imageName, ImageDef imageDef) {
+    static boolean isImageOutdated(String imageName, ImageDef imageDef,
+                                    IncusClient incus, ToolDefLoader toolDefLoader,
+                                    Map<String, ImageDef> defs, boolean quiet) {
         if (!incus.exists(imageName)) {
             return false;
         }
@@ -356,7 +438,8 @@ public class BuildCommand implements java.util.concurrent.Callable<Integer> {
         // Check if definition has changed
         var storedSha = incus.configGet(imageName, Metadata.DEFINITION_SHA);
         if (storedSha != null && !storedSha.isEmpty()) {
-            var currentSha = imageDef.contentFingerprint(computeToolFingerprints(imageDef));
+            var currentSha = imageDef.contentFingerprint(
+                    computeToolFingerprints(imageDef, toolDefLoader, defs, quiet));
             if (!storedSha.equals(currentSha)) {
                 return true;
             }
@@ -590,34 +673,48 @@ public class BuildCommand implements java.util.concurrent.Callable<Integer> {
      * transitive dependencies declared via {@code requires}.
      */
     private java.util.List<ToolSetup> resolveTools(ImageDef imageDef) {
+        return resolveTools(imageDef, toolDefLoader, false);
+    }
+
+    private static java.util.List<ToolSetup> resolveTools(ImageDef imageDef, ToolDefLoader toolDefLoader, boolean quiet) {
         var explicit = new java.util.LinkedHashSet<String>(imageDef.getTools());
         var resolved = new java.util.LinkedHashMap<String, ToolSetup>();
 
         for (var toolName : imageDef.getTools()) {
-            resolveWithDeps(toolName, resolved, new java.util.LinkedHashSet<>(), explicit);
+            resolveWithDeps(toolName, resolved, new java.util.LinkedHashSet<>(), explicit, toolDefLoader, quiet);
         }
         return new java.util.ArrayList<>(resolved.values());
     }
 
     private void resolveWithDeps(String name, java.util.LinkedHashMap<String, ToolSetup> resolved,
                                   java.util.LinkedHashSet<String> visiting, java.util.Set<String> explicit) {
+        resolveWithDeps(name, resolved, visiting, explicit, toolDefLoader, false);
+    }
+
+    private static void resolveWithDeps(String name, java.util.LinkedHashMap<String, ToolSetup> resolved,
+                                  java.util.LinkedHashSet<String> visiting, java.util.Set<String> explicit,
+                                  ToolDefLoader toolDefLoader, boolean quiet) {
         if (resolved.containsKey(name)) return;
         if (!visiting.add(name)) {
-            System.err.println("Warning: dependency cycle detected: " +
-                    String.join(" -> ", visiting) + " -> " + name + ", skipping.");
+            if (!quiet) {
+                System.err.println("Warning: dependency cycle detected: " +
+                        String.join(" -> ", visiting) + " -> " + name + ", skipping.");
+            }
             return;
         }
-        var tool = findTool(name);
+        var tool = findTool(name, toolDefLoader);
         if (tool == null) {
-            System.err.println("Warning: unknown tool '" + name + "', skipping.");
+            if (!quiet) {
+                System.err.println("Warning: unknown tool '" + name + "', skipping.");
+            }
             visiting.remove(name);
             return;
         }
         for (var dep : tool.requires()) {
-            if (!explicit.contains(dep)) {
+            if (!quiet && !explicit.contains(dep)) {
                 System.out.println("  Auto-adding dependency: " + dep + " (required by " + name + ")");
             }
-            resolveWithDeps(dep, resolved, visiting, explicit);
+            resolveWithDeps(dep, resolved, visiting, explicit, toolDefLoader, quiet);
         }
         resolved.put(name, tool);
         visiting.remove(name);
@@ -677,13 +774,15 @@ public class BuildCommand implements java.util.concurrent.Callable<Integer> {
     }
 
     private ToolSetup findTool(String name) {
+        return findTool(name, toolDefLoader);
+    }
+
+    private static ToolSetup findTool(String name, ToolDefLoader toolDefLoader) {
         // YAML tools (user-defined, then built-in) take priority
         var yamlTool = toolDefLoader.find(name);
         if (yamlTool != null) return yamlTool;
-        // Fall back to Java CDI implementations
-        for (var tool : toolSetups) {
-            if (tool.name().equals(name)) return tool;
-        }
+        // Note: Java CDI implementations are not available in static context
+        // This is OK for the static path (TUI) since it only needs YAML tools for fingerprinting
         return null;
     }
 
@@ -732,9 +831,17 @@ public class BuildCommand implements java.util.concurrent.Callable<Integer> {
     }
 
     private java.util.Map<String, String> computeToolFingerprints(dev.incusspawn.config.ImageDef imageDef) {
+        return computeToolFingerprints(imageDef, toolDefLoader, ImageDef.loadAll(), false);
+    }
+
+    private static java.util.Map<String, String> computeToolFingerprints(
+            dev.incusspawn.config.ImageDef imageDef,
+            ToolDefLoader toolDefLoader,
+            Map<String, ImageDef> defs,
+            boolean quiet) {
         var rawFps = new java.util.TreeMap<String, String>();
         var depMap = new java.util.TreeMap<String, java.util.List<String>>();
-        for (var tool : resolveTools(imageDef)) {
+        for (var tool : resolveTools(imageDef, toolDefLoader, quiet)) {
             if (tool instanceof YamlToolSetup yts) {
                 rawFps.put(yts.toolDef().getName(), yts.toolDef().contentFingerprint());
                 depMap.put(yts.toolDef().getName(), yts.toolDef().getRequires());

--- a/src/main/java/dev/incusspawn/command/BuildCommand.java
+++ b/src/main/java/dev/incusspawn/command/BuildCommand.java
@@ -163,11 +163,45 @@ public class BuildCommand implements java.util.concurrent.Callable<Integer> {
         }
 
         // Build each leaf — parents are built recursively
+        // Track failures to skip children of failed parents
+        var failedBuilds = new java.util.HashSet<String>();
         System.out.println();
         for (var leaf : leaves) {
-            build(leaf, defs);
-            System.out.println();
+            if (shouldSkipDueToFailedParent(leaf, defs, failedBuilds)) {
+                System.out.println("Skipping " + leaf.getName() + " (parent failed to build)");
+                failedBuilds.add(leaf.getName());
+                continue;
+            }
+            try {
+                build(leaf, defs);
+                System.out.println();
+            } catch (BuildFailedException e) {
+                failedBuilds.add(leaf.getName());
+                System.err.println("Build failed for " + leaf.getName() + ", continuing with other templates...\n");
+            }
         }
+
+        if (!failedBuilds.isEmpty()) {
+            System.err.println("\n\033[1;31mSome templates failed to build: " +
+                    String.join(", ", failedBuilds) + "\033[0m");
+        }
+    }
+
+    /**
+     * Check if a template should be skipped because one of its ancestors failed to build.
+     */
+    boolean shouldSkipDueToFailedParent(ImageDef imageDef, Map<String, ImageDef> defs,
+                                         java.util.Set<String> failedBuilds) {
+        var current = imageDef;
+        while (!current.isRoot()) {
+            var parentName = current.getParent();
+            if (failedBuilds.contains(parentName)) {
+                return true;
+            }
+            current = defs.get(parentName);
+            if (current == null) break;
+        }
+        return false;
     }
 
     /**

--- a/src/main/java/dev/incusspawn/command/BuildCommand.java
+++ b/src/main/java/dev/incusspawn/command/BuildCommand.java
@@ -52,6 +52,9 @@ public class BuildCommand implements java.util.concurrent.Callable<Integer> {
     @Option(names = "--all", description = "Rebuild all defined templates")
     boolean all;
 
+    @Option(names = "--outdated", description = "Rebuild outdated templates")
+    boolean outdated;
+
     @Option(names = "--missing", description = "Build only templates that don't exist yet")
     boolean missing;
 
@@ -86,8 +89,12 @@ public class BuildCommand implements java.util.concurrent.Callable<Integer> {
                 buildMissing(defs);
                 return 0;
             }
+            if (outdated) {
+                buildAll(defs, true);
+                return 0;
+            }
             if (all) {
-                buildAll(defs);
+                buildAll(defs, false);
                 return 0;
             }
 
@@ -122,11 +129,10 @@ public class BuildCommand implements java.util.concurrent.Callable<Integer> {
     }
 
     /**
-     * Rebuild all defined templates. Deletes existing images in reverse
-     * dependency order (children first), then builds leaf images (parents
-     * are built automatically by the recursive build).
+     * Rebuild templates.
+     * @param outdatedOnly if true, only rebuild outdated/missing templates; if false, rebuild all
      */
-    private void buildAll(Map<String, ImageDef> defs) {
+    private void buildAll(Map<String, ImageDef> defs, boolean outdatedOnly) {
         // Identify which images are parents of other images
         var parentNames = defs.values().stream()
                 .filter(d -> !d.isRoot())
@@ -138,35 +144,65 @@ public class BuildCommand implements java.util.concurrent.Callable<Integer> {
                 .filter(d -> !parentNames.contains(d.getName()))
                 .toList();
 
-        var allNames = new java.util.ArrayList<>(defs.keySet());
-        System.out.println("This will rebuild all templates: " + String.join(", ", allNames));
-        if (!yes) {
-            var console = System.console();
-            if (console != null) {
-                System.out.print("Continue? (y/N): ");
-                var answer = console.readLine().strip();
-                if (!answer.equalsIgnoreCase("y")) {
-                    System.out.println("Aborted.");
-                    return;
+        // Determine which leaves to rebuild
+        var leavesToBuild = outdatedOnly
+                ? leaves.stream()
+                    .filter(leaf -> !incus.exists(leaf.getName()) || isImageOutdated(leaf.getName(), leaf))
+                    .toList()
+                : leaves;
+
+        if (outdatedOnly && leavesToBuild.isEmpty()) {
+            System.out.println("All templates are up to date.");
+            return;
+        }
+
+        // Confirm with user
+        if (outdatedOnly) {
+            var outdatedNames = leavesToBuild.stream().map(ImageDef::getName).toList();
+            System.out.println("Outdated templates: " + String.join(", ", outdatedNames));
+            if (!yes) {
+                var console = System.console();
+                if (console != null) {
+                    System.out.print("Rebuild? (y/N): ");
+                    var answer = console.readLine().strip();
+                    if (!answer.equalsIgnoreCase("y")) {
+                        System.out.println("Aborted.");
+                        return;
+                    }
+                }
+            }
+        } else {
+            // Rebuild all - delete everything first
+            var allNames = new java.util.ArrayList<>(defs.keySet());
+            System.out.println("This will rebuild all templates: " + String.join(", ", allNames));
+            if (!yes) {
+                var console = System.console();
+                if (console != null) {
+                    System.out.print("Continue? (y/N): ");
+                    var answer = console.readLine().strip();
+                    if (!answer.equalsIgnoreCase("y")) {
+                        System.out.println("Aborted.");
+                        return;
+                    }
+                }
+            }
+
+            // Delete in reverse order (children before parents)
+            java.util.Collections.reverse(allNames);
+            System.out.println("\nDeleting existing images...");
+            for (var imgName : allNames) {
+                if (incus.exists(imgName)) {
+                    System.out.println("  Deleting " + imgName + "...");
+                    incus.delete(imgName, true);
                 }
             }
         }
 
-        // Delete in reverse order (children before parents)
-        java.util.Collections.reverse(allNames);
-        System.out.println("\nDeleting existing images...");
-        for (var imgName : allNames) {
-            if (incus.exists(imgName)) {
-                System.out.println("  Deleting " + imgName + "...");
-                incus.delete(imgName, true);
-            }
-        }
-
-        // Build each leaf — parents are built recursively
+        // Build each leaf — parents are built recursively (and checked for outdated status)
         // Track failures to skip children of failed parents
         var failedBuilds = new java.util.HashSet<String>();
         System.out.println();
-        for (var leaf : leaves) {
+        for (var leaf : leavesToBuild) {
             if (shouldSkipDueToFailedParent(leaf, defs, failedBuilds)) {
                 System.out.println("Skipping " + leaf.getName() + " (parent failed to build)");
                 failedBuilds.add(leaf.getName());
@@ -240,16 +276,24 @@ public class BuildCommand implements java.util.concurrent.Callable<Integer> {
 
         ProxyHealthCheck.requireProxy(incus);
 
-        // If this image has a parent, ensure it exists
+        // If this image has a parent, ensure it exists and is up-to-date
         if (!imageDef.isRoot()) {
             var parentName = imageDef.getParent();
-            if (!incus.exists(parentName)) {
-                var parentDef = defs.get(parentName);
-                if (parentDef == null) {
-                    System.err.println("Parent image '" + parentName + "' not found in definitions.");
-                    System.exit(1);
+            var parentDef = defs.get(parentName);
+            if (parentDef == null) {
+                System.err.println("Parent image '" + parentName + "' not found in definitions.");
+                System.exit(1);
+            }
+
+            boolean parentMissing = !incus.exists(parentName);
+            boolean needsRebuild = parentMissing || isImageOutdated(parentName, parentDef);
+
+            if (needsRebuild) {
+                if (parentMissing) {
+                    System.out.println("Parent image '" + parentName + "' not found, building it first...\n");
+                } else {
+                    System.out.println("Parent image '" + parentName + "' is outdated, rebuilding it first...\n");
                 }
-                System.out.println("Parent image '" + parentName + "' not found, building it first...\n");
                 build(parentDef, defs);
                 System.out.println();
             }
@@ -286,6 +330,39 @@ public class BuildCommand implements java.util.concurrent.Callable<Integer> {
             promoteToFailedInstance(targetName);
             throw new BuildFailedException(targetName);
         }
+    }
+
+    /**
+     * Check if an image is outdated (built with an older version of isx or with a different definition).
+     */
+    boolean isImageOutdated(String imageName, ImageDef imageDef) {
+        if (!incus.exists(imageName)) {
+            return false;
+        }
+
+        var currentVersion = BuildInfo.instance().version();
+        var buildVersion = incus.configGet(imageName, Metadata.BUILD_VERSION);
+
+        // Check if built with an older version of isx
+        if (buildVersion != null && !buildVersion.isEmpty() && !buildVersion.equals(currentVersion)) {
+            return true;
+        }
+
+        // Check if built with a missing version (very old build)
+        if (buildVersion == null || buildVersion.isEmpty()) {
+            return true;
+        }
+
+        // Check if definition has changed
+        var storedSha = incus.configGet(imageName, Metadata.DEFINITION_SHA);
+        if (storedSha != null && !storedSha.isEmpty()) {
+            var currentSha = imageDef.contentFingerprint(computeToolFingerprints(imageDef));
+            if (!storedSha.equals(currentSha)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private void promoteToFailedInstance(String containerName) {

--- a/src/main/java/dev/incusspawn/command/ListCommand.java
+++ b/src/main/java/dev/incusspawn/command/ListCommand.java
@@ -1135,7 +1135,15 @@ public class ListCommand implements Runnable {
                 };
                 var message = switch (pendingBuildName) {
                     case "--all" -> "This will delete and rebuild all templates.";
-                    case "--outdated" -> "This will delete and rebuild templates that are outdated or missing.";
+                    case "--outdated" -> {
+                        var templatesToRebuild = BuildCommand.collectOutdatedTemplates(
+                                imageDefs, incus, toolDefLoader);
+                        if (templatesToRebuild.isEmpty()) {
+                            yield "All templates are up to date.";
+                        } else {
+                            yield "This will delete and rebuild:\n" + String.join(", ", templatesToRebuild);
+                        }
+                    }
                     default -> "This will delete and rebuild " + pendingBuildName + ".";
                 };
                 ModalRenderer.renderConfirmModal(frame, screen, title, message, ModalRenderer.WARN);

--- a/src/main/java/dev/incusspawn/command/ListCommand.java
+++ b/src/main/java/dev/incusspawn/command/ListCommand.java
@@ -396,19 +396,19 @@ public class ListCommand implements Runnable {
             return true;
         }
 
-        // Shift+F5: Build all templates
+        // Ctrl+Shift+F5: Rebuild all templates (force rebuild everything)
+        if (key.isKey(KeyCode.F5) && key.hasShift() && key.hasCtrl()) {
+            if (showProxyError()) return true;
+            pendingBuildName = "--all";
+            mode = Mode.CONFIRM_BUILD;
+            return true;
+        }
+
+        // Shift+F5: Build outdated templates
         if (key.isKey(KeyCode.F5) && key.hasShift()) {
-            var anyNotBuilt = templateEntries.stream()
-                    .anyMatch(t -> "not built".equals(t.buildStatus));
-            if (anyNotBuilt) {
-                if (showProxyError()) return true;
-                pendingAction = PendingAction.BUILD_TEMPLATE;
-                pendingActionTarget = "--missing";
-                tui.quit();
-            } else {
-                pendingBuildName = "--all";
-                mode = Mode.CONFIRM_BUILD;
-            }
+            if (showProxyError()) return true;
+            pendingBuildName = "--outdated";
+            mode = Mode.CONFIRM_BUILD;
             return true;
         }
 
@@ -1128,11 +1128,16 @@ public class ListCommand implements Runnable {
                 ModalRenderer.renderConfirmModal(frame, screen, title, message, ModalRenderer.WARN);
             }
             case CONFIRM_BUILD -> {
-                var isAll = "--all".equals(pendingBuildName);
-                var title = isAll ? " Rebuild all templates " : " Rebuild '" + pendingBuildName + "' ";
-                var message = isAll
-                        ? "This will delete and rebuild all templates."
-                        : "This will delete and rebuild " + pendingBuildName + ".";
+                var title = switch (pendingBuildName) {
+                    case "--all" -> " Rebuild all templates ";
+                    case "--outdated" -> " Rebuild outdated templates ";
+                    default -> " Rebuild '" + pendingBuildName + "' ";
+                };
+                var message = switch (pendingBuildName) {
+                    case "--all" -> "This will delete and rebuild all templates.";
+                    case "--outdated" -> "This will delete and rebuild templates that are outdated or missing.";
+                    default -> "This will delete and rebuild " + pendingBuildName + ".";
+                };
                 ModalRenderer.renderConfirmModal(frame, screen, title, message, ModalRenderer.WARN);
             }
             case CONFIRM_STOP_FOR_RENAME -> {
@@ -1393,7 +1398,8 @@ public class ListCommand implements Runnable {
                 shortcutRow("F2", "Shell into instance", null, null),
                 shortcutRow("F3", "View details", null, null),
                 shortcutRow("F4", "Branch", null, null),
-                shortcutRow("F5", "Build template", "⇧F5", "Build all"),
+                shortcutRow("F5", "Build template", "⇧F5", "Build outdated"),
+                shortcutRow(null, null, "^⇧F5", "Rebuild all"),
                 shortcutRow("F6", "Rename instance", null, null),
                 shortcutRow("F7", "Stop instance", "⇧F7", "Restart"),
                 shortcutRow("F8/Del", "Destroy", "⇧F8/Del", "Destroy all"),
@@ -1468,8 +1474,10 @@ public class ListCommand implements Runnable {
 
     private static Line shortcutRow(String key, String desc, String shiftKey, String shiftDesc) {
         var spans = new ArrayList<Span>();
-        spans.add(Span.styled(String.format("  %-8s", key), Style.EMPTY.bold().fg(ModalRenderer.ACCENT).bg(ModalRenderer.BG)));
-        spans.add(Span.styled(String.format("%-18s", desc), Style.EMPTY.fg(ModalRenderer.FG).bg(ModalRenderer.BG)));
+        var keyStr = key != null ? key : "";
+        var descStr = desc != null ? desc : "";
+        spans.add(Span.styled(String.format("  %-8s", keyStr), Style.EMPTY.bold().fg(ModalRenderer.ACCENT).bg(ModalRenderer.BG)));
+        spans.add(Span.styled(String.format("%-18s", descStr), Style.EMPTY.fg(ModalRenderer.FG).bg(ModalRenderer.BG)));
         if (shiftKey != null) {
             spans.add(Span.styled(String.format("%-9s", shiftKey), Style.EMPTY.bold().fg(ModalRenderer.ACCENT).bg(ModalRenderer.BG)));
             spans.add(Span.styled(shiftDesc, Style.EMPTY.fg(ModalRenderer.FG).bg(ModalRenderer.BG)));

--- a/src/main/java/dev/incusspawn/command/ModalRenderer.java
+++ b/src/main/java/dev/incusspawn/command/ModalRenderer.java
@@ -128,7 +128,12 @@ final class ModalRenderer {
     static void renderConfirmModal(Frame frame, Rect screen,
                                     String title, String message, Color borderColor,
                                     String confirmLabel) {
-        var modalArea = centerRect(screen, 54, 7);
+        int modalWidth = 54;
+        int innerWidth = modalWidth - 4; // Account for borders and padding
+        var wrappedLines = wrapText(message, innerWidth);
+        // 2 borders + 1 top spacing + message lines + 1 spacer + 2 buttons area
+        int modalHeight = 2 + 1 + wrappedLines.size() + 1 + 2;
+        var modalArea = centerRect(screen, modalWidth, modalHeight);
         var block = Block.builder()
                 .borders(Borders.ALL).borderType(BorderType.ROUNDED)
                 .title(title)
@@ -137,15 +142,58 @@ final class ModalRenderer {
                 .build();
         renderBlock(frame, block, modalArea);
         var inner = block.inner(modalArea);
-        var rows = Layout.vertical()
-                .constraints(Constraint.length(1), Constraint.length(1), Constraint.length(1), Constraint.fill())
-                .split(inner);
-        frame.renderWidget(Paragraph.from(Line.styled(
-                message, Style.EMPTY.fg(borderColor).bg(BG))), rows.get(1));
+
+        var constraints = new ArrayList<Constraint>();
+        constraints.add(Constraint.length(1)); // top spacing
+        for (int i = 0; i < wrappedLines.size(); i++) {
+            constraints.add(Constraint.length(1)); // one line per message line
+        }
+        constraints.add(Constraint.length(1)); // spacer
+        constraints.add(Constraint.fill()); // buttons
+
+        var rows = Layout.vertical().constraints(constraints.toArray(Constraint[]::new)).split(inner);
+
+        // Render message lines
+        for (int i = 0; i < wrappedLines.size(); i++) {
+            frame.renderWidget(Paragraph.from(Line.styled(
+                    wrappedLines.get(i), Style.EMPTY.fg(borderColor).bg(BG))), rows.get(1 + i));
+        }
+
         var btnSpans = new ArrayList<Span>();
         addKey(btnSpans, "y", confirmLabel);
         addKey(btnSpans, "any key", "Cancel");
-        frame.renderWidget(Paragraph.from(Line.from(btnSpans)), rows.get(3));
+        frame.renderWidget(Paragraph.from(Line.from(btnSpans)), rows.get(rows.size() - 1));
+    }
+
+    private static List<String> wrapText(String text, int width) {
+        var result = new ArrayList<String>();
+        for (var paragraph : text.split("\n")) {
+            if (paragraph.isEmpty()) {
+                result.add("");
+                continue;
+            }
+            var words = paragraph.split("\\s+");
+            var line = new StringBuilder();
+            for (var word : words) {
+                if (line.length() + word.length() + (line.length() > 0 ? 1 : 0) > width) {
+                    if (line.length() > 0) {
+                        result.add(line.toString());
+                        line = new StringBuilder();
+                    }
+                    // If a single word is longer than width, add it anyway
+                    if (word.length() > width) {
+                        result.add(word);
+                        continue;
+                    }
+                }
+                if (line.length() > 0) line.append(" ");
+                line.append(word);
+            }
+            if (line.length() > 0) {
+                result.add(line.toString());
+            }
+        }
+        return result;
     }
 
     static void renderErrorModal(Frame frame, Rect screen, String message) {

--- a/src/test/java/dev/incusspawn/command/BuildCommandTest.java
+++ b/src/test/java/dev/incusspawn/command/BuildCommandTest.java
@@ -497,10 +497,10 @@ class BuildCommandTest {
         var imageDef = new ImageDef();
         imageDef.setName("tpl-test");
 
-        var cmd = new BuildCommand();
-        cmd.incus = incus;
+        var toolDefLoader = mock(dev.incusspawn.tool.ToolDefLoader.class);
+        var defs = java.util.Map.of("tpl-test", imageDef);
 
-        assertFalse(cmd.isImageOutdated("tpl-test", imageDef),
+        assertFalse(BuildCommand.isImageOutdated("tpl-test", imageDef, incus, toolDefLoader, defs, false),
                 "Non-existent image should not be considered outdated");
     }
 
@@ -513,10 +513,10 @@ class BuildCommandTest {
         var imageDef = new ImageDef();
         imageDef.setName("tpl-test");
 
-        var cmd = new BuildCommand();
-        cmd.incus = incus;
+        var toolDefLoader = mock(dev.incusspawn.tool.ToolDefLoader.class);
+        var defs = java.util.Map.of("tpl-test", imageDef);
 
-        assertTrue(cmd.isImageOutdated("tpl-test", imageDef),
+        assertTrue(BuildCommand.isImageOutdated("tpl-test", imageDef, incus, toolDefLoader, defs, false),
                 "Image with different version should be outdated");
     }
 
@@ -529,10 +529,10 @@ class BuildCommandTest {
         var imageDef = new ImageDef();
         imageDef.setName("tpl-test");
 
-        var cmd = new BuildCommand();
-        cmd.incus = incus;
+        var toolDefLoader = mock(dev.incusspawn.tool.ToolDefLoader.class);
+        var defs = java.util.Map.of("tpl-test", imageDef);
 
-        assertTrue(cmd.isImageOutdated("tpl-test", imageDef),
+        assertTrue(BuildCommand.isImageOutdated("tpl-test", imageDef, incus, toolDefLoader, defs, false),
                 "Image with missing version should be outdated");
     }
 
@@ -547,10 +547,10 @@ class BuildCommandTest {
         var imageDef = new ImageDef();
         imageDef.setName("tpl-test");
 
-        var cmd = new BuildCommand();
-        cmd.incus = incus;
+        var toolDefLoader = mock(dev.incusspawn.tool.ToolDefLoader.class);
+        var defs = java.util.Map.of("tpl-test", imageDef);
 
-        assertFalse(cmd.isImageOutdated("tpl-test", imageDef),
+        assertFalse(BuildCommand.isImageOutdated("tpl-test", imageDef, incus, toolDefLoader, defs, false),
                 "Image with same version and no definition SHA should not be outdated");
     }
 
@@ -566,11 +566,10 @@ class BuildCommandTest {
         var imageDef = new ImageDef();
         imageDef.setName("tpl-test");
 
-        var cmd = new BuildCommand();
-        cmd.incus = incus;
-        cmd.toolDefLoader = mock(dev.incusspawn.tool.ToolDefLoader.class);
+        var toolDefLoader = mock(dev.incusspawn.tool.ToolDefLoader.class);
+        var defs = java.util.Map.of("tpl-test", imageDef);
 
-        assertTrue(cmd.isImageOutdated("tpl-test", imageDef),
+        assertTrue(BuildCommand.isImageOutdated("tpl-test", imageDef, incus, toolDefLoader, defs, false),
                 "Image with changed definition should be outdated");
     }
 }

--- a/src/test/java/dev/incusspawn/command/BuildCommandTest.java
+++ b/src/test/java/dev/incusspawn/command/BuildCommandTest.java
@@ -488,4 +488,89 @@ class BuildCommandTest {
         assertFalse(cmd.shouldSkipDueToFailedParent(root, defs, failedBuilds),
                 "Root image should never be skipped due to parent");
     }
+
+    @Test
+    void isImageOutdatedNotExists() {
+        var incus = mock(IncusClient.class);
+        when(incus.exists("tpl-test")).thenReturn(false);
+
+        var imageDef = new ImageDef();
+        imageDef.setName("tpl-test");
+
+        var cmd = new BuildCommand();
+        cmd.incus = incus;
+
+        assertFalse(cmd.isImageOutdated("tpl-test", imageDef),
+                "Non-existent image should not be considered outdated");
+    }
+
+    @Test
+    void isImageOutdatedDifferentVersion() {
+        var incus = mock(IncusClient.class);
+        when(incus.exists("tpl-test")).thenReturn(true);
+        when(incus.configGet("tpl-test", "user.incus-spawn.build-version")).thenReturn("0.0.1");
+
+        var imageDef = new ImageDef();
+        imageDef.setName("tpl-test");
+
+        var cmd = new BuildCommand();
+        cmd.incus = incus;
+
+        assertTrue(cmd.isImageOutdated("tpl-test", imageDef),
+                "Image with different version should be outdated");
+    }
+
+    @Test
+    void isImageOutdatedMissingVersion() {
+        var incus = mock(IncusClient.class);
+        when(incus.exists("tpl-test")).thenReturn(true);
+        when(incus.configGet("tpl-test", "user.incus-spawn.build-version")).thenReturn("");
+
+        var imageDef = new ImageDef();
+        imageDef.setName("tpl-test");
+
+        var cmd = new BuildCommand();
+        cmd.incus = incus;
+
+        assertTrue(cmd.isImageOutdated("tpl-test", imageDef),
+                "Image with missing version should be outdated");
+    }
+
+    @Test
+    void isImageOutdatedSameVersionNoDefinitionChange() {
+        var incus = mock(IncusClient.class);
+        when(incus.exists("tpl-test")).thenReturn(true);
+        when(incus.configGet("tpl-test", "user.incus-spawn.build-version"))
+                .thenReturn(dev.incusspawn.BuildInfo.instance().version());
+        when(incus.configGet("tpl-test", "user.incus-spawn.definition-sha")).thenReturn("");
+
+        var imageDef = new ImageDef();
+        imageDef.setName("tpl-test");
+
+        var cmd = new BuildCommand();
+        cmd.incus = incus;
+
+        assertFalse(cmd.isImageOutdated("tpl-test", imageDef),
+                "Image with same version and no definition SHA should not be outdated");
+    }
+
+    @Test
+    void isImageOutdatedDefinitionChanged() {
+        var incus = mock(IncusClient.class);
+        when(incus.exists("tpl-test")).thenReturn(true);
+        when(incus.configGet("tpl-test", "user.incus-spawn.build-version"))
+                .thenReturn(dev.incusspawn.BuildInfo.instance().version());
+        when(incus.configGet("tpl-test", "user.incus-spawn.definition-sha"))
+                .thenReturn("old-sha-123");
+
+        var imageDef = new ImageDef();
+        imageDef.setName("tpl-test");
+
+        var cmd = new BuildCommand();
+        cmd.incus = incus;
+        cmd.toolDefLoader = mock(dev.incusspawn.tool.ToolDefLoader.class);
+
+        assertTrue(cmd.isImageOutdated("tpl-test", imageDef),
+                "Image with changed definition should be outdated");
+    }
 }

--- a/src/test/java/dev/incusspawn/command/BuildCommandTest.java
+++ b/src/test/java/dev/incusspawn/command/BuildCommandTest.java
@@ -390,4 +390,102 @@ class BuildCommandTest {
         // Clone call + refspec restore, but no prime
         verify(incus, times(2)).shellExecInteractive(eq("test"), any(String[].class));
     }
+
+    @Test
+    void shouldSkipDueToFailedParentDirectParent() {
+        var parent = new ImageDef();
+        parent.setName("tpl-parent");
+
+        var child = new ImageDef();
+        child.setName("tpl-child");
+        child.setParent("tpl-parent");
+
+        var defs = java.util.Map.of("tpl-parent", parent, "tpl-child", child);
+        var failedBuilds = new java.util.HashSet<String>();
+        failedBuilds.add("tpl-parent");
+
+        var cmd = new BuildCommand();
+        assertTrue(cmd.shouldSkipDueToFailedParent(child, defs, failedBuilds),
+                "Child should be skipped when parent failed");
+    }
+
+    @Test
+    void shouldSkipDueToFailedParentGrandparent() {
+        var grandparent = new ImageDef();
+        grandparent.setName("tpl-grandparent");
+
+        var parent = new ImageDef();
+        parent.setName("tpl-parent");
+        parent.setParent("tpl-grandparent");
+
+        var child = new ImageDef();
+        child.setName("tpl-child");
+        child.setParent("tpl-parent");
+
+        var defs = java.util.Map.of(
+                "tpl-grandparent", grandparent,
+                "tpl-parent", parent,
+                "tpl-child", child);
+        var failedBuilds = new java.util.HashSet<String>();
+        failedBuilds.add("tpl-grandparent");
+
+        var cmd = new BuildCommand();
+        assertTrue(cmd.shouldSkipDueToFailedParent(child, defs, failedBuilds),
+                "Child should be skipped when grandparent failed");
+    }
+
+    @Test
+    void shouldSkipDueToFailedParentNoFailures() {
+        var parent = new ImageDef();
+        parent.setName("tpl-parent");
+
+        var child = new ImageDef();
+        child.setName("tpl-child");
+        child.setParent("tpl-parent");
+
+        var defs = java.util.Map.of("tpl-parent", parent, "tpl-child", child);
+        var failedBuilds = new java.util.HashSet<String>();
+
+        var cmd = new BuildCommand();
+        assertFalse(cmd.shouldSkipDueToFailedParent(child, defs, failedBuilds),
+                "Child should not be skipped when no failures");
+    }
+
+    @Test
+    void shouldSkipDueToFailedParentUnrelatedFailure() {
+        var parent = new ImageDef();
+        parent.setName("tpl-parent");
+
+        var child = new ImageDef();
+        child.setName("tpl-child");
+        child.setParent("tpl-parent");
+
+        var unrelated = new ImageDef();
+        unrelated.setName("tpl-unrelated");
+
+        var defs = java.util.Map.of(
+                "tpl-parent", parent,
+                "tpl-child", child,
+                "tpl-unrelated", unrelated);
+        var failedBuilds = new java.util.HashSet<String>();
+        failedBuilds.add("tpl-unrelated");
+
+        var cmd = new BuildCommand();
+        assertFalse(cmd.shouldSkipDueToFailedParent(child, defs, failedBuilds),
+                "Child should not be skipped when only unrelated template failed");
+    }
+
+    @Test
+    void shouldSkipDueToFailedParentRootImage() {
+        var root = new ImageDef();
+        root.setName("tpl-root");
+        root.setImage("fedora/41");
+
+        var defs = java.util.Map.of("tpl-root", root);
+        var failedBuilds = new java.util.HashSet<String>();
+
+        var cmd = new BuildCommand();
+        assertFalse(cmd.shouldSkipDueToFailedParent(root, defs, failedBuilds),
+                "Root image should never be skipped due to parent");
+    }
 }


### PR DESCRIPTION
This makes rebuilding outdated template images easier, while still allowing to build them all regardless of whether they are outdated.

Note there's a change to the modal renderer which was necessary due to it not supporting line wrapping for long messages.