### PR TITLE
Cache Claude Code binary downloads on the host

### DIFF
--- a/src/main/java/dev/incusspawn/tool/ClaudeSetup.java
+++ b/src/main/java/dev/incusspawn/tool/ClaudeSetup.java
@@ -1,11 +1,28 @@
 package dev.incusspawn.tool;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.incusspawn.config.SpawnConfig;
 import dev.incusspawn.incus.Container;
 import jakarta.enterprise.context.Dependent;
 
+import java.io.IOException;
+import java.nio.file.Files;
+
 @Dependent
 public class ClaudeSetup implements ToolSetup {
+
+    private static final String DOWNLOAD_BASE_URL = "https://downloads.claude.ai/claude-code-releases";
+    private static final ObjectMapper JSON = new ObjectMapper();
+
+    private final DownloadCache downloadCache;
+
+    public ClaudeSetup() {
+        this(new DownloadCache());
+    }
+
+    ClaudeSetup(DownloadCache downloadCache) {
+        this.downloadCache = downloadCache;
+    }
 
     @Override
     public String name() {
@@ -21,15 +38,57 @@ public class ClaudeSetup implements ToolSetup {
 
     private void installBinary(Container c) {
         System.out.println("Installing Claude Code...");
-        // Ensure ~/.local/bin is on agentuser's PATH before installing, so the
-        // installer doesn't warn about it and claude is immediately available.
+        // Ensure ~/.local/bin is on agentuser's PATH before installing, so
+        // claude is immediately available in interactive shells.
         c.sh("mkdir -p /home/agentuser/.local/bin && " +
                 "chown -R agentuser:agentuser /home/agentuser/.local && " +
                 "grep -q '.local/bin' /home/agentuser/.bashrc 2>/dev/null || " +
                 "echo 'export PATH=\"$HOME/.local/bin:$PATH\"' >> /home/agentuser/.bashrc");
-        // Install as agentuser so it lands in /home/agentuser/.local/bin
-        c.runAsUser("agentuser", "curl -fsSL https://claude.ai/install.sh | sh",
-                "Failed to install Claude Code");
+
+        try {
+            var version = Files.readString(
+                    downloadCache.download(DOWNLOAD_BASE_URL + "/latest", null)).strip();
+            System.out.println("  Latest version: " + version);
+
+            var platform = detectPlatform();
+            var manifestJson = Files.readString(
+                    downloadCache.download(DOWNLOAD_BASE_URL + "/" + version + "/manifest.json", null));
+            var sha256 = extractChecksum(manifestJson, platform);
+
+            var binaryUrl = DOWNLOAD_BASE_URL + "/" + version + "/" + platform + "/claude";
+            var cached = downloadCache.download(binaryUrl, sha256);
+
+            var claudeBin = "/home/agentuser/.local/bin/claude";
+            c.filePush(cached.toString(), claudeBin);
+            c.exec("chmod", "+x", claudeBin);
+            c.chown(claudeBin, "agentuser:agentuser");
+
+            c.runAsUser("agentuser", claudeBin + " install",
+                    "Failed to set up Claude Code shell integration");
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to install Claude Code: " + e.getMessage(), e);
+        }
+    }
+
+    static String detectPlatform() {
+        var arch = System.getProperty("os.arch");
+        return switch (arch) {
+            case "amd64", "x86_64" -> "linux-x64";
+            case "aarch64" -> "linux-arm64";
+            default -> throw new RuntimeException("Unsupported architecture: " + arch);
+        };
+    }
+
+    static String extractChecksum(String manifestJson, String platform) throws IOException {
+        var root = JSON.readTree(manifestJson);
+        var checksum = root.path("platforms").path(platform).path("checksum").asText(null);
+        if (checksum == null) {
+            throw new IOException("Platform " + platform + " not found in manifest");
+        }
+        if (!checksum.matches("[a-fA-F0-9]{64}")) {
+            throw new IOException("Invalid checksum for platform " + platform + ": " + checksum);
+        }
+        return checksum;
     }
 
     private void configureSettings(Container c) {

--- a/src/test/java/dev/incusspawn/tool/ClaudeSetupTest.java
+++ b/src/test/java/dev/incusspawn/tool/ClaudeSetupTest.java
@@ -1,0 +1,129 @@
+package dev.incusspawn.tool;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ClaudeSetupTest {
+
+    @Test
+    void detectPlatformReturnsLinuxX64OnAmd64() {
+        var original = System.getProperty("os.arch");
+        try {
+            System.setProperty("os.arch", "amd64");
+            assertEquals("linux-x64", ClaudeSetup.detectPlatform());
+
+            System.setProperty("os.arch", "x86_64");
+            assertEquals("linux-x64", ClaudeSetup.detectPlatform());
+        } finally {
+            System.setProperty("os.arch", original);
+        }
+    }
+
+    @Test
+    void detectPlatformReturnsLinuxArm64() {
+        var original = System.getProperty("os.arch");
+        try {
+            System.setProperty("os.arch", "aarch64");
+            assertEquals("linux-arm64", ClaudeSetup.detectPlatform());
+        } finally {
+            System.setProperty("os.arch", original);
+        }
+    }
+
+    @Test
+    void detectPlatformThrowsOnUnsupportedArch() {
+        var original = System.getProperty("os.arch");
+        try {
+            System.setProperty("os.arch", "sparc");
+            assertThrows(RuntimeException.class, ClaudeSetup::detectPlatform);
+        } finally {
+            System.setProperty("os.arch", original);
+        }
+    }
+
+    @Test
+    void extractChecksumParsesValidManifest() throws IOException {
+        var manifest = """
+                {
+                  "platforms": {
+                    "linux-x64": {
+                      "checksum": "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+                    }
+                  }
+                }
+                """;
+        assertEquals(
+                "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789",
+                ClaudeSetup.extractChecksum(manifest, "linux-x64"));
+    }
+
+    @Test
+    void extractChecksumAcceptsUppercaseHex() throws IOException {
+        var manifest = """
+                {
+                  "platforms": {
+                    "linux-x64": {
+                      "checksum": "ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789"
+                    }
+                  }
+                }
+                """;
+        assertEquals(
+                "ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789",
+                ClaudeSetup.extractChecksum(manifest, "linux-x64"));
+    }
+
+    @Test
+    void extractChecksumThrowsOnMissingPlatform() {
+        var manifest = """
+                {
+                  "platforms": {
+                    "linux-x64": {
+                      "checksum": "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+                    }
+                  }
+                }
+                """;
+        var e = assertThrows(IOException.class,
+                () -> ClaudeSetup.extractChecksum(manifest, "linux-arm64"));
+        assertTrue(e.getMessage().contains("not found"));
+        assertTrue(e.getMessage().contains("linux-arm64"));
+    }
+
+    @Test
+    void extractChecksumThrowsOnInvalidChecksum() {
+        var manifest = """
+                {
+                  "platforms": {
+                    "linux-x64": {
+                      "checksum": "not-a-valid-sha256"
+                    }
+                  }
+                }
+                """;
+        var e = assertThrows(IOException.class,
+                () -> ClaudeSetup.extractChecksum(manifest, "linux-x64"));
+        assertTrue(e.getMessage().contains("Invalid checksum"));
+        assertTrue(e.getMessage().contains("not-a-valid-sha256"));
+    }
+
+    @Test
+    void extractChecksumThrowsOnEmptyManifest() {
+        var manifest = "{}";
+        assertThrows(IOException.class,
+                () -> ClaudeSetup.extractChecksum(manifest, "linux-x64"));
+    }
+
+    @Test
+    void downloadCacheIsInjectable(@TempDir Path tempDir) {
+        var cache = new DownloadCache(tempDir);
+        var setup = new ClaudeSetup(cache);
+        assertEquals("claude", setup.name());
+    }
+}


### PR DESCRIPTION
## Summary
- Downloads the Claude Code binary via `DownloadCache` on the host instead of running `curl | sh` inside each container
- Fetches `latest` version + `manifest.json` (tiny requests, always refreshed) to get the SHA256, then caches the ~100MB binary by checksum — subsequent builds skip the download entirely when the version hasn't changed
- After pushing the cached binary into the container, runs `claude install` for shell integration

## Test plan
- [ ] `mvn test` passes (257 tests)
- [ ] `isx build tpl-minimal` succeeds with the new download path
- [ ] Second build shows cache hit (no "Downloading" message for the binary)
- [ ] `claude --version` works inside the built container

🤖 Generated with [Claude Code](https://claude.com/claude-code)