### PR TITLE
fix: set minimum java version + add notice about jbang in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,20 @@ Built with [Quarkus](https://quarkus.io/) and [Tamboui](https://tamboui.dev/).
 
 ## Quick Start
 
+If on a Linux X64 machine, you can install incus-spawn with the following command:
+
 ```shell
 # Install
 curl -fsSL https://raw.githubusercontent.com/Sanne/incus-spawn/main/get-isx.sh | sh
+```
 
+If on any other machine, you can install incus-spawn with the following command:
+
+```shell
+jbang app install isx@Sanne/incus-spawn
+```
+
+```shell
 # One-time host setup (Incus, firewall, auth)
 isx init
 

--- a/jbang-catalog.json
+++ b/jbang-catalog.json
@@ -4,7 +4,8 @@
   "aliases": {
     "isx": {
       "script-ref": "https://github.com/Sanne/incus-spawn/releases/latest/download/incus-spawn-runner.jar",
-      "description": "Manage isolated Incus development environments"
+      "description": "Manage isolated Incus development environments",
+      "java": "25+"
     }
   }
 }


### PR DESCRIPTION
just ensuring jbang command wont fail if user dont have java 25 in path.

+ mention in docs that if you are on non-x64 you should be able to run with jbang 