### PR TITLE
Separate VM root and data disks for upgrade-safe containers

### DIFF
--- a/appliance/build.sh
+++ b/appliance/build.sh
@@ -19,6 +19,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 TARGET_DIR="$(mkdir -p "${1:-$SCRIPT_DIR/build}" && cd "${1:-$SCRIPT_DIR/build}" && pwd)"
 CONTAINER_IMAGE="docker.io/alpine:3.23"
+ISX_ARCH="${ISX_ARCH:-$(uname -m)}"
+ISX_VERSION="${ISX_VERSION:-$(cd "$SCRIPT_DIR/.." && ./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout 2>/dev/null || echo dev)}"
 
 echo "Building incus-spawn appliance..."
 echo "  Target: $TARGET_DIR"
@@ -34,9 +36,9 @@ cleanup() {
 }
 trap cleanup EXIT
 
-echo "==> Extracting container rootfs..."
-podman pull "$CONTAINER_IMAGE"
-CONTAINER_ID=$(podman create "$CONTAINER_IMAGE")
+echo "==> Extracting container rootfs (arch=$ISX_ARCH)..."
+podman pull --arch "$ISX_ARCH" "$CONTAINER_IMAGE"
+CONTAINER_ID=$(podman create --arch "$ISX_ARCH" "$CONTAINER_IMAGE")
 podman export "$CONTAINER_ID" | tar -xC "$ROOTFS_DIR"
 podman rm "$CONTAINER_ID"
 echo "    Base size: $(du -sh "$ROOTFS_DIR" | cut -f1)"
@@ -87,6 +89,9 @@ if [ -f "$SCRIPT_DIR/config.sh" ]; then
     chroot "$ROOTFS_DIR" /config.sh
     rm "$ROOTFS_DIR/config.sh"
 fi
+
+echo "==> Embedding version: $ISX_VERSION"
+echo "$ISX_VERSION" > "$ROOTFS_DIR/etc/isx-version"
 
 echo "==> Final cleanup..."
 rm -rf "$ROOTFS_DIR/usr/share/man" "$ROOTFS_DIR/usr/share/doc" "$ROOTFS_DIR/usr/share/info"

--- a/appliance/config.sh
+++ b/appliance/config.sh
@@ -36,7 +36,8 @@ rm -rf /etc/apk /var/cache/apk 2>/dev/null || true
 
 #-- Fstab: remount root with noatime --#
 cat > /etc/fstab << 'EOF'
-/dev/vda / btrfs noatime,commit=300 0 0
+/dev/vda / btrfs noatime,commit=300,compress=zstd:1 0 0
+/dev/vdc /var/lib/incus btrfs noatime,commit=300,compress=zstd:1 0 0
 EOF
 
 #-- Set default locale and hostname --#

--- a/appliance/root/etc/init.d/rcS
+++ b/appliance/root/etc/init.d/rcS
@@ -18,8 +18,8 @@ mount -t cgroup2 cgroup2 /sys/fs/cgroup
 ts() { cut -d' ' -f1 /proc/uptime; }
 echo "incus-spawn: starting... ($(ts)s)"
 
-#-- Remount root with fstab options (noatime) --#
-mount -o remount,noatime,commit=300 /
+#-- Remount root with fstab options (noatime, compression) --#
+mount -o remount,noatime,commit=300,compress=zstd:1 /
 
 #-- Expand btrfs to fill disk (disk may have been extended after image creation) --#
 btrfs filesystem resize max / 2>/dev/null || true
@@ -40,6 +40,17 @@ if [ -b /dev/vdb ]; then
         mkswap /dev/vdb >/dev/null
     fi
     swapon /dev/vdb
+fi
+
+#-- Data disk: persistent Incus state (survives root disk upgrades) --#
+if [ -b /dev/vdc ]; then
+    if ! blkid /dev/vdc | grep -q btrfs; then
+        echo "incus-spawn: formatting data disk..."
+        mkfs.btrfs -q -L isxdata /dev/vdc
+    fi
+    mkdir -p /var/lib/incus
+    mount -o noatime,commit=300,compress=zstd:1 /dev/vdc /var/lib/incus
+    echo "incus-spawn: data disk mounted ($(ts)s)"
 fi
 
 #-- Disable IPv6 (QEMU user-mode NAT is IPv4-only) --#

