### PR TITLE
Show full system diagnostics in isx vm status on macOS

### DIFF
--- a/src/main/java/dev/incusspawn/command/VmCommand.java
+++ b/src/main/java/dev/incusspawn/command/VmCommand.java
@@ -74,13 +74,21 @@ public class VmCommand extends BaseCommand {
         @Override
         protected CommandResult doExecute() throws Exception {
             if (Environment.isLinux()) {
-                // On Linux, show comprehensive system diagnostics
                 var incus = RuntimeServices.incus();
                 var pool = incus.findCowPool();
                 System.out.println(incus.getSystemDiagnostics(pool));
                 return CommandResult.SUCCESS;
             }
             System.out.println(VmManager.status());
+            var incus = RuntimeServices.incus();
+            var connError = incus.checkConnectivity();
+            if (connError != null) {
+                System.out.println("\nIncus not reachable: " + connError);
+            } else {
+                var pool = incus.findCowPool();
+                System.out.println();
+                System.out.println(incus.getSystemDiagnostics(pool));
+            }
             return CommandResult.SUCCESS;
         }
     }

--- a/src/main/java/dev/incusspawn/incus/IncusApi.java
+++ b/src/main/java/dev/incusspawn/incus/IncusApi.java
@@ -101,14 +101,15 @@ class IncusApi {
                 return "Cannot connect to Incus socket at " + candidate + ": " + e.getMessage();
             }
         }
-        // No socket file found at any candidate path.
+        // No socket file found — check if HTTPS was attempted
+        var httpsTransport = HttpsTransport.fromClientConfig();
+        if (httpsTransport != null) {
+            return "HTTPS remote configured but connection failed.\n\n" +
+                   "The VM may not trust the current client certificate.\n" +
+                   "Re-run 'isx init' to regenerate and trust certificates.";
+        }
         return """
-                Incus socket not found. Checked:
-                  /run/incus/unix.socket
-                  /var/lib/incus/unix.socket
-
-                Ensure Incus is installed and the daemon is running:
-                  sudo systemctl enable --now incus
+                Incus not reachable. No Unix socket found and no HTTPS remote configured.
 
                 First-time setup: run 'isx init'
                 """;

--- a/src/main/java/dev/incusspawn/incus/IncusClient.java
+++ b/src/main/java/dev/incusspawn/incus/IncusClient.java
@@ -382,16 +382,53 @@ public class IncusClient {
                 used * 100 / total);
     }
 
