### PR TITLE
macOS fixes: native image paths, Homebrew formula, and README

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,6 +137,7 @@ jobs:
           sed -i \
             -e "s/version \"[^\"]*\"/version \"${VERSION}\"/" \
             -e "0,/sha256 \"[^\"]*\"/{s/sha256 \"[^\"]*\"/sha256 \"${BINARY_SHA}\"/}" \
+            -e "/resource \"git-remote-isx\"/,/end/{s|url \"[^\"]*\"|url \"https://github.com/Sanne/incus-spawn/releases/download/v${VERSION}/git-remote-isx\"|}" \
             -e "/resource \"git-remote-isx\"/,/end/{s/sha256 \"[^\"]*\"/sha256 \"${GIT_REMOTE_SHA}\"/}" \
             Formula/incus-spawn.rb
 

--- a/README.md
+++ b/README.md
@@ -13,19 +13,24 @@ Built with [Quarkus](https://quarkus.io/) and [Tamboui](https://tamboui.dev/).
 
 ## Requirements
 
-- **Linux** -- Incus system containers require a Linux kernel. macOS and Windows are not yet supported but are on the roadmap (likely via a managed Linux VM).
-- **[Incus](https://linuxcontainers.org/incus/)** -- `isx init` auto-installs via the detected package manager (`dnf`, `apt`, `zypper`, or `pacman`); on other distros, install manually before running init
+- **Linux or macOS (Apple Silicon)** -- On Linux, Incus runs natively. On macOS, `isx init` provisions a lightweight Linux VM automatically via [vfkit](https://github.com/crc-org/vfkit). Windows is not yet supported.
+- **[Incus](https://linuxcontainers.org/incus/)** -- On Linux, `isx init` auto-installs via the detected package manager (`dnf`, `apt`, `zypper`, or `pacman`); on other distros, install manually before running init. On macOS, Incus runs inside the managed VM.
 
 ## Quick Start
 
-If on a Linux X64 machine, you can install incus-spawn with the following command:
+On macOS (Apple Silicon):
 
 ```shell
-# Install
+brew install Sanne/tap/incus-spawn
+```
+
+On Linux (x86_64):
+
+```shell
 curl -fsSL https://raw.githubusercontent.com/Sanne/incus-spawn/main/get-isx.sh | sh
 ```
 
-If on any other machine, you can install incus-spawn with the following command:
+On other Linux architectures:
 
 ```shell
 jbang app install isx@Sanne/incus-spawn
@@ -672,6 +677,14 @@ Details that save time and avoid frustration:
 
 ## Installation
 
+### macOS (Homebrew)
+
+```shell
+brew install Sanne/tap/incus-spawn
+```
+
+Requires Apple Silicon. Updates with `brew upgrade incus-spawn`. See [docs/HOMEBREW.md](docs/HOMEBREW.md) for details.
+
 ### Fedora (DNF)
 
 ```shell
@@ -724,12 +737,13 @@ The script derives the version from the POM snapshot (e.g. `0.1.9-SNAPSHOT` → 
 Pushing the tag triggers a workflow that will:
 1. Set the project version from the tag
 2. Build a self-contained uber-jar (for JBang users)
-3. Build a native binary via container-based GraalVM compilation
-4. Create a GitHub Release with auto-generated release notes and both artifacts attached
-5. Publish the native binary as an RPM to [Fedora COPR](https://copr.fedorainfracloud.org/coprs/sanne/incus-spawn/)
-6. Bump the POM version to the next snapshot
+3. Build native binaries via GraalVM (Linux amd64/aarch64, macOS aarch64)
+4. Create a GitHub Release with auto-generated release notes and all artifacts attached
+5. Update the [Homebrew tap](https://github.com/Sanne/homebrew-tap) with new checksums
+6. Publish the native binary as an RPM to [Fedora COPR](https://copr.fedorainfracloud.org/coprs/sanne/incus-spawn/)
+7. Bump the POM version to the next snapshot
 
-Users can then install or update via `dnf upgrade` (Fedora), `curl -fsSL .../get-isx.sh | sh` (native), or `jbang app install isx@Sanne/incus-spawn` (JVM).
+Users can then install or update via `brew upgrade` (macOS), `dnf upgrade` (Fedora), `curl -fsSL .../get-isx.sh | sh` (native), or `jbang app install isx@Sanne/incus-spawn` (JVM).
 
 ## Configuration
 

--- a/src/main/java/dev/incusspawn/Environment.java
+++ b/src/main/java/dev/incusspawn/Environment.java
@@ -132,6 +132,10 @@ public final class Environment {
         return vmStateDir().resolve("empty-initrd");
     }
 
+    public static Path vfkitAppBundle() {
+        return vmStateDir().resolve("incus-spawn-vm.app");
+    }
+
     // --- VM appliance artifact paths ---
 
     public static Path applianceDir() {

--- a/src/main/java/dev/incusspawn/proxy/MitmProxy.java
+++ b/src/main/java/dev/incusspawn/proxy/MitmProxy.java
@@ -344,6 +344,7 @@ public class MitmProxy {
      */
     public void start(Runnable onReady) throws Exception {
         stopLatch = new CountDownLatch(1);
+        System.setProperty("vertx.cacheDirBase", System.getProperty("java.io.tmpdir"));
         vertx = Vertx.vertx();
 
         var ca = CertificateAuthority.loadOrCreate();

--- a/src/main/java/dev/incusspawn/tool/ClaudeSetup.java
+++ b/src/main/java/dev/incusspawn/tool/ClaudeSetup.java
@@ -36,8 +36,6 @@ public class ClaudeSetup implements ToolSetup {
 
     private void installBinary(Container c) {
         System.out.println("Installing Claude Code...");
-        // Ensure ~/.local/bin is on agentuser's PATH before installing, so
-        // claude is immediately available in interactive shells.
         c.sh("mkdir -p /home/agentuser/.local/bin && " +
                 "chown -R agentuser:agentuser /home/agentuser/.local && " +
                 "grep -q '.local/bin' /home/agentuser/.bashrc 2>/dev/null || " +
@@ -56,10 +54,17 @@ public class ClaudeSetup implements ToolSetup {
             var binaryUrl = DOWNLOAD_BASE_URL + "/" + version + "/" + platform + "/claude";
             var cached = downloadCache.download(binaryUrl, sha256);
 
-            var claudeBin = "/home/agentuser/.local/bin/claude";
-            c.filePush(cached.toString(), claudeBin);
-            c.exec("chmod", "+x", claudeBin);
-            c.chown(claudeBin, "agentuser:agentuser");
+            var versionBin = "/home/agentuser/.local/share/claude/versions/" + version;
+            c.sh("mkdir -p /home/agentuser/.local/share/claude/versions"
+                    + " /home/agentuser/.local/state/claude/locks"
+                    + " /home/agentuser/.cache/claude/staging");
+            c.filePush(cached.toString(), versionBin);
+            c.exec("chmod", "+x", versionBin);
+            c.sh("ln -sf " + versionBin + " /home/agentuser/.local/bin/claude");
+            c.sh("chown -R agentuser:agentuser"
+                    + " /home/agentuser/.local/share/claude"
+                    + " /home/agentuser/.local/state/claude"
+                    + " /home/agentuser/.cache/claude");
         } catch (IOException e) {
             throw new RuntimeException("Failed to install Claude Code: " + e.getMessage(), e);
         }
@@ -124,6 +129,9 @@ public class ClaudeSetup implements ToolSetup {
                   "hasSeenTasksHint": true,
                   "numStartups": 1,
                   "autoUpdates": false,
+                  "installMethod": "native",
+                  "officialMarketplaceAutoInstallAttempted": true,
+                  "officialMarketplaceAutoInstalled": true,
                 """);
         if (!SpawnConfig.load().getClaude().isUseVertex()) {
             claudeJsonBuilder.append("""

--- a/src/main/java/dev/incusspawn/vm/VmManager.java
+++ b/src/main/java/dev/incusspawn/vm/VmManager.java
@@ -368,16 +368,14 @@ public final class VmManager {
 
     // --- Internal: vfkit ---
 
-    private static final Path VFKIT_APP_BUNDLE = Environment.vmStateDir().resolve("incus-spawn-vm.app");
-
     /**
      * Create a macOS .app bundle wrapper around the vfkit binary. macOS uses the
      * bundle's Info.plist for permission dialog text (home folder access, local
      * network), giving users meaningful descriptions instead of a generic prompt.
      */
     private static String ensureVfkitAppBundle() throws IOException {
-        var macosDir = VFKIT_APP_BUNDLE.resolve("Contents/MacOS");
-        var plistFile = VFKIT_APP_BUNDLE.resolve("Contents/Info.plist");
+        var macosDir = Environment.vfkitAppBundle().resolve("Contents/MacOS");
+        var plistFile = Environment.vfkitAppBundle().resolve("Contents/Info.plist");
         var linkedBin = macosDir.resolve("vfkit");
 
         var vfkitPath = resolveVfkitPath();


### PR DESCRIPTION
## Summary

- **Fix vfkit app bundle path baked at build time**: `VmManager` had a `static final` field initialized from `Environment.vmStateDir()`, which GraalVM evaluates at build time — baking `/Users/runner` into the native binary. Moved to `Environment` (marked `--initialize-at-run-time`) so it resolves at runtime.
- **Fix Homebrew resource URL**: `#{version}` doesn't interpolate inside a Homebrew `resource` block, so `git-remote-isx` downloads failed with a 404. The release workflow sed command now updates the resource URL with the hardcoded version.
- **Fix Claude Code install warnings and speed up first startup**
- **Add macOS to README**: Updated Requirements (was "not yet supported"), Quick Start, Installation, and Releasing sections.

## Test plan

- [ ] `brew install Sanne/tap/incus-spawn` installs successfully
- [ ] `isx --version` prints correct version
- [ ] `isx init` starts VM without `/Users/runner` error
- [ ] Next release (`./release.sh`) updates the Homebrew tap correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)