### PR TITLE
macOS: use P-cores only for VM CPU allocation

### DIFF
--- a/src/main/java/dev/incusspawn/vm/VmManager.java
+++ b/src/main/java/dev/incusspawn/vm/VmManager.java
@@ -55,8 +55,26 @@ public final class VmManager {
                 System.err.println("Warning: ISX_VM_CPUS=" + env + " is not a number, ignoring");
             }
         }
+        if (Environment.isMacOS()) {
+            int pcores = detectPerformanceCores();
+            if (pcores > 0) return pcores;
+        }
         int available = Runtime.getRuntime().availableProcessors();
         return Math.max(1, available - 2);
+    }
+
+    private static int detectPerformanceCores() {
+        try {
+            var pb = new ProcessBuilder("sysctl", "-n", "hw.perflevel0.logicalcpu");
+            pb.redirectErrorStream(true);
+            var process = pb.start();
+            var output = new String(process.getInputStream().readAllBytes()).strip();
+            if (process.waitFor() == 0 && !output.isBlank()) {
+                return Integer.parseInt(output);
+            }
+        } catch (Exception ignored) {
+        }
+        return 0;
     }
 
     public static int detectMemoryMiB() {


### PR DESCRIPTION
## Summary

- On Apple Silicon Macs, detect the number of performance cores via `sysctl hw.perflevel0.logicalcpu` and use that as the VM CPU count
- E-cores stay free for macOS housekeeping (Spotlight, WindowServer, etc.)
- Example: M1 Pro (6P+4E) → VM gets 6 vCPUs instead of 8 (10-2)
- Falls back to the existing `availableProcessors() - 2` heuristic on Linux or if sysctl fails
- `ISX_VM_CPUS` env override still takes precedence

## Test plan

- [ ] `isx vm status` shows P-core count on Apple Silicon
- [ ] `ISX_VM_CPUS=4` still overrides the detected value
- [ ] Linux builds unaffected (no `sysctl` available, falls back)

🤖 Generated with [Claude Code](https://claude.com/claude-code)