--- a/appliance/root/usr/local/sbin/incus-spawn-vm-init
+++ b/appliance/root/usr/local/sbin/incus-spawn-vm-init
@@ -57,16 +57,10 @@ else
     echo "incus-spawn-vm-init: bridge already configured at ${BRIDGE_IP}"
 fi
 
-# Ensure btrfs CoW storage pool exists
+# Ensure btrfs CoW storage pool exists.
+# Uses the data disk mounted at /var/lib/incus (btrfs subvolumes, no loop file).
 if ! incus storage show cow > /dev/null 2>&1; then
-    LOOP_FILE="/var/lib/incus/disks/cow.img"
-    mkdir -p "$(dirname "$LOOP_FILE")"
-    DISK_FREE=$(df / | tail -1 | awk '{print $4}')
-    POOL_SIZE=$(( DISK_FREE / 1024 / 2 ))
-    [ "$POOL_SIZE" -gt 30720 ] && POOL_SIZE=30720
-    [ "$POOL_SIZE" -lt 1024 ] && POOL_SIZE=1024
-    truncate -s "${POOL_SIZE}M" "$LOOP_FILE"
-    incus storage create cow btrfs source="$LOOP_FILE" size="${POOL_SIZE}MiB"
+    incus storage create cow btrfs source=/var/lib/incus/storage-pools/cow
 fi
 
 # Ensure default profile has root disk and NIC

--- a/src/main/java/dev/incusspawn/Environment.java
+++ b/src/main/java/dev/incusspawn/Environment.java
@@ -124,6 +124,14 @@ public final class Environment {
         return vmStateDir().resolve("disk.img");
     }
 
+    public static Path vmDataImage() {
+        return vmStateDir().resolve("data.img");
+    }
+
+    public static Path vmDiskVersion() {
+        return vmStateDir().resolve("disk.version");
+    }
+
     public static Path vmSwapImage() {
         return vmStateDir().resolve("swap.img");
     }

--- a/src/main/java/dev/incusspawn/vm/VmManager.java
+++ b/src/main/java/dev/incusspawn/vm/VmManager.java
@@ -108,6 +108,10 @@ public final class VmManager {
         return DEFAULT_DISK_SIZE;
     }
 
