### PR TITLE
Trust client cert via virtio-fs instead of trust token

### DIFF
--- a/appliance/root/usr/local/sbin/incus-spawn-vm-init
+++ b/appliance/root/usr/local/sbin/incus-spawn-vm-init
@@ -106,19 +106,17 @@ fi
 # Enable HTTPS API access so the macOS host can connect
 incus config set core.https_address :8443
 
-# Generate a trust token for the macOS host to add its client certificate.
-# The token is printed to the serial console where the Java host reads it.
-# Syntax: `incus config trust add <name>` (name is a positional argument).
-TRUST_OUTPUT=$(incus config trust add incus-spawn 2>&1) || true
-# The output is typically two lines:
-#   Client incus-spawn certificate add token:
-#   eyJjbGllbnRfbmFtZSI6Imlu...
-# Extract the token (last non-empty line that isn't a label).
-TOKEN_VALUE=$(echo "$TRUST_OUTPUT" | grep -v '^$' | grep -v ':$' | tail -1)
-if [ -n "$TOKEN_VALUE" ] && ! echo "$TOKEN_VALUE" | grep -q 'Error\|Usage\|--'; then
-    echo "ISX_TRUST_TOKEN=$TOKEN_VALUE"
+# Trust the host's client certificate via the virtio-fs shared directory.
+# The host generates its cert in ~/.config/incus-spawn/vm/client.crt,
+# which is visible here at $SHARED_DIR/.config/incus-spawn/vm/client.crt.
+HOST_CERT="${SHARED_DIR}/.config/incus-spawn/vm/client.crt"
+if [ -f "$HOST_CERT" ]; then
+    incus config trust add-certificate "$HOST_CERT" --name incus-spawn 2>/dev/null \
+        || true
+    echo "incus-spawn-vm-init: host certificate trusted"
 else
-    echo "incus-spawn-vm-init: WARNING: could not generate trust token: $TRUST_OUTPUT"
+    echo "incus-spawn-vm-init: WARNING: no host certificate at $HOST_CERT"
+    echo "incus-spawn-vm-init: run 'isx init' on the host first"
 fi
 
 # Symlink isx binary from shared directory if available

--- a/src/main/java/dev/incusspawn/vm/IncusRemoteSetup.java
+++ b/src/main/java/dev/incusspawn/vm/IncusRemoteSetup.java
@@ -14,20 +14,19 @@ import java.nio.file.attribute.PosixFilePermissions;
 import java.security.cert.X509Certificate;
 import java.time.Duration;
 import java.util.Base64;
