### PR TITLE
Add 'merge' mode to host-resources for JSON file merging

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -265,13 +265,15 @@ All other domains (package mirrors, PyPI, etc.) route normally via Incus bridge 
 
 ### Host Resources
 
-Template images can declare host files and directories to share with containers via the `host-resources` YAML key. Three modes control how the resource is made available:
+Template images can declare host files and directories to share with containers via the `host-resources` YAML key. Four modes control how the resource is made available:
 
 **Readonly** (default): a read-only Incus disk device bind mount. The container can read the host file/directory but cannot modify it. Simple and safe for config files like `~/.gitconfig`.
 
 **Overlay**: the host directory is attached as a read-only lower layer, with an ephemeral writable upper layer inside the container, combined via Linux overlayfs. The container sees a normal read-write directory, but writes go to the container-local upper layer — the host is fully protected. This is the right mode for caches (Maven, OCI) where tools expect to write but you don't need writes to persist back to the host.
 
 **Copy**: the file or directory is copied into the container at build time and becomes part of the template. Supports local paths and URLs. No runtime dependency on the host.
+
+**Merge**: deep-merges JSON files from the host with existing JSON files in the container at build time. The merged result becomes part of the template (like copy mode). For objects, keys are recursively merged with host values taking precedence on conflicts. For arrays, the host array completely replaces the container array. For primitives, the host value wins. If the container file doesn't exist, merge behaves like copy. When the source is a directory, all `.json` files are merged recursively while non-JSON files are copied as-is. This mode is designed for customizing JSON config files created by parent templates without losing other settings or files.
 
 #### Overlay internals
 

--- a/README.md
+++ b/README.md
@@ -301,13 +301,14 @@ The `~/.m2/repository` entry shares your host Maven cache with the container. Wi
 
 The `~/.gitconfig` entry mounts your git configuration read-only (the default mode), so `git` inside the container picks up your name, email, aliases, and other settings.
 
-Three modes are available:
+Four modes are available:
 
 | Mode | Default? | Description |
 |------|----------|-------------|
 | `readonly` | Yes | Read-only bind mount. Simple, safe. |
 | `overlay` | No | Read-only lower layer from host + ephemeral writable upper in the container. Tools see a normal read-write directory. Host is fully protected. |
 | `copy` | No | Copied into the container at build time. Becomes part of the template. Also supports URL sources. |
+| `merge` | No | Deep-merges JSON files from host with existing files in the container. Overlay values take precedence. Works on single files or directories. |
 
 If `path` is omitted, it defaults to the same relative path under `/home/agentuser/`. For example, `source: ~/.m2/repository` maps to `/home/agentuser/.m2/repository` inside the container.
 
@@ -326,7 +327,14 @@ host-resources:
   # Share Gradle cache with overlay (writable inside container, host protected)
   - source: ~/.gradle/caches
     mode: overlay
