### PR TITLE
Build robustness: systemd waits, DNS fixes

### DIFF
--- a/src/main/java/dev/incusspawn/command/BuildCommand.java
+++ b/src/main/java/dev/incusspawn/command/BuildCommand.java
@@ -555,6 +555,15 @@ public class BuildCommand extends BaseCommand {
         incus.copy(parentSource, buildName);
         incus.start(buildName);
         waitForReady(buildName);
+
+        // Re-apply DNS fix — systemd-resolved can re-enable after copy+start
+        var gatewayIp = MitmProxy.resolveGatewayIp(incus);
+        new Container(incus, buildName).sh(
+                "sed -i 's/resolve \\[!UNAVAIL=return\\] //' /etc/nsswitch.conf; " +
+                "rm -f /etc/resolv.conf; " +
+                "echo 'nameserver " + gatewayIp + "' > /etc/resolv.conf")
+                .assertSuccess("Failed to fix DNS after copy");
+
         waitForNetwork(buildName);
 
         mountDnfCache(buildName);
@@ -627,12 +636,16 @@ public class BuildCommand extends BaseCommand {
         incus.configSet(buildName, "security.syscalls.intercept.mknod", "true");
         incus.configSet(buildName, "security.syscalls.intercept.setxattr", "true");
         incus.configSet(buildName, "raw.lxc", "lxc.cap.drop =");
-        incus.pollUntilReady(buildName, 30,
-                "sh", "-c", "systemctl is-system-running 2>/dev/null | grep -qE 'running|degraded'");
+        if (!incus.pollUntilReady(buildName, 30,
+                "sh", "-c", "systemctl is-system-running 2>/dev/null | grep -qE 'running|degraded'")) {
+            System.err.println("Warning: systemd did not reach running/degraded before restart — continuing anyway");
+        }
         incus.restart(buildName);
         waitForReady(buildName);
-        incus.pollUntilReady(buildName, 30,
-                "sh", "-c", "systemctl is-system-running 2>/dev/null | grep -qE 'running|degraded'");
+        if (!incus.pollUntilReady(buildName, 30,
+                "sh", "-c", "systemctl is-system-running 2>/dev/null | grep -qE 'running|degraded'")) {
+            System.err.println("Warning: systemd did not reach running/degraded after restart — DNS setup may fail");
+        }
 
         var container = new Container(incus, buildName);
 

--- a/src/main/java/dev/incusspawn/command/BuildCommand.java
+++ b/src/main/java/dev/incusspawn/command/BuildCommand.java
@@ -627,8 +627,12 @@ public class BuildCommand extends BaseCommand {
         incus.configSet(buildName, "security.syscalls.intercept.mknod", "true");
         incus.configSet(buildName, "security.syscalls.intercept.setxattr", "true");
         incus.configSet(buildName, "raw.lxc", "lxc.cap.drop =");
+        incus.pollUntilReady(buildName, 30,
+                "sh", "-c", "systemctl is-system-running 2>/dev/null | grep -qE 'running|degraded'");
         incus.restart(buildName);
         waitForReady(buildName);
+        incus.pollUntilReady(buildName, 30,
+                "sh", "-c", "systemctl is-system-running 2>/dev/null | grep -qE 'running|degraded'");
 
         var container = new Container(incus, buildName);
 

--- a/src/main/java/dev/incusspawn/proxy/MitmProxy.java
+++ b/src/main/java/dev/incusspawn/proxy/MitmProxy.java
@@ -241,12 +241,20 @@ public class MitmProxy {
     public static void configureBridgeDns(IncusClient incus) {
         try {
             var gatewayIp = resolveGatewayIp(incus);
-            var dnsmasqConfig = interceptedDomains().stream()
+            var overrides = interceptedDomains().stream()
                     .sorted()
                     .flatMap(d -> java.util.stream.Stream.of(
                             "address=/" + d + "/" + gatewayIp,
                             "address=/" + d + "/::"))
                     .collect(java.util.stream.Collectors.joining("\n"));
+
+            // Preserve any existing server= lines (upstream DNS forwarders).
+            var existing = incus.networkConfigGet("incusbr0", "raw.dnsmasq");
+            var servers = existing.lines()
+                    .filter(l -> l.startsWith("server="))
+                    .collect(java.util.stream.Collectors.joining("\n"));
+            var dnsmasqConfig = servers.isEmpty() ? overrides : servers + "\n" + overrides;
+
             incus.networkConfigSet("incusbr0", "raw.dnsmasq", dnsmasqConfig);
             System.out.println("  DNS overrides: " + interceptedDomains().size() +
                     " domains -> " + gatewayIp + " (via bridge dnsmasq)");


### PR DESCRIPTION
## Summary

Three targeted fixes for build reliability, especially on slower hosts or VMs:

1. **Preserve upstream DNS forwarders** — `configureBridgeDns` was replacing the entire `raw.dnsmasq` config, wiping out `server=` directives. Now preserves them.

2. **Wait for systemd before/after restart** — `buildFromScratch` now waits for `systemctl is-system-running` to reach `running`/`degraded` before restarting with security configs, and again after restart before configuring DNS. Prevents DNS failures on slower hosts.

3. **DNS fix in buildFromParent** — `systemd-resolved` can re-enable when a container is copied and started, overriding the parent's DNS config. Now re-applies the nsswitch + resolv.conf fix after copy+start.

## Test plan
- Build tpl-minimal from scratch — verify no DNS failures during waitForNetwork
- Build tpl-dev (derives from tpl-minimal) — verify DNS works in derived build
- Run on a slow host or VM to verify the systemd waits prevent timing issues

Extracted from #144 (macOS support)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>