### PR TITLE
fix: support native image builds on macOS

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -25,7 +25,22 @@ fi
 
 if $NATIVE; then
     echo "Building native image (this may take a minute)..."
-    "$SCRIPT_DIR/mvnw" package -Dnative -Dquarkus.native.container-build=true -DskipTests -q
+    NATIVE_ARGS="-Dnative -DskipTests -q"
+    if [ "$(uname -s)" = "Linux" ]; then
+        NATIVE_ARGS="$NATIVE_ARGS -Dquarkus.native.container-build=true"
+    elif [ "$(uname -s)" = "Darwin" ]; then
+        if [ -z "$GRAALVM_HOME" ] || [ ! -x "$GRAALVM_HOME/bin/native-image" ]; then
+            GRAALVM_HOME=$(/usr/libexec/java_home -V 2>&1 | grep -i graal | awk '{print $NF}' | head -1)
+        fi
+        if [ -z "$GRAALVM_HOME" ] || [ ! -x "$GRAALVM_HOME/bin/native-image" ]; then
+            echo "Error: GraalVM with native-image is required for native builds on macOS."
+            echo "  Install with: brew install graalvm-jdk@25"
+            echo "  Or set GRAALVM_HOME to a GraalVM installation."
+            exit 1
+        fi
+        export JAVA_HOME="$GRAALVM_HOME"
+    fi
+    "$SCRIPT_DIR/mvnw" package $NATIVE_ARGS
     echo "Installing to ${INSTALL_DIR}/${BINARY_NAME}..."
     mkdir -p "$INSTALL_DIR"
     RUNNER=$(ls -t "$SCRIPT_DIR"/target/incus-spawn-*-runner 2>/dev/null | head -1)


### PR DESCRIPTION
## Summary
- The `--native` install previously used `-Dquarkus.native.container-build=true` unconditionally, producing a Linux ELF binary even on macOS
- Detect the host OS: use container build on Linux, local GraalVM on macOS
- Auto-detect GraalVM via `/usr/libexec/java_home` with a clear error message if not installed

## Test plan
- [x] Verified `./install.sh --native` produces a Mach-O arm64 binary on macOS
- [x] Verified `isx --version` runs successfully
- [ ] Confirm Linux container build path is unchanged (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)