+
+  # Merge custom Claude settings with parent's defaults
+  - source: ~/.config/custom-claude
+    path: ~/.claude
+    mode: merge
 ```
+
+The `merge` mode is particularly useful for customizing JSON config files created by parent templates. For example, if a parent template installs Claude Code (which creates `.claude/settings.json` and `.claude.json`), a child template can use merge mode to customize `settings.json` while preserving `.claude.json` from the parent. The merge is deep: nested objects are recursively merged with host values taking precedence, while arrays are replaced entirely by the host version.
 
 If a host path doesn't exist at build or branch time, the entry is skipped with a warning -- the build proceeds without it. This means templates with host-resources remain portable: they work on machines that have the declared paths and gracefully degrade on machines that don't.
 

--- a/src/main/java/dev/incusspawn/config/HostResourceSetup.java
+++ b/src/main/java/dev/incusspawn/config/HostResourceSetup.java
@@ -2,10 +2,12 @@ package dev.incusspawn.config;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.incusspawn.incus.Container;
 import dev.incusspawn.incus.IncusClient;
 import dev.incusspawn.tool.DownloadCache;
+import dev.incusspawn.util.JsonMergeUtil;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -89,6 +91,7 @@ public final class HostResourceSetup {
             switch (hr.getMode()) {
                 case "copy" -> applyCopy(container, hr);
                 case "readonly" -> applyReadonly(incus, container.name(), hr);
+                case "merge" -> applyMerge(container, hr);
                 case "overlay" -> {
                     applyOverlay(incus, container, hr);
                     overlayEntries.add(hr);
@@ -113,7 +116,7 @@ public final class HostResourceSetup {
                     removeExistingDevice(incus, container, overlayDeviceName(resolveContainerPath(hr.getSource(), hr.getPath())));
                     applyOverlayDevice(incus, container, hr);
                 }
-                case "copy" -> {} // already baked into the template
+                case "copy", "merge" -> {} // already baked into the template
             }
         }
     }
@@ -307,5 +310,111 @@ public final class HostResourceSetup {
                 "WantedBy=multi-user.target");
 
         container.exec("systemctl", "enable", "incus-spawn-overlays.service");
+    }
+
+    private static void applyMerge(Container container, ImageDef.HostResource hr) {
+        var containerPath = resolveContainerPath(hr.getSource(), hr.getPath());
+        var parentDir = containerPath.contains("/")
+                ? containerPath.substring(0, containerPath.lastIndexOf('/'))
+                : "/";
+
+        var expandedSource = expandHostTilde(hr.getSource());
+        var sourcePath = Path.of(expandedSource);
+
+        if (!Files.exists(sourcePath)) {
+            System.err.println("Warning: host-resource source not found: " + hr.getSource() + " (skipping)");
+            return;
+        }
+
+        container.exec("mkdir", "-p", parentDir);
+
+        if (Files.isDirectory(sourcePath)) {
+            // Directory: merge all .json files, copy others
+            try {
+                mergeDirectory(container, sourcePath, containerPath);
+            } catch (IOException e) {
+                System.err.println("Warning: failed to merge directory " + hr.getSource() + ": " + e.getMessage());
+                return;
+            }
+        } else {
+            // Single file: must be .json for merge mode
+            if (!expandedSource.endsWith(".json")) {
+                System.err.println("Error: merge mode requires .json files, got: " + hr.getSource());
+                throw new RuntimeException("merge mode requires .json files");
+            }
+            mergeJsonFile(container, expandedSource, containerPath);
+        }
+
+        container.chown(containerPath, "agentuser:agentuser");
+        System.out.println("  Merged " + hr.getSource() + " -> " + containerPath);
+    }
+
+    private static void mergeDirectory(Container container, Path hostDir, String containerDir) throws IOException {
+        Files.walk(hostDir).forEach(hostPath -> {
+            if (Files.isDirectory(hostPath)) return;
+
+            var relativePath = hostDir.relativize(hostPath).toString();
+            var containerFilePath = containerDir + "/" + relativePath;
+            var containerFileDir = containerFilePath.substring(0,
+                    containerFilePath.lastIndexOf('/'));
+
+            container.exec("mkdir", "-p", containerFileDir);
+
+            if (hostPath.toString().endsWith(".json")) {
+                mergeJsonFile(container, hostPath.toString(), containerFilePath);
+            } else {
+                // Non-JSON files: just copy
+                container.filePush(hostPath.toString(), containerFilePath);
+            }
+        });
+    }
+
+    private static void mergeJsonFile(Container container, String hostFilePath, String containerFilePath) {
+        try {
+            // Read host JSON
+            var hostJson = Files.readString(Path.of(hostFilePath));
+            JsonNode hostNode;
+            try {
+                hostNode = JSON.readTree(hostJson);
+            } catch (Exception e) {
+                System.err.println("Warning: invalid JSON in host file " + hostFilePath
+                        + ", skipping merge: " + e.getMessage());
+                return;
+            }
+
+            // Read container JSON (if exists)
+            var checkResult = container.exec("test", "-f", containerFilePath);
+            JsonNode containerNode = null;
+
+            if (checkResult.success()) {
+                // Container file exists - verify it's JSON
+                if (!containerFilePath.endsWith(".json")) {
+                    System.err.println("Error: can only merge JSON files, container file is not .json: "
+                            + containerFilePath);
+                    throw new RuntimeException("container file is not .json: " + containerFilePath);
+                }
+
+                var catResult = container.exec("cat", containerFilePath);
+                if (catResult.success()) {
+                    try {
+                        containerNode = JSON.readTree(catResult.stdout());
+                    } catch (Exception e) {
+                        System.err.println("Warning: invalid JSON in container file " + containerFilePath
+                                + ", treating as empty: " + e.getMessage());
+                        // containerNode stays null, will merge with empty
+                    }
+                }
+            }
+
+            // Merge: host overlays container
+            JsonNode merged = JsonMergeUtil.deepMerge(containerNode, hostNode);
+
+            // Write back to container
+            var mergedJson = JSON.writerWithDefaultPrettyPrinter().writeValueAsString(merged);
+            container.writeFile(containerFilePath, mergedJson);
+
+        } catch (IOException e) {
+            System.err.println("Warning: failed to merge JSON file " + hostFilePath + ": " + e.getMessage());
+        }
     }
 }

--- a/src/main/java/dev/incusspawn/util/JsonMergeUtil.java
+++ b/src/main/java/dev/incusspawn/util/JsonMergeUtil.java
@@ -1,0 +1,76 @@
+package dev.incusspawn.util;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+/**
+ * Utility for deep-merging JSON trees.
+ */
+public final class JsonMergeUtil {
+
+    private JsonMergeUtil() {}
+
+    /**
+     * Deep merge two JSON trees. Overlay values take precedence over base values.
+     * <p>
+     * Merge rules:
+     * <ul>
+     *   <li>Objects: recursively merge keys from both, overlay wins on conflicts</li>
+     *   <li>Arrays: overlay completely replaces base (REPLACE strategy)</li>
+     *   <li>Primitives: overlay value wins</li>
+     *   <li>Null overlay: return base unchanged</li>
+     *   <li>Null base: return overlay unchanged</li>
+     * </ul>
+     *
+     * @param base the base JSON tree (lower precedence)
+     * @param overlay the overlay JSON tree (higher precedence)
+     * @return the merged JSON tree
+     */
+    public static JsonNode deepMerge(JsonNode base, JsonNode overlay) {
+        // Null or missing handling
+        if (overlay == null || overlay.isNull() || overlay.isMissingNode()) {
+            return base;
+        }
+        if (base == null || base.isNull() || base.isMissingNode()) {
+            return overlay;
+        }
+
+        // Both are objects - merge recursively
+        if (base.isObject() && overlay.isObject()) {
+            ObjectNode result = ((ObjectNode) base).deepCopy();
+            ObjectNode overlayObj = (ObjectNode) overlay;
+
+            // Iterate through overlay fields
+            overlayObj.fields().forEachRemaining(entry -> {
+                String fieldName = entry.getKey();
+                JsonNode overlayValue = entry.getValue();
+
+                if (result.has(fieldName)) {
+                    // Field exists in both - recursively merge if both are objects
+                    JsonNode baseValue = result.get(fieldName);
+                    if (baseValue.isObject() && overlayValue.isObject()) {
+                        result.set(fieldName, deepMerge(baseValue, overlayValue));
+                    } else {
+                        // Not both objects - overlay wins
+                        result.set(fieldName, overlayValue.deepCopy());
+                    }
+                } else {
+                    // Field only in overlay - add it
+                    result.set(fieldName, overlayValue.deepCopy());
+                }
+            });
+
+            return result;
+        }
+
+        // Arrays - REPLACE strategy (overlay replaces base entirely)
+        // TODO: Future enhancement - support append, union, or by-key merge strategies
+        if (overlay.isArray()) {
+            return overlay.deepCopy();
+        }
+
+        // Primitives (strings, numbers, booleans, null) - overlay wins
+        return overlay.deepCopy();
+    }
+}

--- a/src/test/java/dev/incusspawn/config/HostResourceSetupTest.java
+++ b/src/test/java/dev/incusspawn/config/HostResourceSetupTest.java
@@ -201,6 +201,50 @@ class HostResourceSetupTest {
         assertTrue(HostResourceSetup.deserialize("not json").isEmpty());
     }
 
+    @Test
+    void collectEffectiveMergeMode() {
+        var defs = new LinkedHashMap<String, ImageDef>();
+        var imageDef = makeImageDef("tpl-test", null, List.of(
+                new ImageDef.HostResource("~/.claude/settings.json", null, "merge")));
+        defs.put("tpl-test", imageDef);
+
+        var result = HostResourceSetup.collectEffective(imageDef, defs);
+        assertEquals(1, result.size());
+        assertEquals("merge", result.get(0).getMode());
+        assertEquals("~/.claude/settings.json", result.get(0).getSource());
+    }
+
+    @Test
+    void serializeDeserializeMergeMode() {
+        var resources = List.of(
+                new ImageDef.HostResource("~/.claude/settings.json", null, "merge"));
+
+        var json = HostResourceSetup.serialize(resources);
+        var deserialized = HostResourceSetup.deserialize(json);
+
+        assertEquals(1, deserialized.size());
+        assertEquals("merge", deserialized.get(0).getMode());
+        assertEquals("~/.claude/settings.json", deserialized.get(0).getSource());
+    }
+
+    @Test
+    void collectEffectiveMergeModeInheritance() {
+        var defs = new LinkedHashMap<String, ImageDef>();
+        var parent = makeImageDef("tpl-parent", null, List.of(
+                new ImageDef.HostResource("~/.gitconfig", null, "readonly")));
+        var child = makeImageDef("tpl-child", "tpl-parent", List.of(
+                new ImageDef.HostResource("~/.claude", null, "merge")));
+        defs.put("tpl-parent", parent);
+        defs.put("tpl-child", child);
+
+        var result = HostResourceSetup.collectEffective(child, defs);
+        assertEquals(2, result.size());
+        // Should have both resources with correct modes
+        var modes = result.stream().map(ImageDef.HostResource::getMode).toList();
+        assertTrue(modes.contains("readonly"));
+        assertTrue(modes.contains("merge"));
+    }
+
     private static ImageDef makeImageDef(String name, String parent, List<ImageDef.HostResource> hostResources) {
         var def = new ImageDef();
         def.setName(name);

--- a/src/test/java/dev/incusspawn/util/JsonMergeUtilTest.java
+++ b/src/test/java/dev/incusspawn/util/JsonMergeUtilTest.java
@@ -1,0 +1,152 @@
+package dev.incusspawn.util;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class JsonMergeUtilTest {
+    private static final ObjectMapper JSON = new ObjectMapper();
+
+    @Test
+    void testMergeDisjointObjects() throws Exception {
+        var base = JSON.readTree("{\"a\": 1, \"b\": 2}");
+        var overlay = JSON.readTree("{\"c\": 3}");
+        var result = JsonMergeUtil.deepMerge(base, overlay);
+
+        assertEquals(1, result.get("a").asInt());
+        assertEquals(2, result.get("b").asInt());
+        assertEquals(3, result.get("c").asInt());
+    }
+
+    @Test
+    void testOverlayWinsOnConflict() throws Exception {
+        var base = JSON.readTree("{\"a\": 1, \"b\": 2}");
+        var overlay = JSON.readTree("{\"b\": 99}");
+        var result = JsonMergeUtil.deepMerge(base, overlay);
+
+        assertEquals(1, result.get("a").asInt());
+        assertEquals(99, result.get("b").asInt());
+    }
+
+    @Test
+    void testDeepMergeNestedObjects() throws Exception {
+        var base = JSON.readTree("{\"settings\": {\"theme\": \"dark\", \"size\": 12}}");
+        var overlay = JSON.readTree("{\"settings\": {\"theme\": \"light\"}}");
+        var result = JsonMergeUtil.deepMerge(base, overlay);
+
+        assertEquals("light", result.get("settings").get("theme").asText());
+        assertEquals(12, result.get("settings").get("size").asInt());
+    }
+
+    @Test
+    void testArrayReplacement() throws Exception {
+        var base = JSON.readTree("{\"permissions\": {\"allow\": [\"Bash\", \"Read\"]}}");
+        var overlay = JSON.readTree("{\"permissions\": {\"allow\": [\"Bash\", \"Read\", \"Write\"]}}");
+        var result = JsonMergeUtil.deepMerge(base, overlay);
+
+        var allowArray = result.get("permissions").get("allow");
+        assertEquals(3, allowArray.size());
+        assertEquals("Bash", allowArray.get(0).asText());
+        assertEquals("Read", allowArray.get(1).asText());
+        assertEquals("Write", allowArray.get(2).asText());
+    }
+
+    @Test
+    void testNullOverlay() throws Exception {
+        var base = JSON.readTree("{\"a\": 1}");
+        var result = JsonMergeUtil.deepMerge(base, null);
+
+        assertEquals(base, result);
+    }
+
+    @Test
+    void testNullBase() throws Exception {
+        var overlay = JSON.readTree("{\"a\": 1}");
+        var result = JsonMergeUtil.deepMerge(null, overlay);
+
+        assertEquals(overlay, result);
+    }
+
+    @Test
+    void testComplexRealWorldExample() throws Exception {
+        // Simulating .claude/settings.json merge
+        var base = JSON.readTree("""
+                {
+                  "permissions": {
+                    "defaultMode": "bypassPermissions",
+                    "allow": ["Bash(*)", "Read(**)", "Edit(**)"]
+                  },
+                  "skipDangerousModePermissionPrompt": true
+                }
+                """);
+
+        var overlay = JSON.readTree("""
+                {
+                  "permissions": {
+                    "allow": ["CustomTool(*)"]
+                  },
+                  "customField": "value"
+                }
+                """);
+
+        var result = JsonMergeUtil.deepMerge(base, overlay);
+
+        // Permissions.allow should be replaced (array replacement)
+        var allowArray = result.get("permissions").get("allow");
+        assertEquals(1, allowArray.size());
+        assertEquals("CustomTool(*)", allowArray.get(0).asText());
+
+        // defaultMode should be preserved from base
+        assertEquals("bypassPermissions", result.get("permissions").get("defaultMode").asText());
+
+        // skipDangerousModePermissionPrompt should be preserved
+        assertTrue(result.get("skipDangerousModePermissionPrompt").asBoolean());
+
+        // customField should be added from overlay
+        assertEquals("value", result.get("customField").asText());
+    }
+
+    @Test
+    void testMixedTypes() throws Exception {
+        var base = JSON.readTree("{\"str\": \"hello\", \"num\": 42, \"bool\": true, \"nil\": null}");
+        var overlay = JSON.readTree("{\"str\": \"world\", \"num\": 99, \"bool\": false}");
+        var result = JsonMergeUtil.deepMerge(base, overlay);
+
+        assertEquals("world", result.get("str").asText());
+        assertEquals(99, result.get("num").asInt());
+        assertFalse(result.get("bool").asBoolean());
+        assertTrue(result.get("nil").isNull());
+    }
+
+    @Test
+    void testOverlayAddsNewNestedObject() throws Exception {
+        var base = JSON.readTree("{\"existing\": {\"field\": 1}}");
+        var overlay = JSON.readTree("{\"newSection\": {\"nested\": {\"deep\": \"value\"}}}");
+        var result = JsonMergeUtil.deepMerge(base, overlay);
+
+        assertEquals(1, result.get("existing").get("field").asInt());
+        assertEquals("value", result.get("newSection").get("nested").get("deep").asText());
+    }
+
+    @Test
+    void testTypeConflictObjectReplacesArray() throws Exception {
+        var base = JSON.readTree("{\"field\": [1, 2, 3]}");
+        var overlay = JSON.readTree("{\"field\": {\"newType\": \"object\"}}");
+        var result = JsonMergeUtil.deepMerge(base, overlay);
+
+        assertTrue(result.get("field").isObject());
+        assertEquals("object", result.get("field").get("newType").asText());
+    }
+
+    @Test
+    void testTypeConflictArrayReplacesObject() throws Exception {
+        var base = JSON.readTree("{\"field\": {\"old\": \"object\"}}");
+        var overlay = JSON.readTree("{\"field\": [1, 2, 3]}");
+        var result = JsonMergeUtil.deepMerge(base, overlay);
+
+        assertTrue(result.get("field").isArray());
+        assertEquals(3, result.get("field").size());
+    }
+}


### PR DESCRIPTION
Problem:
In template inheritance chains, child templates need to customize JSON config files created by parent templates without losing other files or settings. For example, the built-in tpl-dev template installs Claude Code and creates .claude/settings.json and .claude.json. A child template (e.g., tpl-mydev) wants to add custom permissions to settings.json while preserving .claude.json from the parent.

The existing modes don't solve this:
- mode: overlay - Mounts the entire .claude directory, hiding .claude.json from the parent
- mode: copy - Completely replaces settings.json, losing the parent's default settings
- Mounting only settings.json as copy works but requires manually duplicating all parent settings

Solution:
Add a new 'merge' mode that deep-merges JSON files:
- For objects: recursively merges keys from both, overlay wins on conflicts
- For arrays: overlay array completely replaces base array (REPLACE strategy)
- For primitives: overlay value wins
- If container file doesn't exist: acts like copy
- Validates JSON and skips invalid files with warnings

The merge mode works on both single files and directories. For directories, all .json files are merged recursively, while non-JSON files are copied as-is.

Implementation:
- Created JsonMergeUtil utility class with deepMerge() algorithm
- Extended HostResourceSetup with applyMerge(), mergeDirectory(), and mergeJsonFile() methods
- Added comprehensive unit and integration tests

Usage example:
  host-resources:
    - source: ~/.config/custom-claude path: ~/.claude mode: merge

This merges all .json files from the host directory with existing files in the container, preserving both the custom settings and the parent's state files.

Assisted-By: Claude Code <noreply@anthropic.com>