+    /**
+     * Read memory stats from /proc/meminfo via container exec.
+     * Returns [MemTotal, MemAvailable, SwapTotal, SwapFree] in kB, or null on failure.
+     */
+    private long[] getMemoryInfo() {
+        try {
+            var instances = list();
+            var running = instances.stream()
+                    .filter(i -> "Running".equals(i.get("status")))
+                    .map(i -> i.get("name"))
+                    .findFirst().orElse(null);
+            if (running == null) return null;
+            var result = shellExec(running, "sh", "-c",
+                    "awk '/^(MemTotal|MemAvailable|SwapTotal|SwapFree):/ {print $1, $2}' /dev/.lxc/proc/meminfo 2>/dev/null || awk '/^(MemTotal|MemAvailable|SwapTotal|SwapFree):/ {print $1, $2}' /proc/meminfo");
+            if (!result.success()) return null;
+            long memTotal = 0, memAvail = 0, swapTotal = 0, swapFree = 0;
+            for (var line : result.stdout().strip().split("\n")) {
+                var parts = line.split("\\s+");
+                if (parts.length < 2) continue;
+                long kB = Long.parseLong(parts[1]);
+                switch (parts[0]) {
+                    case "MemTotal:" -> memTotal = kB;
+                    case "MemAvailable:" -> memAvail = kB;
+                    case "SwapTotal:" -> swapTotal = kB;
+                    case "SwapFree:" -> swapFree = kB;
+                }
+            }
+            if (memTotal == 0) return null;
+            return new long[]{memTotal, memAvail, swapTotal, swapFree};
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
     public String getServerMemoryUsage() {
-        var resp = http().get("/1.0/resources");
-        if (!resp.isSuccess()) return "";
-        var mem = resp.body().path("metadata").path("memory");
-        long total = mem.path("total").asLong(0);
-        long used = mem.path("used").asLong(0);
-        if (total == 0) return "";
-        return "Server memory: %dMiB used / %dMiB total (%d%% used)".formatted(
-                used / (1024 * 1024), total / (1024 * 1024),
-                used * 100 / total);
+        var info = getMemoryInfo();
+        if (info == null) return "";
+        long memUsed = info[0] - info[1];
+        var sb = new StringBuilder();
+        sb.append("Server memory: %dMiB used / %dMiB total (%d%% used)".formatted(
+                memUsed / 1024, info[0] / 1024, memUsed * 100 / info[0]));
+        if (info[2] > 0) {
+            long swapUsed = info[2] - info[3];
+            sb.append(", swap: %dMiB used / %dMiB total".formatted(
+                    swapUsed / 1024, info[2] / 1024));
+        }
+        return sb.toString();
     }
 
     /**
@@ -515,45 +552,42 @@ public class IncusClient {
     public String getSystemDiagnostics(String poolName) {
         var sb = new StringBuilder();
 
-        // Fetch /1.0/resources once for CPU, memory, and swap
+        // CPU from /1.0/resources (reliable)
         var resourcesResp = http().get("/1.0/resources");
         if (resourcesResp.isSuccess()) {
-            var metadata = resourcesResp.body().path("metadata");
-
-            // CPU
-            var cpu = metadata.path("cpu");
+            var cpu = resourcesResp.body().path("metadata").path("cpu");
             int cpuTotal = cpu.path("total").asInt(0);
             if (cpuTotal > 0) {
                 var arch = cpu.path("architecture").asText("unknown");
-                sb.append("CPU: ").append("%d CPU cores (%s)".formatted(cpuTotal, arch)).append("\n");
-            } else {
-                sb.append("CPU: (no CPU info)\n");
+                sb.append("CPU: ").append("%d cores (%s)".formatted(cpuTotal, arch)).append("\n");
             }
+        }
 
-            // Memory
-            var mem = metadata.path("memory");
-            long memTotal = mem.path("total").asLong(0);
-            long memUsed = mem.path("used").asLong(0);
-            if (memTotal > 0) {
-                sb.append("Memory: %dMiB used / %dMiB total (%d%% used)".formatted(
-                        memUsed / (1024 * 1024), memTotal / (1024 * 1024),
-                        memUsed * 100 / memTotal)).append("\n");
-            }
-
-            // Swap
-            long swapTotal = mem.path("swap_total").asLong(0);
-            long swapUsed = mem.path("swap_used").asLong(0);
-            if (swapTotal == 0) {
-                sb.append("Swap: no swap configured\n");
-            } else {
+        // Memory and swap from /proc/meminfo via container exec (resources API doesn't report swap)
+        var memInfo = getMemoryInfo();
+        if (memInfo != null) {
+            long memUsed = memInfo[0] - memInfo[1];
+            sb.append("Memory: %dMiB used / %dMiB total (%d%% used)".formatted(
+                    memUsed / 1024, memInfo[0] / 1024,
+                    memInfo[0] > 0 ? memUsed * 100 / memInfo[0] : 0)).append("\n");
+            if (memInfo[2] > 0) {
+                long swapUsed = memInfo[2] - memInfo[3];
                 sb.append("Swap: %dMiB used / %dMiB total (%d%% used)".formatted(
-                        swapUsed / (1024 * 1024), swapTotal / (1024 * 1024),
-                        swapUsed * 100 / swapTotal)).append("\n");
+                        swapUsed / 1024, memInfo[2] / 1024,
+                        swapUsed * 100 / memInfo[2])).append("\n");
+            } else {
+                sb.append("Swap: no swap configured\n");
             }
-        } else {
-            sb.append("CPU: (could not query resources)\n");
-            sb.append("Memory: (could not query resources)\n");
-            sb.append("Swap: (could not query resources)\n");
+        } else if (resourcesResp.isSuccess()) {
+            var mem = resourcesResp.body().path("metadata").path("memory");
+            long total = mem.path("total").asLong(0);
+            long used = mem.path("used").asLong(0);
+            if (total > 0) {
+                long totalMiB = total / (1024 * 1024);
+                long usedMiB = used / (1024 * 1024);
+                sb.append("Memory: %dMiB used / %dMiB total (%d%% used)".formatted(
+                        usedMiB, totalMiB, used * 100 / total)).append("\n");
+            }
         }
 
         // Disk


### PR DESCRIPTION
## Summary

- Show CPU, memory, swap, disk, and container info on macOS when Incus is reachable (previously only showed pid/REST/log)
- Read host memory/swap from `/dev/.lxc/proc/meminfo` to bypass lxcfs virtualization (which reports SwapTotal: 0 when the kernel lacks `CONFIG_MEMCG_SWAP`)
- Fall back to `/proc/meminfo` then the resources API when containers aren't running
- Show connectivity errors instead of silently swallowing them
- Improve `diagnoseConnectionFailure()` to detect HTTPS cert issues on macOS

## Test plan

- [x] 546 unit tests pass
- [x] `isx vm status` shows memory and swap correctly with running containers
- [x] `isx vm status` shows memory (without swap) when no containers are running
- [x] Connectivity errors are displayed clearly when Incus is unreachable

🤖 Generated with [Claude Code](https://claude.com/claude-code)