### PR TITLE
Support building and running templates as VMs

### DIFF
--- a/src/main/java/dev/incusspawn/command/BuildCommand.java
+++ b/src/main/java/dev/incusspawn/command/BuildCommand.java
@@ -76,8 +76,11 @@ public class BuildCommand extends BaseCommand {
     @Option(name = "missing", hasValue = false, description = "Build only templates that don't exist yet")
     boolean missing;
 
-    @Option(name = "vm", hasValue = false, description = "Build as a VM instead of a container")
+    @Option(name = "vm", hasValue = false, description = "Build as a VM instead of a container (overrides image definition)")
     boolean vm;
+
+    @Option(name = "no-vm", hasValue = false, description = "Build as a container even if the image definition specifies vm: true")
+    boolean noVm;
 
     @Option(name = "yes", hasValue = false, description = "Skip interactive confirmations (for TUI integration)")
     boolean yes;
@@ -483,7 +486,9 @@ public class BuildCommand extends BaseCommand {
         activeBuild = new String[]{tempName, canonicalName};
 
         try {
-            if (imageDef.isRoot()) {
+            boolean typeChange = !imageDef.isRoot()
+                    && effectiveVm(imageDef) != incus.isVm(imageDef.getParent());
+            if (imageDef.isRoot() || typeChange) {
                 buildFromScratch(imageDef, defs, tempName);
             } else {
                 buildFromParent(imageDef, defs, tempName, imageDef.getParent());
@@ -670,14 +675,21 @@ public class BuildCommand extends BaseCommand {
      * This is the full setup path: DNS, user, packages, tools.
      * @param buildName the Incus container name to create (may be a temp name)
      */
+    private boolean effectiveVm(ImageDef imageDef) {
+        return vm ? true : noVm ? false : imageDef.isVm();
+    }
+
     private void buildFromScratch(ImageDef imageDef, Map<String, ImageDef> defs, String buildName) {
         var canonicalName = imageDef.getName();
-        var image = imageDef.getImage();
+        var ancestors = ImageDef.ancestors(imageDef, defs);
+        var rootDef = ancestors.isEmpty() ? imageDef : ancestors.get(ancestors.size() - 1);
+        var image = rootDef.getImage();
+        var effectiveVm = effectiveVm(imageDef);
 
         // Launch base image
-        System.out.println("Launching " + image + "...");
+        System.out.println("Launching " + image + (effectiveVm ? " (VM)..." : "..."));
         try {
-            incus.launch(image, buildName, vm);
+            incus.launch(image, buildName, effectiveVm);
         } catch (IncusException e) {
             if (incus.exists(buildName)) {
                 var log = incus.getLog(buildName);
@@ -708,18 +720,17 @@ public class BuildCommand extends BaseCommand {
         container.exec("update-ca-trust")
                 .assertSuccess("Failed to update CA trust");
 
-        // UID mapping for Wayland passthrough, nested containers, and no dropped
-        // capabilities since the container itself is the security boundary.
-        // mknod intercept is NOT enabled: the seccomp_notify handler causes
-        // per-container lock contention during startup, adding 5+ seconds to
-        // every exec call while systemd-tmpfiles processes device nodes.
-        // Podman uses fuse-overlayfs instead of native mknod-based whiteouts.
-        incus.configSet(buildName, "raw.idmap", "both 1000 1000");
-        incus.configSet(buildName, "security.nesting", "true");
-        if (Environment.isLinux()) {
-            incus.configSet(buildName, "security.syscalls.intercept.setxattr", "true");
+        // Container-only security tweaks: UID mapping, nesting, capability
+        // retention, and setxattr interception. VMs run a full kernel and
+        // don't need any of these.
+        if (!effectiveVm) {
+            incus.configSet(buildName, "raw.idmap", "both 1000 1000");
+            incus.configSet(buildName, "security.nesting", "true");
+            if (Environment.isLinux()) {
+                incus.configSet(buildName, "security.syscalls.intercept.setxattr", "true");
+            }
+            incus.configSet(buildName, "raw.lxc", "lxc.cap.drop =");
         }
-        incus.configSet(buildName, "raw.lxc", "lxc.cap.drop =");
         incus.restart(buildName);
         incus.waitForSystemd(buildName);
 
@@ -738,8 +749,6 @@ public class BuildCommand extends BaseCommand {
 
         mountDnfCache(buildName);
 
-        removePackages(container, imageDef);
-
         System.out.println("Updating system packages...");
         container.runInteractive("Failed to update system packages",
                 "dnf", "-y", "--setopt=keepcache=true", "upgrade", "--refresh");
@@ -753,8 +762,6 @@ public class BuildCommand extends BaseCommand {
                 "systemctl mask systemd-resolved 2>/dev/null; " +
                 "sed -i 's/resolve \\[!UNAVAIL=return\\] //' /etc/nsswitch.conf")
                 .assertSuccess("Failed to finalize DNS configuration");
-
-        maskServices(container, imageDef);
 
         System.out.println("Creating agentuser...");
         container.exec("useradd", "-m", "-u", "1000", "-G", "systemd-journal", "agentuser")
@@ -789,20 +796,37 @@ public class BuildCommand extends BaseCommand {
             HostResourceSetup.applyForBuild(incus, container, hostResources);
         }
 
-        var tools = resolveTools(imageDef);
-        enablePackageRepos(container, imageDef, tools, List.of(), defs);
-        installAllPackages(container, imageDef, tools, List.of(), defs);
-        runToolSetup(container, tools);
-        installSkills(container, imageDef, defs);
-        cloneRepos(container, imageDef);
-        updateClaudeJsonTrust(container, imageDef);
+        // Build the full ancestor chain (root first) so that each layer's
+        // packages, tools, repos, and skills are applied in order. For root
+        // images this list contains only imageDef itself.
+        var chain = new ArrayList<ImageDef>();
+        for (int i = ancestors.size() - 1; i >= 0; i--) {
+            chain.add(ancestors.get(i));
+        }
+        chain.add(imageDef);
+
+        for (var layer : chain) {
+            if (chain.size() > 1) {
+                System.out.println("\nApplying layer: " + layer.getName());
+            }
+            removePackages(container, layer);
+            var toolResolution = collectEffectiveTools(layer, defs);
+            enablePackageRepos(container, layer, toolResolution.effective(), toolResolution.ancestors(), defs);
+            installAllPackages(container, layer, toolResolution.effective(), toolResolution.ancestors(), defs);
+            runToolSetup(container, toolResolution.effective());
+            maskServices(container, layer);
+            installSkills(container, layer, defs);
+            cloneRepos(container, layer);
+            updateClaudeJsonTrust(container, layer);
+        }
 
         HostResourceSetup.removeBuildDevices(incus, buildName, hostResources);
         unmountDnfCache(buildName);
 
         cleanCaches(buildName);
 
-        tagTemplateMetadata(buildName, canonicalName, imageDef, null, hostResources, defs);
+        var parentCanonical = imageDef.isRoot() ? null : imageDef.getParent();
+        tagTemplateMetadata(buildName, canonicalName, imageDef, parentCanonical, hostResources, defs);
 
         System.out.println("Stopping image...");
         incus.stop(buildName);

--- a/src/main/java/dev/incusspawn/command/BuildCommand.java
+++ b/src/main/java/dev/incusspawn/command/BuildCommand.java
@@ -618,6 +618,7 @@ public class BuildCommand extends BaseCommand {
                                   String buildName, String parentSource) {
         var canonicalName = imageDef.getName();
         var parentCanonical = imageDef.getParent();
+        var effectiveVm = effectiveVm(imageDef);
 
         System.out.println("Deriving from parent image '" + parentCanonical + "'...");
         incus.copy(parentSource, buildName);
@@ -634,7 +635,7 @@ public class BuildCommand extends BaseCommand {
 
         waitForNetwork(buildName);
 
-        mountDnfCache(buildName);
+        mountDnfCache(buildName, effectiveVm);
         var container = new Container(incus, buildName);
 
         container.sh("sed -i \"s/^export ISX_TEMPLATE=.*/export ISX_TEMPLATE='" + canonicalName + "'/\" /home/agentuser/.bashrc")
@@ -643,7 +644,7 @@ public class BuildCommand extends BaseCommand {
         var hostResources = HostResourceSetup.collectEffective(imageDef, defs);
         if (!hostResources.isEmpty()) {
             System.out.println("Applying host-resources...");
-            HostResourceSetup.applyForBuild(incus, container, hostResources);
+            HostResourceSetup.applyForBuild(incus, container, hostResources, effectiveVm);
         }
 
         removePackages(container, imageDef);
@@ -654,7 +655,7 @@ public class BuildCommand extends BaseCommand {
         runToolSetup(container, toolResolution.effective());
         maskServices(container, imageDef);
         installSkills(container, imageDef, defs);
-        cloneRepos(container, imageDef);
+        cloneRepos(container, imageDef, effectiveVm);
         updateClaudeJsonTrust(container, imageDef);
 
         HostResourceSetup.removeBuildDevices(incus, buildName, hostResources);
@@ -747,7 +748,7 @@ public class BuildCommand extends BaseCommand {
 
         waitForNetwork(buildName);
 
-        mountDnfCache(buildName);
+        mountDnfCache(buildName, effectiveVm);
 
         System.out.println("Updating system packages...");
         container.runInteractive("Failed to update system packages",
@@ -793,7 +794,7 @@ public class BuildCommand extends BaseCommand {
         var hostResources = HostResourceSetup.collectEffective(imageDef, defs);
         if (!hostResources.isEmpty()) {
             System.out.println("Applying host-resources...");
-            HostResourceSetup.applyForBuild(incus, container, hostResources);
+            HostResourceSetup.applyForBuild(incus, container, hostResources, effectiveVm);
         }
 
         // Build the full ancestor chain (root first) so that each layer's
@@ -816,7 +817,7 @@ public class BuildCommand extends BaseCommand {
             runToolSetup(container, toolResolution.effective());
             maskServices(container, layer);
             installSkills(container, layer, defs);
-            cloneRepos(container, layer);
+            cloneRepos(container, layer, effectiveVm);
             updateClaudeJsonTrust(container, layer);
         }
 
@@ -1266,8 +1267,9 @@ public class BuildCommand extends BaseCommand {
      * metadata and downloaded packages across builds, avoiding redundant
      * downloads when building a parent→child image chain.
      */
-    private void mountDnfCache(String container) {
+    private void mountDnfCache(String container, boolean isVm) {
         if (!Environment.isLinux()) return;
+        if (isVm) return;
         try {
             Files.createDirectories(dnfCacheDir());
         } catch (IOException e) {
@@ -1526,7 +1528,7 @@ public class BuildCommand extends BaseCommand {
      * alternates removal makes the clone self-contained while the reference device
      * is still mounted.
      */
-    void cloneRepos(Container container, ImageDef imageDef) {
+    void cloneRepos(Container container, ImageDef imageDef, boolean isVm) {
         var config = SpawnConfig.load();
 
         for (var repo : imageDef.getRepos()) {
@@ -1536,7 +1538,7 @@ public class BuildCommand extends BaseCommand {
             RepoReference ref = null;
 
             try {
-                ref = tryMountReference(container, repo.getUrl(), config);
+                ref = tryMountReference(container, repo.getUrl(), config, isVm);
                 if (ref != null) {
                     System.out.println("  \033[1;32mUsing local host reference to speed up clone...\033[0m");
                     try {
@@ -1608,7 +1610,7 @@ public class BuildCommand extends BaseCommand {
         return cmd.toString();
     }
 
-    RepoReference tryMountReference(Container container, String cloneUrl, SpawnConfig config) {
+    RepoReference tryMountReference(Container container, String cloneUrl, SpawnConfig config, boolean isVm) {
         try {
             var repoName = GitRemoteUtils.repoNameFromUrl(cloneUrl);
             if (repoName.isEmpty()) return null;
@@ -1636,7 +1638,7 @@ public class BuildCommand extends BaseCommand {
                     "source=" + HostResourceSetup.translateForVm(hostPath.toString()),
                     "path=" + containerPath,
                     "readonly=true"));
-            HostResourceSetup.addShiftIfSupported(refArgs);
+            HostResourceSetup.addShiftIfSupported(refArgs, isVm);
             incus.deviceAdd(container.name(), deviceName, "disk", refArgs.toArray(String[]::new));
 
             return new RepoReference(deviceName, containerPath);

--- a/src/main/java/dev/incusspawn/config/HostResourceSetup.java
+++ b/src/main/java/dev/incusspawn/config/HostResourceSetup.java
@@ -34,6 +34,7 @@ public final class HostResourceSetup {
         if (resolved.startsWith("http://") || resolved.startsWith("https://")) {
             throw new IllegalArgumentException("'path' is required for URL sources: " + source);
         }
+        if (!resolved.startsWith("/")) return "/home/agentuser/" + resolved;
         return resolved;
     }
 

--- a/src/main/java/dev/incusspawn/config/HostResourceSetup.java
+++ b/src/main/java/dev/incusspawn/config/HostResourceSetup.java
@@ -43,8 +43,8 @@ public final class HostResourceSetup {
         return source;
     }
 
-    public static void addShiftIfSupported(java.util.List<String> args) {
-        if (!Environment.isMacOS()) args.add("shift=true");
+    public static void addShiftIfSupported(java.util.List<String> args, boolean isVm) {
+        if (!isVm && !Environment.isMacOS()) args.add("shift=true");
     }
 
     public static String translateForVm(String hostPath) {
@@ -108,12 +108,13 @@ public final class HostResourceSetup {
         return new ArrayList<>(result.values());
     }
 
-    public static void applyForBuild(IncusClient incus, Container container, List<ImageDef.HostResource> resources) {
+    public static void applyForBuild(IncusClient incus, Container container, List<ImageDef.HostResource> resources,
+                                      boolean isVm) {
         var overlayEntries = new ArrayList<ImageDef.HostResource>();
         for (var hr : resources) {
-            switch (hr.getMode()) {
+            switch (effectiveMode(hr, isVm)) {
                 case "copy" -> applyCopy(container, hr);
-                case "readonly" -> applyReadonly(incus, container.name(), hr);
+                case "readonly" -> applyReadonly(incus, container.name(), hr, isVm);
                 case "overlay" -> {
                     if (Environment.isMacOS()) {
                         throw new IllegalStateException(
@@ -122,7 +123,7 @@ public final class HostResourceSetup {
                                 + "  or remove the host-resource entry to skip it entirely.\n"
                                 + "  Tracking: https://github.com/Sanne/incus-spawn/issues/157");
                     }
-                    applyOverlay(incus, container, hr);
+                    applyOverlay(incus, container, hr, isVm);
                     overlayEntries.add(hr);
                 }
                 default -> System.err.println("Warning: unknown host-resource mode '" + hr.getMode()
@@ -151,12 +152,13 @@ public final class HostResourceSetup {
         }
     }
 
-    public static void applyForInstance(IncusClient incus, String container, List<ImageDef.HostResource> resources) {
+    public static void applyForInstance(IncusClient incus, String container, List<ImageDef.HostResource> resources,
+                                        boolean isVm) {
         for (var hr : resources) {
-            switch (hr.getMode()) {
+            switch (effectiveMode(hr, isVm)) {
                 case "readonly" -> {
                     removeExistingDevice(incus, container, deviceNameForMode(hr));
-                    applyReadonly(incus, container, hr);
+                    applyReadonly(incus, container, hr, isVm);
                 }
                 case "overlay" -> {
                     if (Environment.isMacOS()) {
@@ -167,7 +169,7 @@ public final class HostResourceSetup {
                                 + "  Tracking: https://github.com/Sanne/incus-spawn/issues/157");
                     }
                     removeExistingDevice(incus, container, deviceNameForMode(hr));
-                    applyOverlayDevice(incus, container, hr);
+                    applyOverlayDevice(incus, container, hr, isVm);
                 }
                 case "copy" -> {} // already baked into the template
             }
@@ -211,6 +213,20 @@ public final class HostResourceSetup {
         }
     }
 
+    /**
+     * VMs cannot mount individual files as disk devices (only directories).
+     * Fall back to copy mode for file-level readonly/overlay host resources.
+     */
+    private static String effectiveMode(ImageDef.HostResource hr, boolean isVm) {
+        if (!isVm || "copy".equals(hr.getMode())) return hr.getMode();
+        var expandedSource = expandHostTilde(hr.getSource());
+        if (Files.exists(Path.of(expandedSource)) && !Files.isDirectory(Path.of(expandedSource))) {
+            System.out.println("  VM: falling back to copy mode for file " + hr.getSource());
+            return "copy";
+        }
+        return hr.getMode();
+    }
+
     // --- Private helpers ---
 
     private static void applyCopy(Container container, ImageDef.HostResource hr) {
@@ -248,7 +264,7 @@ public final class HostResourceSetup {
         }
     }
 
-    private static void applyReadonly(IncusClient incus, String container, ImageDef.HostResource hr) {
+    private static void applyReadonly(IncusClient incus, String container, ImageDef.HostResource hr, boolean isVm) {
         var expandedSource = expandHostTilde(hr.getSource());
         if (!Files.exists(Path.of(expandedSource))) {
             System.err.println("Warning: host-resource source not found: " + hr.getSource() + " (skipping)");
@@ -260,12 +276,12 @@ public final class HostResourceSetup {
                 "source=" + translateForVm(expandedSource),
                 "path=" + containerPath,
                 "readonly=true"));
-        addShiftIfSupported(args);
+        addShiftIfSupported(args, isVm);
         incus.deviceAdd(container, devName, "disk", args.toArray(String[]::new));
         System.out.println("  Mounted " + hr.getSource() + " -> " + containerPath + " (readonly)");
     }
 
-    private static void applyOverlay(IncusClient incus, Container container, ImageDef.HostResource hr) {
+    private static void applyOverlay(IncusClient incus, Container container, ImageDef.HostResource hr, boolean isVm) {
         var containerPath = resolveContainerPath(hr.getSource(), hr.getPath());
         var oDir = overlayDir(containerPath);
         var lowerDir = oDir + "/lower";
@@ -282,7 +298,7 @@ public final class HostResourceSetup {
                 "source=" + translateForVm(expandedSource),
                 "path=" + lowerDir,
                 "readonly=true"));
-        addShiftIfSupported(overlayArgs);
+        addShiftIfSupported(overlayArgs, isVm);
         incus.deviceAdd(container.name(), overlayDeviceName(containerPath), "disk",
                 overlayArgs.toArray(String[]::new));
 
@@ -296,7 +312,8 @@ public final class HostResourceSetup {
         System.out.println("  Mounted " + hr.getSource() + " -> " + containerPath + " (overlay)");
     }
 
-    private static void applyOverlayDevice(IncusClient incus, String container, ImageDef.HostResource hr) {
+    private static void applyOverlayDevice(IncusClient incus, String container, ImageDef.HostResource hr,
+                                            boolean isVm) {
         var containerPath = resolveContainerPath(hr.getSource(), hr.getPath());
         var lowerDir = overlayDir(containerPath) + "/lower";
 
@@ -310,7 +327,7 @@ public final class HostResourceSetup {
                 "source=" + translateForVm(expandedSource),
                 "path=" + lowerDir,
                 "readonly=true"));
-        addShiftIfSupported(devArgs);
+        addShiftIfSupported(devArgs, isVm);
         incus.deviceAdd(container, overlayDeviceName(containerPath), "disk",
                 devArgs.toArray(String[]::new));
     }

--- a/src/main/java/dev/incusspawn/config/ImageDef.java
+++ b/src/main/java/dev/incusspawn/config/ImageDef.java
@@ -92,6 +92,7 @@ public class ImageDef {
     @JsonProperty("mask_services")
     private List<String> maskServices = List.of();
     private boolean gui;
+    private boolean vm;
     private String workdir;
     @JsonProperty("shell-command")
     private String shellCommand;
@@ -125,6 +126,8 @@ public class ImageDef {
     public void setMaskServices(List<String> maskServices) { this.maskServices = maskServices; }
     public boolean isGui() { return gui; }
     public void setGui(boolean gui) { this.gui = gui; }
+    public boolean isVm() { return vm; }
+    public void setVm(boolean vm) { this.vm = vm; }
     public String getWorkdir() { return workdir; }
     public void setWorkdir(String workdir) { this.workdir = workdir; }
     public String getShellCommand() { return shellCommand; }
@@ -304,6 +307,7 @@ public class ImageDef {
                     .append(',').append(hr.getMode()).append('\n');
         }
         if (gui) sb.append("gui=true\n");
+        if (vm) sb.append("vm=true\n");
         if (workdir != null && !workdir.isEmpty()) sb.append("workdir=").append(workdir).append('\n');
         if (shellCommand != null && !shellCommand.isEmpty()) sb.append("shell-command=").append(shellCommand).append('\n');
         return sha256hex(sb.toString());

--- a/src/main/java/dev/incusspawn/incus/Container.java
+++ b/src/main/java/dev/incusspawn/incus/Container.java
@@ -19,6 +19,30 @@ public class Container {
         return name;
     }
 
+    public boolean isVm() {
+        return incus.isVm(name);
+    }
+
+    public void waitForPath(String path) {
+        for (int i = 0; i < 30; i++) {
+            if (exec("test", "-e", path).success()) return;
+            try { Thread.sleep(500); } catch (InterruptedException e) { break; }
+        }
+        throw new IncusException("Timed out waiting for " + path + " in " + name);
+    }
+
+    public void addDiskDevice(String deviceName, String hostSource, String containerPath, boolean readonly) {
+        var args = new java.util.ArrayList<>(java.util.List.of(
+                "source=" + hostSource,
+                "path=" + containerPath));
+        if (readonly) args.add("readonly=true");
+        incus.deviceAdd(name, deviceName, "disk", args.toArray(String[]::new));
+    }
+
+    public void removeDiskDevice(String deviceName) {
+        incus.deviceRemove(name, deviceName);
+    }
+
     /** Run a command as root. Returns the result for inspection. */
     public IncusClient.ExecResult exec(String... command) {
         return incus.shellExec(name, command);

--- a/src/main/java/dev/incusspawn/incus/IncusClient.java
+++ b/src/main/java/dev/incusspawn/incus/IncusClient.java
@@ -1010,6 +1010,12 @@ public class IncusClient {
         return resp.body().path("metadata").path("status").asText("");
     }
 
+    public boolean isVm(String name) {
+        var resp = http().get("/1.0/instances/" + name);
+        if (!resp.isSuccess()) return false;
+        return "virtual-machine".equals(resp.body().path("metadata").path("type").asText(""));
+    }
+
     /**
      * Get a specific config value. Returns empty string if the key is not set.
      */

--- a/src/main/java/dev/incusspawn/lifecycle/InstanceLifecycle.java
+++ b/src/main/java/dev/incusspawn/lifecycle/InstanceLifecycle.java
@@ -61,7 +61,7 @@ public final class InstanceLifecycle {
         var hostResources = HostResourceSetup.deserialize(hrJson);
         if (!hostResources.isEmpty()) {
             System.out.println("Applying host-resource devices...");
-            HostResourceSetup.applyForInstance(incus, name, hostResources);
+            HostResourceSetup.applyForInstance(incus, name, hostResources, incus.isVm(name));
         }
 
         if (instanceType == InstanceType.INSTANCE) {

--- a/src/main/java/dev/incusspawn/tool/YamlToolSetup.java
+++ b/src/main/java/dev/incusspawn/tool/YamlToolSetup.java
@@ -123,7 +123,12 @@ public class YamlToolSetup implements ToolSetup {
         try {
             var cached = downloadCache.download(dl.getUrl(), dl.getSha256());
 
-            if (dl.isExtractInContainer()) {
+            if (container.isVm()) {
+                // VMs use the incus-agent for file I/O (over vsock), which
+                // cannot handle pushing large files. Mount the host directory
+                // as a disk device and copy locally inside the VM instead.
+                extractOnHostAndMountCopy(dl, cached, container);
+            } else if (dl.isExtractInContainer()) {
                 extractInContainer(dl, cached, container);
             } else {
                 extractOnHostAndPush(dl, cached, container);
@@ -147,6 +152,31 @@ public class YamlToolSetup implements ToolSetup {
 
         for (var linkEntry : dl.getLinks().entrySet()) {
             container.exec("ln", "-sf", linkEntry.getKey(), linkEntry.getValue());
+        }
+    }
+
+    private void extractOnHostAndMountCopy(ToolDef.DownloadEntry dl, Path cached, Container container)
+            throws IOException {
+        var extractDir = Files.createTempDirectory("isx-extract-");
+        var deviceName = "dl-" + def.getName();
+        var mountPath = "/mnt/isx-download";
+        try {
+            extractOnHost(cached, extractDir);
+            ensureWorldReadable(extractDir);
+
+            container.addDiskDevice(deviceName, extractDir.toString(), mountPath, true);
+            container.waitForPath(mountPath);
+            container.exec("mkdir", "-p", dl.getExtract());
+            container.runInteractive("Failed to copy download for " + def.getName(),
+                    "cp", "-a", mountPath + "/.", dl.getExtract());
+            container.exec("chmod", "-R", "a+rX", dl.getExtract());
+
+            for (var linkEntry : dl.getLinks().entrySet()) {
+                container.exec("ln", "-sf", linkEntry.getKey(), linkEntry.getValue());
+            }
+        } finally {
+            try { container.removeDiskDevice(deviceName); } catch (Exception ignored) {}
+            deleteRecursive(extractDir);
         }
     }
 

--- a/src/test/java/dev/incusspawn/command/BuildCommandTest.java
+++ b/src/test/java/dev/incusspawn/command/BuildCommandTest.java
@@ -203,7 +203,7 @@ class BuildCommandTest {
         imageDef.setRepos(List.of(repo));
 
         var cmd = new BuildCommand();
-        cmd.cloneRepos(container, imageDef);
+        cmd.cloneRepos(container, imageDef, false);
 
         verify(incus).shellExecInteractiveAsUser("test", "agentuser",
                 "git clone --single-branch -- 'https://github.com/quarkusio/quarkus.git' '/home/agentuser/quarkus'");
@@ -629,7 +629,7 @@ class BuildCommandTest {
         imageDef.setRepos(List.of(repo));
 
         var cmd = new BuildCommand();
-        cmd.cloneRepos(container, imageDef);
+        cmd.cloneRepos(container, imageDef, false);
 
         verify(incus).shellExecInteractiveAsUser("test", "agentuser",
                 "git clone --single-branch --branch 'feature/my branch' -- 'https://github.com/owner/repo.git' '/home/agentuser/repo'");
@@ -654,7 +654,7 @@ class BuildCommandTest {
         imageDef.setRepos(List.of(repo));
 
         var cmd = new BuildCommand();
-        cmd.cloneRepos(container, imageDef);
+        cmd.cloneRepos(container, imageDef, false);
 
         // Clone call + refspec restore, but no prime
         verify(incus, times(2)).shellExecInteractiveAsUser(eq("test"), anyString(), anyString());
@@ -677,9 +677,9 @@ class BuildCommandTest {
         var cmd = spy(new BuildCommand());
         cmd.incus = incus;
         var ref = new BuildCommand.RepoReference("ref-repo", "/mnt/ref/repo");
-        doReturn(ref).when(cmd).tryMountReference(eq(container), eq(repo.getUrl()), any());
+        doReturn(ref).when(cmd).tryMountReference(eq(container), eq(repo.getUrl()), any(), eq(false));
 
-        cmd.cloneRepos(container, imageDef);
+        cmd.cloneRepos(container, imageDef, false);
 
         // Reference clone command
         verify(incus).shellExecInteractiveAsUser("test", "agentuser",
@@ -713,9 +713,9 @@ class BuildCommandTest {
         var cmd = spy(new BuildCommand());
         cmd.incus = incus;
         var ref = new BuildCommand.RepoReference("ref-repo", "/mnt/ref/repo");
-        doReturn(ref).when(cmd).tryMountReference(eq(container), eq(repo.getUrl()), any());
+        doReturn(ref).when(cmd).tryMountReference(eq(container), eq(repo.getUrl()), any(), eq(false));
 
-        cmd.cloneRepos(container, imageDef);
+        cmd.cloneRepos(container, imageDef, false);
 
         // Should fall back to normal clone
         verify(incus).shellExecInteractiveAsUser("test", "agentuser",

--- a/src/test/java/dev/incusspawn/incus/IncusApiLiveTest.java
+++ b/src/test/java/dev/incusspawn/incus/IncusApiLiveTest.java
@@ -114,8 +114,10 @@ class IncusApiLiveTest {
         assertTrue(imagesResp.isSuccess());
 
         String imageFingerprint = null;
+        String imageType = "container";
         for (var img : imagesResp.body().path("metadata")) {
             imageFingerprint = img.path("fingerprint").asText();
+            imageType = img.path("type").asText("container");
             break;
         }
 
@@ -132,7 +134,7 @@ class IncusApiLiveTest {
             // Create (privileged to avoid nested idmap issues in CI/nested environments)
             var createBody = new java.util.LinkedHashMap<String, Object>();
             createBody.put("name", name);
-            createBody.put("type", "container");
+            createBody.put("type", imageType);
             createBody.put("source", java.util.Map.of("type", "image", "fingerprint", imageFingerprint));
             createBody.put("config", java.util.Map.of("security.privileged", "true"));
             var createResp = http.requestAndWait("POST", "/1.0/instances", createBody);
@@ -222,19 +224,18 @@ class IncusApiLiveTest {
     void copyInstance() throws Exception {
         if (skip()) return;
 
-        var imagesResp = http.get("/1.0/images?recursion=1");
-        if (imagesResp.body().path("metadata").size() == 0) {
+        var image = testImage();
+        if (image == null) {
             System.out.println("Skipping copy test: no local images."); return;
         }
-        var fingerprint = imagesResp.body().path("metadata").get(0).path("fingerprint").asText();
         String src = "isx-copy-src-" + System.currentTimeMillis() % 10000;
         String dst = src + "-copy";
 
         try {
             var createBody = new java.util.LinkedHashMap<String, Object>();
             createBody.put("name", src);
-            createBody.put("type", "container");
-            createBody.put("source", java.util.Map.of("type", "image", "fingerprint", fingerprint));
+            createBody.put("type", image.type());
+            createBody.put("source", java.util.Map.of("type", "image", "fingerprint", image.fingerprint()));
             createBody.put("config", java.util.Map.of("security.privileged", "true",
                     "user.test-marker", "original"));
             assertTrue(http.requestAndWait("POST", "/1.0/instances", createBody).isSuccess(),
@@ -269,13 +270,15 @@ class IncusApiLiveTest {
         if (imagesResp.body().path("metadata").size() == 0) {
             System.out.println("Skipping launch test: no local images."); return;
         }
-        var fingerprint = imagesResp.body().path("metadata").get(0).path("fingerprint").asText();
+        var imageNode = imagesResp.body().path("metadata").get(0);
+        var fingerprint = imageNode.path("fingerprint").asText();
+        var imageType = imageNode.path("type").asText("container");
 
         String name = "isx-launch-test-" + System.currentTimeMillis() % 10000;
         try {
             var createBody = new java.util.LinkedHashMap<String, Object>();
             createBody.put("name", name);
-            createBody.put("type", "container");
+            createBody.put("type", imageType);
             createBody.put("source", java.util.Map.of("type", "image", "fingerprint", fingerprint));
             createBody.put("config", java.util.Map.of("security.privileged", "true"));
             var createResp = http.requestAndWait("POST", "/1.0/instances", createBody);
@@ -304,17 +307,16 @@ class IncusApiLiveTest {
     void deviceConfigSet() throws Exception {
         if (skip()) return;
 
-        var imagesResp = http.get("/1.0/images?recursion=1");
-        if (imagesResp.body().path("metadata").size() == 0) {
+        var image = testImage();
+        if (image == null) {
             System.out.println("Skipping deviceConfigSet test: no local images."); return;
         }
-        var fingerprint = imagesResp.body().path("metadata").get(0).path("fingerprint").asText();
         String name = "isx-devset-test-" + System.currentTimeMillis() % 10000;
         try {
             var createBody = new java.util.LinkedHashMap<String, Object>();
             createBody.put("name", name);
-            createBody.put("type", "container");
-            createBody.put("source", java.util.Map.of("type", "image", "fingerprint", fingerprint));
+            createBody.put("type", image.type());
+            createBody.put("source", java.util.Map.of("type", "image", "fingerprint", image.fingerprint()));
             createBody.put("config", java.util.Map.of("security.privileged", "true"));
             assertTrue(http.requestAndWait("POST", "/1.0/instances", createBody).isSuccess());
 
@@ -337,19 +339,22 @@ class IncusApiLiveTest {
     // Exec via WebSocket
     // =========================================================================
 
-    private static String testImageFingerprint() throws Exception {
+    private record TestImage(String fingerprint, String type) {}
+
+    private static TestImage testImage() throws Exception {
         if (skip()) return null;
         var r = http.get("/1.0/images?recursion=1");
         var meta = r.body().path("metadata");
         if (meta.size() == 0) return null;
-        return meta.get(0).path("fingerprint").asText();
+        var img = meta.get(0);
+        return new TestImage(img.path("fingerprint").asText(), img.path("type").asText("container"));
     }
 
-    private static String createAndStartContainer(String name, String fingerprint) throws Exception {
+    private static String createAndStartContainer(String name, TestImage image) throws Exception {
         var body = new java.util.LinkedHashMap<String, Object>();
         body.put("name", name);
-        body.put("type", "container");
-        body.put("source", java.util.Map.of("type", "image", "fingerprint", fingerprint));
+        body.put("type", image.type());
+        body.put("source", java.util.Map.of("type", "image", "fingerprint", image.fingerprint()));
         body.put("config", java.util.Map.of("security.privileged", "true"));
         assertTrue(http.requestAndWait("POST", "/1.0/instances", body).isSuccess());
         assertTrue(http.requestAndWait("PUT", "/1.0/instances/" + name + "/state",
@@ -368,12 +373,12 @@ class IncusApiLiveTest {
     @Test
     void execCaptureReturnsStdoutStderrAndExitCode() throws Exception {
         if (skip()) return;
-        var fp = testImageFingerprint();
-        if (fp == null) { System.out.println("Skipping exec test: no images."); return; }
+        var image = testImage();
+        if (image == null) { System.out.println("Skipping exec test: no images."); return; }
 
         String name = "isx-exec-test-" + System.currentTimeMillis() % 10000;
         try {
-            createAndStartContainer(name, fp);
+            createAndStartContainer(name, image);
 
             var result = http.execCapture(name,
                     List.of("sh", "-c", "echo hello-stdout; echo hello-stderr >&2; exit 7"),
@@ -393,12 +398,12 @@ class IncusApiLiveTest {
     @Test
     void execCaptureWithUserAndGroup() throws Exception {
         if (skip()) return;
-        var fp = testImageFingerprint();
-        if (fp == null) { System.out.println("Skipping exec user test: no images."); return; }
+        var image = testImage();
+        if (image == null) { System.out.println("Skipping exec user test: no images."); return; }
 
         String name = "isx-execuser-test-" + System.currentTimeMillis() % 10000;
         try {
-            createAndStartContainer(name, fp);
+            createAndStartContainer(name, image);
 
             // Run id as root (uid=0)
             var rootResult = http.execCapture(name, List.of("id", "-u"), 0, 0, "/root", java.util.Map.of());
@@ -429,12 +434,12 @@ class IncusApiLiveTest {
     @Test
     void execStreamWritesToOutputStreams() throws Exception {
         if (skip()) return;
-        var fp = testImageFingerprint();
-        if (fp == null) { System.out.println("Skipping execStream test: no images."); return; }
+        var image = testImage();
+        if (image == null) { System.out.println("Skipping execStream test: no images."); return; }
 
         String name = "isx-stream-test-" + System.currentTimeMillis() % 10000;
         try {
-            createAndStartContainer(name, fp);
+            createAndStartContainer(name, image);
 
             var stdoutBuf = new java.io.ByteArrayOutputStream();
             var stderrBuf = new java.io.ByteArrayOutputStream();
@@ -454,12 +459,12 @@ class IncusApiLiveTest {
     @Test
     void getLogReturnsContent() throws Exception {
         if (skip()) return;
-        var fp = testImageFingerprint();
-        if (fp == null) { System.out.println("Skipping log test: no images."); return; }
+        var image = testImage();
+        if (image == null) { System.out.println("Skipping log test: no images."); return; }
 
         String name = "isx-log-test-" + System.currentTimeMillis() % 10000;
         try {
-            createAndStartContainer(name, fp);
+            createAndStartContainer(name, image);
             var logsResp = http.get("/1.0/instances/" + name + "/logs");
             assertTrue(logsResp.isSuccess(), "logs endpoint should return 200");
             var logs = logsResp.body().path("metadata");
@@ -507,19 +512,18 @@ class IncusApiLiveTest {
         if (skip()) return;
 
         // Need a running instance for file push
-        var imagesResp = http.get("/1.0/images?recursion=1");
-        if (imagesResp.body().path("metadata").size() == 0) {
+        var image = testImage();
+        if (image == null) {
             System.out.println("Skipping file push test: no local images.");
             return;
         }
-        var imageFingerprint = imagesResp.body().path("metadata").get(0).path("fingerprint").asText();
         String name = "isx-filepush-test-" + System.currentTimeMillis() % 10000;
 
         try {
             var createBody = new java.util.LinkedHashMap<String, Object>();
             createBody.put("name", name);
-            createBody.put("type", "container");
-            createBody.put("source", java.util.Map.of("type", "image", "fingerprint", imageFingerprint));
+            createBody.put("type", image.type());
+            createBody.put("source", java.util.Map.of("type", "image", "fingerprint", image.fingerprint()));
             createBody.put("config", java.util.Map.of("security.privileged", "true"));
             assertTrue(http.requestAndWait("POST", "/1.0/instances", createBody).isSuccess());
 


### PR DESCRIPTION
## Summary

- Add `vm: true` field to image definition YAML so templates can declare they should be built as VMs
- Add `--vm` / `--no-vm` CLI flags for overriding the image definition
- Handle type-mismatch between parent and child templates (e.g. container parent, VM child) by falling back to `buildFromScratch` with the full ancestor chain
- Fix VM-specific disk device limitations: skip `shift=true` (container-only), fall back to copy mode for individual file mounts (VMs only support directory mounts), skip shared DNF cache mount (incompatible with virtiofs)
- Fix `IncusApiLiveTest` failures when cached images are VMs (pre-existing issue)

## Status

**Not tested yet** — builds compile and all 548 unit tests pass, but we haven't completed a full VM build end-to-end. Known issues encountered during testing (stale DNF cache, file mount failures) have been addressed but the full build cycle hasn't been verified.

## Changes

- `ImageDef.java` — new `vm` boolean field, included in content fingerprint
- `BuildCommand.java` — `--vm`/`--no-vm` flags, `effectiveVm()` tri-state resolution, type-mismatch detection in `buildSingleImage`, full ancestor chain in `buildFromScratch`, VM-aware `mountDnfCache`/`cloneRepos`/`tryMountReference`, skip container-only security configs for VMs
- `IncusClient.java` — new `isVm()` method
- `HostResourceSetup.java` — `isVm` parameter threaded through all device methods, `effectiveMode()` for file→copy fallback, `addShiftIfSupported` skips shift for VMs
- `InstanceLifecycle.java` — detect VM at branch time for host-resource device application
- `IncusApiLiveTest.java` — read image type dynamically instead of hardcoding "container"
- `BuildCommandTest.java` — updated for new method signatures

## Test plan

- [ ] Build a template with `vm: true` end-to-end
- [ ] Verify host-resources work (directory mounts, file fallback to copy, overlay)
- [ ] Branch from a VM template and verify host-resource re-application
- [ ] Build a non-VM template to verify no regressions
- [ ] `mvn test` (passing: 548/548)