### PR TITLE
Fix reference clone checkout failure by deferring dissociation

### DIFF
--- a/src/main/java/dev/incusspawn/command/BuildCommand.java
+++ b/src/main/java/dev/incusspawn/command/BuildCommand.java
@@ -916,7 +916,10 @@ public class BuildCommand implements java.util.concurrent.Callable<Integer> {
     /**
      * Clone git repos declared in the image definition as agentuser.
      * When a matching host-side checkout is available (via SpawnConfig host-path/repo-paths),
-     * uses --reference --dissociate to speed up cloning from local objects.
+     * uses {@code --reference} to speed up cloning from local objects. Dissociation
+     * is deferred to after checkout: a manual {@code repack -a -d} followed by
+     * alternates removal makes the clone self-contained while the reference device
+     * is still mounted.
      */
     void cloneRepos(Container container, ImageDef imageDef) {
         var config = SpawnConfig.load();
@@ -935,6 +938,15 @@ public class BuildCommand implements java.util.concurrent.Callable<Integer> {
                         container.runAsUser("agentuser",
                                 buildCloneCommand(repo, ref.containerPath()),
                                 "Failed to clone " + repo.getUrl() + " with reference");
+                        // Dissociate now that checkout succeeded: repack referenced
+                        // objects locally and drop the alternates entry, so the clone
+                        // is self-contained before the reference device is removed.
+                        var expandedPath = expandHome(repo.getPath());
+                        var clonePath = shellQuote(expandedPath);
+                        container.runAsUser("agentuser",
+                                "git -C " + clonePath + " repack -a -d"
+                                        + " && rm -f -- " + shellQuote(expandedPath + "/.git/objects/info/alternates"),
+                                "Failed to dissociate " + repo.getUrl() + " from reference");
                         cloned = true;
                         System.out.println("  Done.");
                     } catch (Exception e) {
@@ -986,7 +998,6 @@ public class BuildCommand implements java.util.concurrent.Callable<Integer> {
         var cmd = new StringBuilder("git clone --single-branch");
         if (referencePath != null) {
             cmd.append(" --reference ").append(shellQuote(referencePath));
-            cmd.append(" --dissociate");
         }
         if (repo.getBranch() != null && !repo.getBranch().isBlank()) {
             cmd.append(" --branch ").append(shellQuote(repo.getBranch()));
@@ -996,7 +1007,7 @@ public class BuildCommand implements java.util.concurrent.Callable<Integer> {
         return cmd.toString();
     }
 
-    private RepoReference tryMountReference(Container container, String cloneUrl, SpawnConfig config) {
+    RepoReference tryMountReference(Container container, String cloneUrl, SpawnConfig config) {
         try {
             var repoName = GitRemoteUtils.repoNameFromUrl(cloneUrl);
             if (repoName.isEmpty()) return null;

--- a/src/test/java/dev/incusspawn/command/BuildCommandTest.java
+++ b/src/test/java/dev/incusspawn/command/BuildCommandTest.java
@@ -390,4 +390,71 @@ class BuildCommandTest {
         // Clone call + refspec restore, but no prime
         verify(incus, times(2)).shellExecInteractive(eq("test"), any(String[].class));
     }
+
+    @Test
+    void cloneReposWithReferenceDissociates() {
+        var incus = mock(IncusClient.class);
+        var container = new Container(incus, "test");
+        when(incus.shellExecInteractive(eq("test"), any(String[].class))).thenReturn(0);
+
+        var repo = new ImageDef.RepoEntry();
+        repo.setUrl("https://github.com/owner/repo.git");
+        repo.setPath("~/repo");
+
+        var imageDef = new ImageDef();
+        imageDef.setName("tpl-test");
+        imageDef.setRepos(List.of(repo));
+
+        var cmd = spy(new BuildCommand());
+        cmd.incus = incus;
+        var ref = new BuildCommand.RepoReference("ref-repo", "/mnt/ref/repo");
+        doReturn(ref).when(cmd).tryMountReference(eq(container), eq(repo.getUrl()), any());
+
+        cmd.cloneRepos(container, imageDef);
+
+        // Reference clone command
+        verify(incus).shellExecInteractive("test",
+                "su", "-l", "agentuser", "-c",
+                "git clone --single-branch --reference '/mnt/ref/repo' -- 'https://github.com/owner/repo.git' '/home/agentuser/repo'");
+        // Dissociation: repack + alternates removal
+        verify(incus).shellExecInteractive("test",
+                "su", "-l", "agentuser", "-c",
+                "git -C '/home/agentuser/repo' repack -a -d && rm -f -- '/home/agentuser/repo/.git/objects/info/alternates'");
+        // Reference device cleaned up
+        verify(incus).deviceRemove("test", "ref-repo");
+    }
+
+    @Test
+    void cloneReposWithReferenceFailsFallsBack() {
+        var incus = mock(IncusClient.class);
+        var container = new Container(incus, "test");
+        // First call (reference clone) fails, rest succeed
+        when(incus.shellExecInteractive(eq("test"), any(String[].class)))
+                .thenReturn(1)  // reference clone fails
+                .thenReturn(0)  // cleanup rm -rf
+                .thenReturn(0)  // normal clone
+                .thenReturn(0); // refspec restore
+
+        var repo = new ImageDef.RepoEntry();
+        repo.setUrl("https://github.com/owner/repo.git");
+        repo.setPath("~/repo");
+
+        var imageDef = new ImageDef();
+        imageDef.setName("tpl-test");
+        imageDef.setRepos(List.of(repo));
+
+        var cmd = spy(new BuildCommand());
+        cmd.incus = incus;
+        var ref = new BuildCommand.RepoReference("ref-repo", "/mnt/ref/repo");
+        doReturn(ref).when(cmd).tryMountReference(eq(container), eq(repo.getUrl()), any());
+
+        cmd.cloneRepos(container, imageDef);
+
+        // Should fall back to normal clone
+        verify(incus).shellExecInteractive("test",
+                "su", "-l", "agentuser", "-c",
+                "git clone --single-branch -- 'https://github.com/owner/repo.git' '/home/agentuser/repo'");
+        // Reference device still cleaned up
+        verify(incus).deviceRemove("test", "ref-repo");
+    }
 }


### PR DESCRIPTION
## Summary

- `git clone --reference --dissociate` repacks borrowed objects *before* checkout — if the repack produces an unparseable commit (delta-chain issue or git version mismatch between host and container), checkout fails and the full clone is discarded
- Split into two steps: clone with `--reference` only (checkout reads directly from the mounted reference via alternates), then dissociate manually (`repack -a -d` + remove alternates) while the reference device is still mounted
- If dissociation fails, the existing fallback to a normal clone still applies

## Test plan

- [x] `BuildCommandTest` passes (30/30)
- [ ] Rebuild `tpl-quarkus` with a host-side Quarkus checkout as reference — verify clone succeeds without falling back to full re-clone

🤖 Generated with [Claude Code](https://claude.com/claude-code)