### PR TITLE
Fix failed build cleanup: force-stop and hide transient containers

### DIFF
--- a/src/main/java/dev/incusspawn/command/BuildCommand.java
+++ b/src/main/java/dev/incusspawn/command/BuildCommand.java
@@ -107,7 +107,7 @@ public class BuildCommand extends BaseCommand {
         return true;
     }
     private static final String DNF_CACHE_DEVICE = "dnf-cache";
-    private static final String REBUILDING_SUFFIX = "-rebuilding";
+    static final String REBUILDING_SUFFIX = "-rebuilding";
 
     private volatile String[] activeBuild;
 
@@ -535,7 +535,7 @@ public class BuildCommand extends BaseCommand {
         try {
             incus.deleteIfExists(promotedName);
             try { unmountDnfCache(buildName); } catch (Exception ignored) {}
-            incus.stop(buildName);
+            incus.forceStop(buildName);
             incus.rename(buildName, promotedName);
             incus.configSet(promotedName, Metadata.TYPE, Metadata.TYPE_FAILED_BUILD);
             incus.configSet(promotedName, Metadata.PARENT, canonicalName);

--- a/src/main/java/dev/incusspawn/command/ListCommand.java
+++ b/src/main/java/dev/incusspawn/command/ListCommand.java
@@ -380,6 +380,7 @@ public class ListCommand extends BaseCommand {
         var storedNames = new java.util.HashSet<String>();
         for (var inst : allInstances) {
             if (templateNames.contains(inst.name)) continue;
+            if (inst.name.endsWith(BuildCommand.REBUILDING_SUFFIX)) continue;
             if (!Metadata.TYPE_BASE.equals(inst.type)) continue;
 
             var buildSource = BuildSource.fromJson(inst.buildSourceJson);

--- a/src/main/java/dev/incusspawn/incus/IncusClient.java
+++ b/src/main/java/dev/incusspawn/incus/IncusClient.java
@@ -527,6 +527,15 @@ public class IncusClient {
     }
 
     /**
+     * Force-stop a container/VM, even if it is in an Error state.
+     */
+    public void forceStop(String name) {
+        var resp = http().requestAndWait("PUT", "/1.0/instances/" + name + "/state",
+                Map.of("action", "stop", "timeout", 30, "force", true));
+        if (!resp.isSuccess()) throw new IncusException("Failed to force-stop " + name);
+    }
+
+    /**
      * Restart a container/VM.
      */
     public void restart(String name) {


### PR DESCRIPTION
## Summary

- **Force-stop in `promoteToFailedInstance`**: `stop()` fails on Error-state containers, leaving orphaned `-rebuilding` containers that poison the next build attempt (the stale container conflicts with `deleteIfExists` + `copy` + `start`, causing "Instance is not running" errors). Changed to `forceStop()`.
- **Hide `-rebuilding` from templates panel**: These transient build containers inherit `type=base` from their parent template and were misclassified as templates in the TUI. They now only appear in the instances panel where the user can clean them up.
- **Added `IncusClient.forceStop()`**: Sends `force: true` to the stop endpoint, succeeding even on Error-state containers.

## Test plan

- [ ] Trigger a build failure (e.g., interrupt mid-build), verify the container is promoted to `-failed-build` instead of being left as `-rebuilding`
- [ ] Retry the build immediately after a failure — should succeed without manual cleanup
- [ ] Open the TUI with an orphaned `-rebuilding` container: should appear in instances panel, not templates panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)