-import java.util.regex.Pattern;
 
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509ExtendedTrustManager;
-import javax.net.ssl.X509TrustManager;
 
 /**
  * One-time setup of the Incus HTTPS remote for macOS.
  * <p>
- * The Incus daemon inside the VM enables HTTPS on port 8443 and prints a
- * trust token to the serial console (vm.log) during boot. This class
- * generates client certificates, reads that token, adds our cert to the
- * daemon's trust store, and writes the local Incus client config.
+ * The VM reads the host's client certificate directly from the virtio-fs
+ * shared directory ({@code /host/.config/incus-spawn/vm/client.crt}) and
+ * adds it to the Incus trust store on every boot. This class generates
+ * the client certificate, saves the server certificate, and writes the
+ * local Incus client config.
  */
 public final class IncusRemoteSetup {
 
@@ -35,7 +34,6 @@ public final class IncusRemoteSetup {
 
     private static final String REMOTE_NAME = "isx-vm";
     private static final int INCUS_PORT = 8443;
-    private static final Pattern TRUST_TOKEN_PATTERN = Pattern.compile("ISX_TRUST_TOKEN=(.+)");
 
     public static boolean isConfigured() {
         if (!Files.exists(Environment.incusConfigFile())) return false;
@@ -50,9 +48,22 @@ public final class IncusRemoteSetup {
     }
 
     /**
+     * Ensure the client certificate exists, generating it if needed.
+     * Call this before starting the VM so the cert is available via
+     * virtio-fs when the VM boots.
+     */
+    public static void ensureCertExists() throws IOException {
+        Files.createDirectories(Environment.incusConfigDir());
+        if (!Files.exists(Environment.incusClientCert())) {
+            generateClientCertificate();
+        }
+    }
+
+    /**
      * Configure the Incus remote for the VM at the given IP.
-     * The VM must already be running with HTTPS enabled on port 8443
-     * and a trust token printed to the VM log.
+     * The VM must already be running with HTTPS enabled on port 8443.
+     * The VM trusts our client cert via virtio-fs, so no trust token
+     * exchange is needed.
      */
     public static void configure(String vmIp) throws IOException {
         System.err.println("Configuring Incus remote for VM at " + vmIp + "...");
@@ -60,36 +71,19 @@ public final class IncusRemoteSetup {
         Files.createDirectories(Environment.incusConfigDir());
         Files.createDirectories(Environment.incusServerCertsDir());
 
-        // Step 1: Generate client certificate if not present
-        if (!Files.exists(Environment.incusClientCert())) {
-            generateClientCertificate();
-        }
+        ensureCertExists();
 
-        // Step 2: Wait for the Incus HTTPS API to be reachable
         System.err.println("  Waiting for Incus HTTPS API on " + vmIp + ":" + INCUS_PORT + "...");
         if (!waitForPort(vmIp, INCUS_PORT, 60)) {
             throw new IOException("Incus HTTPS API not reachable at " + vmIp + ":" + INCUS_PORT
                     + " after 60s. Check 'isx vm console' for boot logs.");
         }
 
-        // Step 3: Read trust token from VM log
-        var trustToken = readTrustToken();
-        if (trustToken == null) {
-            throw new IOException("No trust token found in VM log (" + Environment.vmLogFile() + ").\n"
-                    + "The VM appliance may need to be rebuilt with the latest incus-spawn-vm-init.");
-        }
-        System.err.println("  Trust token found.");
-
-        // Step 4: Add our client certificate using the trust token
-        var baseUrl = "https://" + vmIp + ":" + INCUS_PORT;
-        addClientTrust(baseUrl, trustToken);
-
-        // Step 5: Save the server certificate for future TLS verification
         saveServerCert(vmIp);
 
-        // Step 6: Write the client config
         writeClientConfig(vmIp);
 
+        var baseUrl = "https://" + vmIp + ":" + INCUS_PORT;
         System.err.println("  Incus remote '" + REMOTE_NAME + "' configured at " + baseUrl);
     }
 
@@ -100,7 +94,7 @@ public final class IncusRemoteSetup {
 
     // --- Certificate generation ---
 
-    private static void generateClientCertificate() throws IOException {
+    static void generateClientCertificate() throws IOException {
         System.err.println("  Generating Incus client certificate...");
         try {
             generateCertWithOpenssl();
@@ -187,47 +181,7 @@ public final class IncusRemoteSetup {
         }
     }
 
-    // --- Trust token ---
-
-    static String readTrustToken() {
-        var logFile = Environment.vmLogFile();
-        if (!Files.exists(logFile)) return null;
-        try {
-            var content = Files.readString(logFile);
-            var matcher = TRUST_TOKEN_PATTERN.matcher(content);
-            if (matcher.find()) {
-                return matcher.group(1).strip();
-            }
-        } catch (IOException ignored) {}
-        return null;
-    }
-
-    // --- Incus API ---
-
-    private static void addClientTrust(String baseUrl, String trustToken) throws IOException {
-        var body = "{\"type\":\"client\",\"name\":\"incus-spawn\""
-                + ",\"trust_token\":\"" + trustToken + "\"}";
-
-        var client = buildClientCertHttpClient();
-        var request = HttpRequest.newBuilder()
-                .uri(URI.create(baseUrl + "/1.0/certificates"))
-                .POST(HttpRequest.BodyPublishers.ofString(body))
-                .header("Content-Type", "application/json")
-                .timeout(Duration.ofSeconds(10))
-                .build();
-        try {
-            var response = client.send(request, HttpResponse.BodyHandlers.ofString());
-            if (response.statusCode() >= 400
-                    && !response.body().contains("already exists")
-                    && !response.body().contains("already trusted")) {
-                throw new IOException("Failed to add client certificate: HTTP "
-                        + response.statusCode() + " — " + response.body());
-            }
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new IOException("Interrupted", e);
-        }
-    }
+    // --- Server cert & config ---
 
     private static void saveServerCert(String vmIp) {
         try {
@@ -323,62 +277,6 @@ public final class IncusRemoteSetup {
             throw new IOException("Interrupted running " + command[0]);
         }
         return output;
-    }
-
-    private static HttpClient buildClientCertHttpClient() {
-        try {
-            var certPath = Environment.incusClientCert();
-            var keyPath = Environment.incusClientKey();
-
-            var certFactory = java.security.cert.CertificateFactory.getInstance("X.509");
-            java.security.cert.Certificate clientCert;
-            try (var is = Files.newInputStream(certPath)) {
-                clientCert = certFactory.generateCertificate(is);
-            }
-
-            var keyPem = Files.readString(keyPath);
-            var keyB64 = keyPem
-                    .replaceAll("-----BEGIN[^-]+-----", "")
-                    .replaceAll("-----END[^-]+-----", "")
-                    .replaceAll("\\s+", "");
-            var keyBytes = Base64.getDecoder().decode(keyB64);
-            var keySpec = new java.security.spec.PKCS8EncodedKeySpec(keyBytes);
-            java.security.PrivateKey privateKey;
-            try {
-                privateKey = java.security.KeyFactory.getInstance("EC").generatePrivate(keySpec);
-            } catch (Exception e) {
-                privateKey = java.security.KeyFactory.getInstance("RSA").generatePrivate(keySpec);
-            }
-
-            var ks = java.security.KeyStore.getInstance("PKCS12");
-            ks.load(null, null);
-            ks.setKeyEntry("incus-client", privateKey, new char[0],
-                    new java.security.cert.Certificate[]{clientCert});
-            var kmf = javax.net.ssl.KeyManagerFactory.getInstance(
-                    javax.net.ssl.KeyManagerFactory.getDefaultAlgorithm());
-            kmf.init(ks, new char[0]);
-
-            var sslContext = SSLContext.getInstance("TLS");
-            sslContext.init(kmf.getKeyManagers(), new TrustManager[]{new PermissiveTrustManager()}, null);
-
-            return HttpClient.newBuilder()
-                    .sslContext(sslContext)
-                    .connectTimeout(Duration.ofSeconds(10))
-                    .version(HttpClient.Version.HTTP_1_1)
-                    .build();
-        } catch (Exception e) {
-            throw new VmException("Failed to create HTTP client with client certificate: " + e.getMessage());
-        }
-    }
-
-    private static class PermissiveTrustManager extends X509ExtendedTrustManager {
-        @Override public void checkClientTrusted(X509Certificate[] c, String a) {}
-        @Override public void checkServerTrusted(X509Certificate[] c, String a) {}
-        @Override public void checkClientTrusted(X509Certificate[] c, String a, java.net.Socket s) {}
-        @Override public void checkServerTrusted(X509Certificate[] c, String a, java.net.Socket s) {}
-        @Override public void checkClientTrusted(X509Certificate[] c, String a, javax.net.ssl.SSLEngine e) {}
-        @Override public void checkServerTrusted(X509Certificate[] c, String a, javax.net.ssl.SSLEngine e) {}
-        @Override public X509Certificate[] getAcceptedIssuers() { return new X509Certificate[0]; }
     }
 
     private static class CertCapturingTrustManager extends X509ExtendedTrustManager {

--- a/src/main/java/dev/incusspawn/vm/VmManager.java
+++ b/src/main/java/dev/incusspawn/vm/VmManager.java
@@ -170,6 +170,12 @@ public final class VmManager {
             return false;
         }
 
+        try {
+            IncusRemoteSetup.ensureCertExists();
+        } catch (java.io.IOException e) {
+            System.err.println("Warning: could not ensure client certificate: " + e.getMessage());
+        }
+
         var backend = detectBackend();
         int cpus = detectCpus();
         int memoryMiB = detectMemoryMiB();

--- a/src/test/java/dev/incusspawn/vm/IncusRemoteSetupTest.java
+++ b/src/test/java/dev/incusspawn/vm/IncusRemoteSetupTest.java
@@ -1,10 +1,12 @@
 package dev.incusspawn.vm;
 
+import dev.incusspawn.Environment;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import java.nio.file.Files;
 import java.nio.file.Path;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -28,5 +30,29 @@ class IncusRemoteSetupTest {
     @Test
     void isConfiguredReturnsFalseWhenNoConfigExists() {
         assertFalse(IncusRemoteSetup.isConfigured());
+    }
+
+    @Test
+    void ensureCertExistsGeneratesCertAndKey() throws Exception {
+        assertFalse(Files.exists(Environment.incusClientCert()));
+        assertFalse(Files.exists(Environment.incusClientKey()));
+
+        IncusRemoteSetup.ensureCertExists();
+
+        assertTrue(Files.exists(Environment.incusClientCert()));
+        assertTrue(Files.exists(Environment.incusClientKey()));
+        var certContent = Files.readString(Environment.incusClientCert());
+        assertTrue(certContent.contains("BEGIN CERTIFICATE"));
+    }
+
+    @Test
+    void ensureCertExistsIsIdempotent() throws Exception {
+        IncusRemoteSetup.ensureCertExists();
+        var firstCert = Files.readString(Environment.incusClientCert());
+
+        IncusRemoteSetup.ensureCertExists();
+        var secondCert = Files.readString(Environment.incusClientCert());
+
+        assertEquals(firstCert, secondCert);
     }
 }


### PR DESCRIPTION
## Summary

- Replace the one-shot trust token handshake with direct cert import via virtio-fs
- VM init script reads the host's client cert from `/host/.config/incus-spawn/vm/client.crt` on every boot and adds it to the Incus trust store
- Host generates the cert before VM start (`ensureCertExists()`), guaranteeing it's on disk when the VM reads it via virtio-fs
- Remove all trust token machinery from `IncusRemoteSetup` (readTrustToken, addClientTrust, PermissiveTrustManager)

This makes the trust relationship **self-healing**: disk replacement, cert regeneration, or path migration no longer silently break connectivity.

**Breaking**: requires appliance rebuild — old appliances still use the trust token flow which is no longer supported on the host side.

Closes #154

## Test plan

- [x] All 548 unit tests pass
- [ ] Rebuild appliance with updated `incus-spawn-vm-init`
- [ ] End-to-end: `rm -rf ~/.config/incus-spawn/vm/ && isx vm stop && isx vm start && isx list`
- [ ] Verify `vm.log` no longer contains `ISX_TRUST_TOKEN=`
- [ ] Verify `vm.log` contains `incus-spawn-vm-init: host certificate trusted`

🤖 Generated with [Claude Code](https://claude.com/claude-code)