### PR TITLE
fix: disable sshd.socket to prevent startup conflict with sshd.service

### DIFF
--- a/src/main/resources/tools/sshd.yaml
+++ b/src/main/resources/tools/sshd.yaml
@@ -8,6 +8,10 @@ run:
   - sed -i 's/^#*PasswordAuthentication.*/PasswordAuthentication no/' /etc/ssh/sshd_config
   - sed -i 's/^#*PubkeyAuthentication.*/PubkeyAuthentication yes/' /etc/ssh/sshd_config
   - ssh-keygen -A
+  # Disable socket activation to avoid conflict with sshd.service. Both sshd.service
+  # and sshd.socket may be enabled (from package install or base image), but they
+  # conflict (both claim port 22). When both are enabled, neither starts on boot.
+  - systemctl disable sshd.socket
   - systemctl enable --now sshd
   - mkdir -p /home/agentuser/.ssh
   - touch /home/agentuser/.ssh/authorized_keys


### PR DESCRIPTION
It's all guesses and I still don't know why sshd.socket was enabled to begin with, but... worth a try?

---


sshd was intermittently failing to start on instance boot. Investigation revealed that both sshd.service and sshd.socket were enabled, but since they both claim port 22 (sshd.socket has "Conflicts=sshd.service"), when both are enabled neither starts automatically on boot.

The two units provide mutually exclusive modes of operation:
- sshd.service: traditional daemon running continuously (sshd -D)
- sshd.socket: socket activation spawning sshd -i per connection

We use sshd.service (via "systemctl enable --now sshd"), but somehow sshd.socket also ends up enabled, likely from:
1. The openssh-server package %post script, or
2. The base Fedora container image (images:fedora/44)

While Fedora deprecated sshd.socket in F39 due to DoS concerns, the unit file is still shipped in openssh-server on F44. The fix is to explicitly disable sshd.socket before enabling sshd.service to ensure only one mode is active.

Symptom: After branching an instance, sshd.service shows:
  UnitFileState=enabled but ActiveState=inactive (dead)
  ConditionResult=no AssertResult=no (systemd never tried to start it)

Manual "systemctl start sshd" works fine, proving sshd itself is functional. The issue is purely the boot-time conflict between the two enabled units.

Assisted-By: Claude Code <noreply@anthropic.com>