### PR TITLE
Clarify group membership requirements for init and proxy service

### DIFF
--- a/src/main/java/dev/incusspawn/command/InitCommand.java
+++ b/src/main/java/dev/incusspawn/command/InitCommand.java
@@ -438,10 +438,11 @@ public class InitCommand implements Runnable {
                 System.out.println("  Cannot connect to the Incus daemon.");
                 System.out.println("  This usually means the 'incus-admin' group membership is not active in this shell.");
                 System.out.println();
-                System.out.println("  Please do one of the following:");
+                System.out.println("  To continue init in this session:");
                 System.out.println("    - Run: newgrp incus-admin");
-                System.out.println("    - Or log out and log back in");
-                System.out.println("  Then re-run 'isx init' to continue.");
+                System.out.println("    - Then re-run 'isx init'");
+                System.out.println();
+                System.out.println("  After init completes, log out and log back in for the proxy service to work.");
                 System.exit(1);
             }
             // Unknown error — continue anyway (daemon may start during init)

--- a/src/main/java/dev/incusspawn/proxy/ProxyService.java
+++ b/src/main/java/dev/incusspawn/proxy/ProxyService.java
@@ -268,7 +268,21 @@ public final class ProxyService {
             if (!output.isBlank()) {
                 System.err.println("Recent logs:");
                 System.err.println(output);
-                if (output.contains("status=127")) {
+                if (output.contains("could not determine Incus bridge gateway IP")) {
+                    System.err.println();
+                    System.err.println("The proxy cannot access Incus. The systemd user manager was started");
+                    System.err.println("before you were added to the 'incus-admin' group.");
+                    System.err.println();
+                    System.err.println("Fix: Restart the systemd user manager to pick up new group membership:");
+                    System.err.println("     systemctl --user exit    # WARNING: ends your session immediately");
+                    System.err.println("     # Then log back in and run:");
+                    System.err.println("     systemctl --user restart " + SERVICE_NAME);
+                    System.err.println();
+                    System.err.println("(Note: Logging out/in is not sufficient when user lingering is enabled)");
+                    System.err.println();
+                    System.err.println("Alternatively, start the proxy manually instead:");
+                    System.err.println("     isx proxy start");
+                } else if (output.contains("status=127")) {
                     System.err.println();
                     System.err.println("Exit code 127 usually means the Java binary was not found.");
                     System.err.println("If isx was installed as a JVM wrapper, ensure Java "


### PR DESCRIPTION
When init adds the user to incus-admin, `newgrp` lets the current shell continue but doesn't help the systemd user manager (which started before the group was added). Even logging out/in isn't sufficient when user lingering is enabled, because the user systemd instance persists across login sessions and retains the old group membership.

Updated messaging to explain that `systemctl --user exit` is needed to restart the user systemd manager and pick up the new group membership. Added a warning that this command ends the session immediately.

I ran into this issue on Fedora 43 with user lingering enabled (confirmed by `loginctl show-user $USER | grep -i linger`). If lingering is off, then I think that `systemctl --user daemon-reexec` would be enough to get the correct permissions, but I didn't experiment with it.