### PR TITLE
Add arch-filtered downloads to fix starship on aarch64

### DIFF
--- a/src/main/java/dev/incusspawn/tool/ToolDef.java
+++ b/src/main/java/dev/incusspawn/tool/ToolDef.java
@@ -96,6 +96,7 @@ public class ToolDef {
         private Map<String, String> links = Map.of();
         @JsonProperty("extract_in_container")
         private boolean extractInContainer = false;
+        private String arch;
 
         public String getUrl() { return url; }
         public void setUrl(String url) { this.url = url; }
@@ -107,6 +108,8 @@ public class ToolDef {
         public void setLinks(Map<String, String> links) { this.links = links; }
         public boolean isExtractInContainer() { return extractInContainer; }
         public void setExtractInContainer(boolean extractInContainer) { this.extractInContainer = extractInContainer; }
+        public String getArch() { return arch; }
+        public void setArch(String arch) { this.arch = arch; }
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -313,7 +316,8 @@ public class ToolDef {
         for (var d : downloads) {
             sb.append("dl=").append(d.url).append(',').append(d.sha256)
                     .append(',').append(d.extract)
-                    .append(',').append(d.extractInContainer);
+                    .append(',').append(d.extractInContainer)
+                    .append(',').append(d.arch);
             new TreeMap<>(d.links).forEach((k, v) -> sb.append(',').append(k).append('=').append(v));
             sb.append('\n');
         }

--- a/src/main/java/dev/incusspawn/tool/YamlToolSetup.java
+++ b/src/main/java/dev/incusspawn/tool/YamlToolSetup.java
@@ -61,7 +61,11 @@ public class YamlToolSetup implements ToolSetup {
         // Packages are installed in bulk by BuildCommand before tool.install() is called.
 
         // 1. Downloads — fetch on host, extract on host, push into container
+        var hostArch = canonicalArch();
         for (var dl : def.getDownloads()) {
+            if (dl.getArch() != null && !dl.getArch().equals(hostArch)) {
+                continue;
+            }
             processDownload(dl, container);
         }
 
@@ -105,6 +109,14 @@ public class YamlToolSetup implements ToolSetup {
                 System.err.println("  Warning: verification failed for " + def.getName());
             }
         }
+    }
+
+    static String canonicalArch() {
+        return switch (System.getProperty("os.arch")) {
+            case "amd64", "x86_64" -> "x86_64";
+            case "aarch64" -> "aarch64";
+            default -> System.getProperty("os.arch");
+        };
     }
 
     private void processDownload(ToolDef.DownloadEntry dl, Container container) {

--- a/src/main/resources/tools/starship.yaml
+++ b/src/main/resources/tools/starship.yaml
@@ -5,6 +5,11 @@ downloads:
   - url: https://github.com/starship/starship/releases/download/v1.25.1/starship-x86_64-unknown-linux-gnu.tar.gz
     sha256: 4488c11ca632327d1f1f16fb2f102c0646094c35479cd5435991385da43c61ac
     extract: /tmp/starship
+    arch: x86_64
+  - url: https://github.com/starship/starship/releases/download/v1.25.1/starship-aarch64-unknown-linux-gnu.tar.gz
+    sha256: 0019dfc4b32d63c1392aa264aed2253c1e0c2fb09216f8e2cc269bbfb8bb49b5
+    extract: /tmp/starship
+    arch: aarch64
 
 run:
   - install -m 755 /tmp/starship/starship /usr/local/bin/starship

--- a/src/test/java/dev/incusspawn/tool/ToolDefTest.java
+++ b/src/test/java/dev/incusspawn/tool/ToolDefTest.java
@@ -695,6 +695,82 @@ class ToolDefTest {
         assertEquals(r1.get("parent"), r2.get("parent"), "Dep order should not affect composite fp");
     }
 
+    @Test
+    void parseDownloadWithArch() throws Exception {
+        var yaml = """
+                name: starship
+                downloads:
+                  - url: https://example.com/starship-x86_64.tar.gz
+                    sha256: abc123
+                    extract: /tmp/starship
+                    arch: x86_64
+                  - url: https://example.com/starship-aarch64.tar.gz
+                    sha256: def456
+                    extract: /tmp/starship
+                    arch: aarch64
+                """;
+        var def = ToolDef.loadFromStream(toStream(yaml));
+
+        assertEquals(2, def.getDownloads().size());
+        assertEquals("x86_64", def.getDownloads().get(0).getArch());
+        assertEquals("aarch64", def.getDownloads().get(1).getArch());
+    }
+
+    @Test
+    void parseDownloadWithoutArchHasNullArch() throws Exception {
+        var yaml = """
+                name: maven-3
+                downloads:
+                  - url: https://example.com/maven.tar.gz
+                    sha256: abc123
+                    extract: /opt
+                """;
+        var def = ToolDef.loadFromStream(toStream(yaml));
+
+        assertNull(def.getDownloads().get(0).getArch());
+    }
+
+    @Test
+    void fingerprintChangesWhenArchChanges() throws Exception {
+        var a = ToolDef.loadFromStream(toStream("""
+                name: test
+                downloads:
+                  - url: https://example.com/tool.tar.gz
+                    sha256: abc123
+                    extract: /opt
+                    arch: x86_64
+                """));
+        var b = ToolDef.loadFromStream(toStream("""
+                name: test
+                downloads:
+                  - url: https://example.com/tool.tar.gz
+                    sha256: abc123
+                    extract: /opt
+                    arch: aarch64
+                """));
+        assertNotEquals(a.contentFingerprint(), b.contentFingerprint());
+    }
+
+    @Test
+    void fingerprintChangesWhenArchAddedToDownload() throws Exception {
+        var a = ToolDef.loadFromStream(toStream("""
+                name: test
+                downloads:
+                  - url: https://example.com/tool.tar.gz
+                    sha256: abc123
+                    extract: /opt
+                """));
+        var b = ToolDef.loadFromStream(toStream("""
+                name: test
+                downloads:
+                  - url: https://example.com/tool.tar.gz
+                    sha256: abc123
+                    extract: /opt
+                    arch: x86_64
+                """));
+        assertNotEquals(a.contentFingerprint(), b.contentFingerprint());
+    }
+
     private static ByteArrayInputStream toStream(String yaml) {
         return new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8));
     }

--- a/src/test/java/dev/incusspawn/tool/YamlToolSetupTest.java
+++ b/src/test/java/dev/incusspawn/tool/YamlToolSetupTest.java
@@ -199,6 +199,91 @@ class YamlToolSetupTest {
     }
 
     @Test
+    void downloadWithMatchingArchIsProcessed(@TempDir Path tempDir) throws IOException {
+        var incus = mock(IncusClient.class);
+        when(incus.shellExec(anyString(), any(String[].class))).thenReturn(OK);
+
+        var fakeArchive = tempDir.resolve("tool.tar.gz");
+        Files.writeString(fakeArchive, "fake");
+
+        var downloadCache = mock(DownloadCache.class);
+        when(downloadCache.download(anyString(), any())).thenReturn(fakeArchive);
+
+        var dl = new ToolDef.DownloadEntry();
+        dl.setUrl("https://example.com/tool-" + YamlToolSetup.canonicalArch() + ".tar.gz");
+        dl.setSha256("abc123");
+        dl.setExtract("/opt");
+        dl.setArch(YamlToolSetup.canonicalArch());
+
+        var def = new ToolDef();
+        def.setName("arch-match");
+        def.setDownloads(List.of(dl));
+
+        var setup = new YamlToolSetup(def, downloadCache);
+        try {
+            setup.install(new Container(incus, CONTAINER), Map.of());
+        } catch (RuntimeException ignored) {
+            // extraction of fake archive fails
+        }
+
+        verify(downloadCache).download(dl.getUrl(), "abc123");
+    }
+
+    @Test
+    void downloadWithNonMatchingArchIsSkipped(@TempDir Path tempDir) throws IOException {
+        var incus = mock(IncusClient.class);
+
+        var downloadCache = mock(DownloadCache.class);
+
+        var otherArch = YamlToolSetup.canonicalArch().equals("x86_64") ? "aarch64" : "x86_64";
+        var dl = new ToolDef.DownloadEntry();
+        dl.setUrl("https://example.com/tool-" + otherArch + ".tar.gz");
+        dl.setSha256("abc123");
+        dl.setExtract("/opt");
+        dl.setArch(otherArch);
+
+        var def = new ToolDef();
+        def.setName("arch-skip");
+        def.setDownloads(List.of(dl));
+
+        var setup = new YamlToolSetup(def, downloadCache);
+        setup.install(new Container(incus, CONTAINER), Map.of());
+
+        verify(downloadCache, never()).download(anyString(), any());
+    }
+
+    @Test
+    void downloadWithoutArchIsAlwaysProcessed(@TempDir Path tempDir) throws IOException {
+        var incus = mock(IncusClient.class);
+        when(incus.shellExec(anyString(), any(String[].class))).thenReturn(OK);
+
+        var fakeArchive = tempDir.resolve("tool.tar.gz");
+        Files.writeString(fakeArchive, "fake");
+
+        var downloadCache = mock(DownloadCache.class);
+        when(downloadCache.download(anyString(), any())).thenReturn(fakeArchive);
+
+        var dl = new ToolDef.DownloadEntry();
+        dl.setUrl("https://example.com/tool.tar.gz");
+        dl.setSha256("abc123");
+        dl.setExtract("/opt");
+        // no arch set — should match all
+
+        var def = new ToolDef();
+        def.setName("no-arch");
+        def.setDownloads(List.of(dl));
+
+        var setup = new YamlToolSetup(def, downloadCache);
+        try {
+            setup.install(new Container(incus, CONTAINER), Map.of());
+        } catch (RuntimeException ignored) {
+            // extraction of fake archive fails
+        }
+
+        verify(downloadCache).download(dl.getUrl(), "abc123");
+    }
+
+    @Test
     void fileWithoutOwnerSkipsChown() {
         var incus = mock(IncusClient.class);
         when(incus.shellExec(anyString(), any(String[].class))).thenReturn(OK);


### PR DESCRIPTION
The starship tool hardcoded an x86_64 download URL, causing "cannot execute binary file: Exec format error" on aarch64 hosts. Add an optional `arch` field to YAML download entries that filters by host architecture at install time, and provide both x86_64 and aarch64 starship binaries.