### PR TITLE
Fix: Add git remotes for image branches

### DIFF
--- a/src/main/java/dev/incusspawn/command/BranchCommand.java
+++ b/src/main/java/dev/incusspawn/command/BranchCommand.java
@@ -97,6 +97,9 @@ public class BranchCommand implements Runnable {
 
         applyHostResourceDevices(name);
 
+        // Add git remotes to host repos (doesn't require instance to be running)
+        AutoRemoteService.addRemotes(incus, name);
+
         if (noStart) {
             System.out.println("Branch '" + name + "' created (not started).");
             return;
@@ -131,7 +134,6 @@ public class BranchCommand implements Runnable {
         incus.shellExec(name, "chown", getUid() + ":" + getUid(), "/home/agentuser");
 
         injectSshKeyIfAvailable(incus, name);
-        AutoRemoteService.addRemotes(incus, name);
 
         System.out.println("Branch '" + name + "' is ready.\n");
         incus.interactiveShell(name, "agentuser");

--- a/src/main/java/dev/incusspawn/command/ListCommand.java
+++ b/src/main/java/dev/incusspawn/command/ListCommand.java
@@ -2421,6 +2421,13 @@ public class ListCommand implements Runnable {
             HostResourceSetup.applyForInstance(incus, name, hostResources);
         }
 
+        incus.configSet(name, Metadata.TYPE, Metadata.TYPE_CLONE);
+        incus.configSet(name, Metadata.PARENT, source);
+        incus.configSet(name, Metadata.CREATED, Metadata.today());
+
+        // Add git remotes to host repos (doesn't require instance to be running)
+        AutoRemoteService.addRemotes(incus, name);
+
         incus.start(name);
         waitForReady(name);
 
@@ -2450,12 +2457,7 @@ public class ListCommand implements Runnable {
         // large images with many pre-built dependencies)
         incus.shellExec(name, "chown", String.valueOf(getUid()) + ":" + String.valueOf(getUid()), "/home/agentuser");
 
-        incus.configSet(name, Metadata.TYPE, Metadata.TYPE_CLONE);
-        incus.configSet(name, Metadata.PARENT, source);
-        incus.configSet(name, Metadata.CREATED, Metadata.today());
-
         BranchCommand.injectSshKeyIfAvailable(incus, name);
-        AutoRemoteService.addRemotes(incus, name);
 
         System.out.println("Branch '" + name + "' is ready.");
         System.out.println("Connecting to " + name + "...\n");


### PR DESCRIPTION
I noticed than when branching images, the host repo didn't get a remote added automatically. This should fix it.

Claude's word salad below if you want it.

---

When branching with --no-start, AutoRemoteService.addRemotes was never called because it was placed after the early return. Since addRemotes only manipulates host-side git repos and reads instance metadata (which works on stopped instances), it should be called before the --no-start check.

Also moved metadata tagging and addRemotes earlier in ListCommand for consistency - both operations work on stopped instances and should happen in the post-creation phase, not the running-instance phase.

The fix ensures that:
- Remotes are added after Metadata.PARENT is set (required dependency)
- Remotes are added regardless of whether instance will be started
- Placement mirrors removeRemotes pattern (works without running instance)

Assisted-By: Claude Code <noreply@anthropic.com>