+    static String rootDiskSize() {
+        return "4G";
+    }
+
     public static String swapSize() {
         var env = System.getenv("ISX_VM_SWAP");
         if (env != null && !env.isBlank()) {
@@ -182,6 +186,7 @@ public final class VmManager {
         try {
             checkArtifacts();
             ensureDisk();
+            ensureDataDisk();
             ensureSwap();
         } catch (VmException e) {
             System.err.println("Error: " + e.getMessage());
@@ -471,6 +476,7 @@ public final class VmManager {
                 "--kernel-cmdline", kernelCmdline("hvc0"),
                 "--device", "virtio-blk,path=" + Environment.vmDiskImage(),
                 "--device", "virtio-blk,path=" + Environment.vmSwapImage(),
+                "--device", "virtio-blk,path=" + Environment.vmDataImage(),
                 "--device", "virtio-net,nat,mac=" + VmNetwork.ISX_VM_MAC,
                 "--device", "virtio-serial,logFilePath=" + Environment.vmLogFile(),
                 "--device", "virtio-fs,sharedDir=" + System.getProperty("user.home") + ",mountTag=hostfs",
@@ -529,6 +535,7 @@ public final class VmManager {
                 "-kernel", Environment.applianceKernel().toString(),
                 "-drive", "id=root,file=" + Environment.vmDiskImage() + ",format=raw,if=virtio",
                 "-drive", "id=swap,file=" + Environment.vmSwapImage() + ",format=raw,if=virtio",
+                "-drive", "id=data,file=" + Environment.vmDataImage() + ",format=raw,if=virtio",
                 "-netdev", "user,id=net0",
                 "-device", "virtio-net-pci,netdev=net0",
                 "-append", kernelCmdline(console)
@@ -551,14 +558,45 @@ public final class VmManager {
             throw new VmException(Environment.applianceKernel() + " not found.\n"
                     + "Run 'isx init' to download appliance artifacts, or set ISX_APPLIANCE_DIR.");
         }
-        if (!Files.exists(Environment.vmDiskImage()) && !Files.exists(Environment.applianceDiskImage())) {
-            throw new VmException("No disk image found.\n"
-                    + "Run 'isx init' to download appliance artifacts, or set ISX_APPLIANCE_DIR.");
+        boolean hasDiskVersion = Files.exists(Environment.vmDiskVersion());
+        boolean needsReExtract = hasDiskVersion && !BuildInfo.instance().version()
+                .equals(readVersionFile());
+        if (needsReExtract || (!Files.exists(Environment.vmDiskImage())
+                && !Files.exists(Environment.applianceDiskImage()))) {
+            if (!Files.exists(Environment.applianceDiskImage())) {
+                throw new VmException("No disk image found.\n"
+                        + "Run 'isx init' to download appliance artifacts, or set ISX_APPLIANCE_DIR.");
+            }
+        }
+    }
+
+    private static String readVersionFile() {
+        try {
+            return Files.readString(Environment.vmDiskVersion()).strip();
+        } catch (IOException e) {
+            return "";
         }
     }
 
     static void ensureDisk() {
-        if (Files.exists(Environment.vmDiskImage())) return;
+        var currentVersion = BuildInfo.instance().version();
+        var versionFile = Environment.vmDiskVersion();
+
+        if (Files.exists(Environment.vmDiskImage())) {
+            try {
+                if (Files.exists(versionFile)) {
+                    var diskVersion = Files.readString(versionFile).strip();
+                    if (diskVersion.equals(currentVersion)) return;
+                    System.out.println("Appliance version changed (" + diskVersion + " -> "
+                            + currentVersion + "), replacing root disk...");
+                    Files.delete(Environment.vmDiskImage());
+                } else {
+                    return;
+                }
+            } catch (IOException e) {
+                return;
+            }
+        }
 
         var compressed = Environment.applianceDiskImage();
         if (!Files.exists(compressed)) {
@@ -566,7 +604,7 @@ public final class VmManager {
                     + "\nRun 'isx init' to download appliance artifacts.");
         }
 
-        System.out.println("Extracting disk image (first run)...");
+        System.out.println("Extracting root disk image...");
         var tmp = Environment.vmDiskImage().resolveSibling("disk.img.tmp");
         try {
             Files.createDirectories(Environment.vmStateDir());
@@ -575,14 +613,30 @@ public final class VmManager {
                 gzIn.transferTo(out);
             }
             try (var raf = new RandomAccessFile(tmp.toFile(), "rw")) {
-                raf.setLength(parseDiskSize(diskSize()));
+                raf.setLength(parseDiskSize(rootDiskSize()));
             }
             Files.move(tmp, Environment.vmDiskImage(), StandardCopyOption.ATOMIC_MOVE);
-            System.out.println("Disk image ready: " + humanSize(Files.size(Environment.vmDiskImage()))
-                    + " (" + diskSize() + " virtual)");
+            Files.writeString(versionFile, currentVersion);
+            System.out.println("Root disk ready: " + humanSize(Files.size(Environment.vmDiskImage()))
+                    + " (" + rootDiskSize() + " virtual)");
         } catch (IOException e) {
             try { Files.deleteIfExists(tmp); } catch (IOException ignored) {}
             throw new VmException("Failed to extract disk image: " + e.getMessage());
+        }
+    }
+
+    static void ensureDataDisk() {
+        var dataImage = Environment.vmDataImage();
+        if (Files.exists(dataImage)) return;
+
+        System.out.println("Creating data disk (" + diskSize() + " sparse)...");
+        try {
+            Files.createDirectories(Environment.vmStateDir());
+            try (var raf = new RandomAccessFile(dataImage.toFile(), "rw")) {
+                raf.setLength(parseDiskSize(diskSize()));
+            }
+        } catch (IOException e) {
+            throw new VmException("Failed to create data disk: " + e.getMessage());
         }
     }
 


### PR DESCRIPTION
## Summary

- Splits the single VM disk into a disposable root disk (4G) and a persistent data disk (60G)
- Root disk is version-tracked and re-extracted on appliance upgrade — containers survive
- Storage pool uses btrfs subvolumes directly on the data disk (no loop file indirection)
- Both disks use `compress=zstd:1` for transparent compression
- Appliance build supports cross-arch builds via `ISX_ARCH` env var

## Test plan

- [x] Three disk images created (root 4G, swap 12G, data 60G sparse)
- [x] VM boots, data disk formatted and mounted at `/var/lib/incus`
- [x] Storage pool created directly on data disk btrfs
- [x] Full boot completes: `=== ISX READY ===` in ~25s
- [ ] `isx build tpl-minimal && isx branch test tpl-minimal` — containers work
- [ ] Simulate upgrade: bump version, rebuild, restart — root re-extracted, containers survive

🤖 Generated with [Claude Code](https://claude.com/claude-code)