### PR TITLE
Add GUI passthrough tracking and Wayland health warnings

### DIFF
--- a/.incus-spawn/images/firefox.yaml
+++ b/.incus-spawn/images/firefox.yaml
@@ -1,5 +1,6 @@
 name: tpl-firefox
 description: With Firefox :)
 parent: tpl-minimal
+gui: true
 packages:
   - firefox

--- a/src/main/java/dev/incusspawn/command/BranchCommand.java
+++ b/src/main/java/dev/incusspawn/command/BranchCommand.java
@@ -1,6 +1,7 @@
 package dev.incusspawn.command;
 
 import dev.incusspawn.config.HostResourceSetup;
+import dev.incusspawn.config.ImageDef;
 import dev.incusspawn.config.NetworkMode;
 import dev.incusspawn.config.ProjectConfig;
 import dev.incusspawn.git.AutoRemoteService;
@@ -100,6 +101,20 @@ public class BranchCommand implements Runnable {
         // Add git remotes to host repos (doesn't require instance to be running)
         AutoRemoteService.addRemotes(incus, name);
 
+        // Configure GUI before start so environment.* keys are visible to init
+        if (gui) {
+            if (configureGui()) {
+                incus.configSet(name, Metadata.GUI_ENABLED, "true");
+            } else {
+                removeGui(incus, name);
+                System.err.println("Continuing without GUI passthrough.");
+            }
+        } else {
+            // Clean up inherited GUI devices/env from incus copy
+            removeGui(incus, name);
+            warnIfTemplateWantsGui(resolvedSource);
+        }
+
         if (noStart) {
             System.out.println("Branch '" + name + "' created (not started).");
             return;
@@ -110,10 +125,6 @@ public class BranchCommand implements Runnable {
 
         if (networkMode == NetworkMode.PROXY_ONLY) {
             applyProxyOnlyFirewall(name);
-        }
-
-        if (gui && !configureGui()) {
-            System.err.println("Continuing without GUI passthrough.");
         }
 
         if (inbox != null) {
@@ -166,11 +177,35 @@ public class BranchCommand implements Runnable {
     }
 
     private boolean configureGui() {
+        return configureGui(incus, name);
+    }
+
+    // Env vars needed for Wayland GUI passthrough (toolkit backends + quirk suppressors).
+    private static final java.util.Map<String, String> WAYLAND_ENV = java.util.Map.of(
+            "GDK_BACKEND", "wayland",
+            "QT_QPA_PLATFORM", "wayland",
+            "SDL_VIDEODRIVER", "wayland",
+            "MOZ_ENABLE_WAYLAND", "1",
+            "ELECTRON_OZONE_PLATFORM_HINT", "wayland",
+            "NO_AT_BRIDGE", "1");
+
+    private static final java.util.regex.Pattern WAYLAND_DISPLAY_PATTERN =
+            java.util.regex.Pattern.compile("[A-Za-z0-9._-]+");
+
+    /**
+     * Configure GUI passthrough on a (stopped) container: GPU device, Wayland
+     * socket mount, environment variables, and tmpfiles.d for XDG_RUNTIME_DIR.
+     */
+    static boolean configureGui(IncusClient incus, String name) {
         var xdgRuntimeDir = System.getenv("XDG_RUNTIME_DIR");
         var waylandDisplay = System.getenv("WAYLAND_DISPLAY");
         if (xdgRuntimeDir == null || waylandDisplay == null) {
             System.err.println("Error: GUI passthrough requires WAYLAND_DISPLAY and XDG_RUNTIME_DIR.");
             System.err.println("Make sure you are running isx from a Wayland graphical session.");
+            return false;
+        }
+        if (!WAYLAND_DISPLAY_PATTERN.matcher(waylandDisplay).matches()) {
+            System.err.println("Error: WAYLAND_DISPLAY contains invalid characters: " + waylandDisplay);
             return false;
         }
         var hostSocket = xdgRuntimeDir + "/" + waylandDisplay;
@@ -181,23 +216,119 @@ public class BranchCommand implements Runnable {
         }
 
         System.out.println("Enabling GUI passthrough...");
-        var uid = getUid();
+        // Remove first in case the source already had these devices (incus copy carries them over).
+        incus.exec("config", "device", "remove", name, "gpu");
+        incus.exec("config", "device", "remove", name, "xdg-runtime");
         incus.deviceAdd(name, "gpu", "gpu");
+        // Mount to /mnt/host-xdg instead of /run/user/<uid> — systemd-logind
+        // mounts its own tmpfs at /run/user/<uid> which would hide this device.
         incus.deviceAdd(name, "xdg-runtime", "disk",
                 "source=" + xdgRuntimeDir,
-                "path=/run/user/" + uid);
-        incus.shellExec(name, "sh", "-c",
-                "cat > /etc/profile.d/wayland.sh << 'ENVEOF'\n" +
-                "export WAYLAND_DISPLAY=" + waylandDisplay + "\n" +
-                "export XDG_RUNTIME_DIR=/run/user/" + uid + "\n" +
-                "export GDK_BACKEND=wayland\n" +
-                "export QT_QPA_PLATFORM=wayland\n" +
-                "export SDL_VIDEODRIVER=wayland\n" +
-                "export MOZ_ENABLE_WAYLAND=1\n" +
-                "export ELECTRON_OZONE_PLATFORM_HINT=wayland\n" +
-                "ENVEOF\n" +
-                "chmod 644 /etc/profile.d/wayland.sh");
+                "path=/mnt/host-xdg");
+        // Set env vars via container config (visible to init and direct exec)
+        // AND via profile.d script (visible to login shells, since su - resets env).
+        var uid = getUid();
+        var waylandSocketPath = "/mnt/host-xdg/" + waylandDisplay;
+        incus.configSet(name, "environment.WAYLAND_DISPLAY", waylandSocketPath);
+        incus.configSet(name, "environment.XDG_RUNTIME_DIR", "/run/user/" + uid);
+        WAYLAND_ENV.forEach((k, v) -> incus.configSet(name, "environment." + k, v));
+        if (!pushWaylandFiles(incus, name, waylandSocketPath, uid)) {
+            System.err.println("Warning: GUI devices configured but profile.d scripts failed to install.");
+            System.err.println("GUI may not work in login shells.");
+            return false;
+        }
         return true;
+    }
+
+    /**
+     * Remove GUI passthrough from a container that inherited it via incus copy.
+     * Clears devices, environment keys, metadata, and profile.d/tmpfiles.d scripts.
+     */
+    static void removeGui(IncusClient incus, String name) {
+        incus.exec("config", "device", "remove", name, "gpu");
+        incus.exec("config", "device", "remove", name, "xdg-runtime");
+        incus.exec("config", "unset", name, Metadata.GUI_ENABLED);
+        incus.exec("config", "unset", name, "environment.WAYLAND_DISPLAY");
+        incus.exec("config", "unset", name, "environment.XDG_RUNTIME_DIR");
+        for (var key : WAYLAND_ENV.keySet()) {
+            incus.exec("config", "unset", name, "environment." + key);
+        }
+        // Remove profile.d and tmpfiles.d scripts that re-export Wayland env in login shells
+        try {
+            pushTempFile(incus, name, "", "/etc/profile.d/wayland.sh");
+            pushTempFile(incus, name, "", "/etc/tmpfiles.d/wayland-runtime.conf");
+        } catch (IOException | RuntimeException e) {
+            // Best-effort: files may not exist if GUI was never fully configured
+        }
+    }
+
+    /**
+     * Warn at shell entry if a GUI-enabled container can't reach the host
+     * Wayland compositor.
+     */
+    static void checkGuiHealth(IncusClient incus, String name) {
+        var guiEnabled = incus.configGet(name, Metadata.GUI_ENABLED);
+        if (!"true".equals(guiEnabled)) return;
+        var waylandDisplay = System.getenv("WAYLAND_DISPLAY");
+        var xdgRuntimeDir = System.getenv("XDG_RUNTIME_DIR");
+        if (waylandDisplay == null || xdgRuntimeDir == null) {
+            System.err.println("\033[33mWarning: GUI passthrough is enabled but no Wayland session detected.\033[0m");
+            System.err.println("GUI applications will not work in this session.");
+            return;
+        }
+        var socket = xdgRuntimeDir + "/" + waylandDisplay;
+        if (!java.nio.file.Files.exists(java.nio.file.Path.of(socket))) {
+            System.err.println("\033[33mWarning: GUI passthrough is enabled but Wayland socket not found.\033[0m");
+            System.err.println("GUI applications may not work. Try re-branching with --gui.");
+        }
+    }
+
+    private static boolean pushWaylandFiles(IncusClient incus, String container, String waylandSocketPath, String uid) {
+        try {
+            var profile = new StringBuilder();
+            profile.append("export WAYLAND_DISPLAY=").append(waylandSocketPath).append('\n');
+            profile.append("export XDG_RUNTIME_DIR=/run/user/").append(uid).append('\n');
+            WAYLAND_ENV.forEach((k, v) -> profile.append("export ").append(k).append('=').append(v).append('\n'));
+            pushTempFile(incus, container, profile.toString(), "/etc/profile.d/wayland.sh");
+
+            // systemd-logind may not create /run/user/<uid> in containers;
+            // ensure it exists at boot so XDG_RUNTIME_DIR is usable.
+            var tmpfiles = "d /run/user/" + uid + " 0700 " + uid + " " + uid + " -\n";
+            pushTempFile(incus, container, tmpfiles, "/etc/tmpfiles.d/wayland-runtime.conf");
+            return true;
+        } catch (IOException | RuntimeException e) {
+            System.err.println("Warning: failed to push wayland config: " + e.getMessage());
+            return false;
+        }
+    }
+
+    private static void pushTempFile(IncusClient incus, String container, String content, String destPath)
+            throws IOException {
+        var tmp = Files.createTempFile("isx-", ".tmp");
+        try {
+            Files.writeString(tmp, content);
+            var perms = java.util.Set.of(
+                    java.nio.file.attribute.PosixFilePermission.OWNER_READ,
+                    java.nio.file.attribute.PosixFilePermission.OWNER_WRITE,
+                    java.nio.file.attribute.PosixFilePermission.GROUP_READ,
+                    java.nio.file.attribute.PosixFilePermission.OTHERS_READ);
+            Files.setPosixFilePermissions(tmp, perms);
+            incus.filePush(tmp.toString(), container, destPath);
+        } finally {
+            Files.deleteIfExists(tmp);
+        }
+    }
+
+    private void warnIfTemplateWantsGui(String source) {
+        if ("true".equals(incus.configGet(source, Metadata.GUI_ENABLED))) {
+            System.err.println("Note: '" + source + "' has GUI passthrough — consider using --gui.");
+            return;
+        }
+        var defs = ImageDef.loadAll();
+        var def = defs.get(source);
+        if (def != null && def.isGui()) {
+            System.err.println("Note: '" + source + "' has GUI passthrough — consider using --gui.");
+        }
     }
 
     private NetworkMode resolveNetworkMode() {

--- a/src/main/java/dev/incusspawn/command/ListCommand.java
+++ b/src/main/java/dev/incusspawn/command/ListCommand.java
@@ -590,7 +590,9 @@ public class ListCommand implements Runnable {
     private void openBranchModal(String sourceName, String runtime) {
         branchSourceName = sourceName;
         branchNameInput = new TextInputState(suggestBranchName(sourceName));
-        branchEnableGui = false;
+        var def = imageDefs.get(sourceName);
+        branchEnableGui = (def != null && def.isGui())
+                || "true".equals(incus.configGet(sourceName, Metadata.GUI_ENABLED));
         branchNetworkMode = NetworkMode.FULL;
         branchEnableInbox = false;
         branchInboxInput = new TextInputState("");
@@ -2428,15 +2430,24 @@ public class ListCommand implements Runnable {
         // Add git remotes to host repos (doesn't require instance to be running)
         AutoRemoteService.addRemotes(incus, name);
 
+        // Configure GUI before start so environment.* keys are visible to init
+        if (gui) {
+            if (configureGui(name)) {
+                incus.configSet(name, Metadata.GUI_ENABLED, "true");
+            } else {
+                BranchCommand.removeGui(incus, name);
+                System.err.println("Continuing without GUI passthrough.");
+            }
+        } else {
+            // Clean up inherited GUI devices/env from incus copy
+            BranchCommand.removeGui(incus, name);
+        }
+
         incus.start(name);
         waitForReady(name);
 
         if (networkMode == NetworkMode.PROXY_ONLY) {
             BranchCommand.applyProxyOnlyFirewall(incus, name);
-        }
-
-        if (gui && !configureGui(name)) {
-            System.err.println("Continuing without GUI passthrough.");
         }
 
         if (inboxPath != null && !inboxPath.isEmpty()) {
@@ -2466,40 +2477,7 @@ public class ListCommand implements Runnable {
     }
 
     private boolean configureGui(String name) {
-        var xdgRuntimeDir = System.getenv("XDG_RUNTIME_DIR");
-        var waylandDisplay = System.getenv("WAYLAND_DISPLAY");
-        if (xdgRuntimeDir == null || waylandDisplay == null) {
-            System.err.println("Error: GUI passthrough requires WAYLAND_DISPLAY and XDG_RUNTIME_DIR.");
-            System.err.println("Make sure you are running isx from a Wayland graphical session.");
-            return false;
-        }
-        var hostSocket = xdgRuntimeDir + "/" + waylandDisplay;
-        if (!java.nio.file.Files.exists(java.nio.file.Path.of(hostSocket))) {
-            System.err.println("Error: Wayland socket not found at " + hostSocket);
-            System.err.println("Make sure you are running isx from a Wayland graphical session.");
-            return false;
-        }
-
-        System.out.println("Enabling GUI passthrough...");
-        var uid = String.valueOf(getUid());
-
-        incus.deviceAdd(name, "gpu", "gpu");
-        incus.deviceAdd(name, "xdg-runtime", "disk",
-                "source=" + xdgRuntimeDir,
-                "path=/run/user/" + uid);
-
-        incus.shellExec(name, "sh", "-c",
-                "cat > /etc/profile.d/wayland.sh << 'ENVEOF'\n" +
-                "export WAYLAND_DISPLAY=" + waylandDisplay + "\n" +
-                "export XDG_RUNTIME_DIR=/run/user/" + uid + "\n" +
-                "export GDK_BACKEND=wayland\n" +
-                "export QT_QPA_PLATFORM=wayland\n" +
-                "export SDL_VIDEODRIVER=wayland\n" +
-                "export MOZ_ENABLE_WAYLAND=1\n" +
-                "export ELECTRON_OZONE_PLATFORM_HINT=wayland\n" +
-                "ENVEOF\n" +
-                "chmod 644 /etc/profile.d/wayland.sh");
-        return true;
+        return BranchCommand.configureGui(incus, name);
     }
 
     private void configureProxyOnly(String name) {
@@ -2582,9 +2560,14 @@ public class ListCommand implements Runnable {
             incus.start(name);
             waitForReady(name);
         }
+        checkGuiHealth(name);
         System.out.println("Connecting to " + name + "...\n");
         incus.interactiveShell(name, "agentuser");
         System.out.println();
+    }
+
+    private void checkGuiHealth(String name) {
+        BranchCommand.checkGuiHealth(incus, name);
     }
 
     private void waitForReady(String name) {

--- a/src/main/java/dev/incusspawn/command/ShellCommand.java
+++ b/src/main/java/dev/incusspawn/command/ShellCommand.java
@@ -46,6 +46,8 @@ public class ShellCommand implements Runnable {
             waitForReady(name);
         }
 
+        BranchCommand.checkGuiHealth(incus, name);
+
         System.out.println("Connecting to " + name + "...\n");
         incus.interactiveShell(name, "agentuser");
     }

--- a/src/main/java/dev/incusspawn/config/ImageDef.java
+++ b/src/main/java/dev/incusspawn/config/ImageDef.java
@@ -77,6 +77,7 @@ public class ImageDef {
     private SkillsDef skills = SkillsDef.EMPTY;
     @JsonProperty("host-resources")
     private List<HostResource> hostResources = List.of();
+    private boolean gui;
 
     @JsonIgnore
     private String source = "unknown";
@@ -99,6 +100,8 @@ public class ImageDef {
     public void setSkills(SkillsDef skills) { this.skills = skills; }
     public List<HostResource> getHostResources() { return hostResources; }
     public void setHostResources(List<HostResource> hostResources) { this.hostResources = hostResources; }
+    public boolean isGui() { return gui; }
+    public void setGui(boolean gui) { this.gui = gui; }
     public String getSource() { return source; }
     public void setSource(String source) { this.source = source; }
 
@@ -234,6 +237,7 @@ public class ImageDef {
             sb.append("hr=").append(hr.getSource()).append(',').append(hr.getPath())
                     .append(',').append(hr.getMode()).append('\n');
         }
+        if (gui) sb.append("gui=true\n");
         return sha256hex(sb.toString());
     }
 

--- a/src/main/java/dev/incusspawn/incus/Metadata.java
+++ b/src/main/java/dev/incusspawn/incus/Metadata.java
@@ -24,6 +24,7 @@ public final class Metadata {
     public static final String HOST_RESOURCES = PREFIX + "host-resources";
     public static final String DEFINITION_SHA = PREFIX + "definition-sha";
     public static final String BUILD_SOURCE = PREFIX + "build-source";
+    public static final String GUI_ENABLED = PREFIX + "gui-enabled";
 
     public static final String TYPE_BASE = "base";
     public static final String TYPE_PROJECT = "project";


### PR DESCRIPTION
## Summary
- Templates can declare `gui: true` in YAML to indicate they need GUI passthrough; the TUI defaults the GUI toggle ON for these templates, and the CLI prints a note recommending `--gui` when branching without it
- GUI enablement is tracked via `gui-enabled` instance metadata so shell entry (`isx shell` and TUI F2) can verify Wayland health and warn when the host session is unavailable
- Fixed Wayland socket mounting: uses `/mnt/host-xdg` instead of `/run/user/<uid>` to avoid being hidden by systemd-logind's tmpfs, with a tmpfiles.d config ensuring `/run/user/<uid>` exists at boot
- Environment variables set via both container-level `environment.*` config (for init/direct exec) and `/etc/profile.d/wayland.sh` (for login shells via `su -`)
- Removes existing GPU/xdg-runtime devices before re-adding to handle re-branching from GUI-enabled instances

## Test plan
- [ ] Build from firefox template via TUI — GUI toggle should default to ON
- [ ] `isx branch test --from tpl-firefox` without `--gui` — should print note
- [ ] Branch with `--gui`, verify Firefox launches and renders
- [ ] Branch from a GUI-enabled instance — should inherit GUI default, no duplicate device errors
- [ ] `isx shell <gui-instance>` from a non-Wayland session (SSH) — should show warning
- [ ] `isx shell <gui-instance>` from Wayland — no warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)