### PR TITLE
Detect corrupt cached images and fail fast on startup timeout

### DIFF
--- a/src/main/java/dev/incusspawn/command/BuildCommand.java
+++ b/src/main/java/dev/incusspawn/command/BuildCommand.java
@@ -12,6 +12,7 @@ import dev.incusspawn.config.SpawnConfig;
 import dev.incusspawn.git.GitRemoteUtils;
 import dev.incusspawn.incus.Container;
 import dev.incusspawn.incus.IncusClient;
+import dev.incusspawn.incus.IncusException;
 import dev.incusspawn.incus.Metadata;
 import dev.incusspawn.proxy.CertificateAuthority;
 import dev.incusspawn.proxy.ProxyHealthCheck;
@@ -337,7 +338,21 @@ public class BuildCommand implements java.util.concurrent.Callable<Integer> {
 
         // Launch base image
         System.out.println("Launching " + image + "...");
-        incus.launch(image, targetName, vm);
+        try {
+            incus.launch(image, targetName, vm);
+        } catch (IncusException e) {
+            if (incus.exists(targetName)) {
+                var log = incus.getLog(targetName);
+                if (log.contains("Exec format error")) {
+                    throw new RuntimeException(
+                            "The cached image for '" + image + "' has a broken /sbin/init " +
+                            "(Exec format error). " +
+                            "Delete it with 'incus image list' + 'incus image delete <fingerprint>' " +
+                            "and retry the build.", e);
+                }
+            }
+            throw e;
+        }
 
         waitForReady(targetName);
 
@@ -608,7 +623,8 @@ public class BuildCommand implements java.util.concurrent.Callable<Integer> {
             if (result.success()) return;
             try { Thread.sleep(1000); } catch (InterruptedException e) { break; }
         }
-        System.err.println("Warning: container " + container + " may not be fully ready.");
+        throw new RuntimeException(
+                "Container " + container + " failed to become ready after 30 seconds");
     }
 
     private void stampBuildVersion(String container, dev.incusspawn.config.ImageDef imageDef) {

--- a/src/main/java/dev/incusspawn/incus/IncusClient.java
+++ b/src/main/java/dev/incusspawn/incus/IncusClient.java
@@ -296,6 +296,10 @@ public class IncusClient {
         exec(args).assertSuccess("Failed to copy " + source + " to " + target);
     }
 
+    public String getLog(String instance) {
+        return exec("info", "--show-log", instance).stdout();
+    }
+
     /**
      * Start a stopped container/VM.
      */


### PR DESCRIPTION
## Summary
- When `incus launch` fails due to a corrupt cached image (all binaries 0 bytes, "Exec format error" on `/sbin/init`), surface an actionable error message telling the user to delete the cached image and retry
- Make `waitForReady` throw on timeout instead of printing a warning and continuing — prevents the build from running blind into later steps with a broken container
- Add `IncusClient.getLog()` helper for reading container logs via `incus info --show-log`

## Test plan
- [x] `mvn test` passes
- [ ] Manual: build with a known-bad cached image — verify the "cached image appears corrupt" message appears
- [ ] Manual: build with a good image — verify normal build succeeds as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)