### PR TITLE
Prevent proxy crash loop after macOS sleep/wake

### DIFF
--- a/src/main/java/dev/incusspawn/command/ProxyCommand.java
+++ b/src/main/java/dev/incusspawn/command/ProxyCommand.java
@@ -71,7 +71,10 @@ public class ProxyCommand extends BaseCommand {
         @Override
         protected CommandResult doExecute() throws Exception {
             var incus = RuntimeServices.incus();
-            if (!InitCommand.requireInit()) return CommandResult.valueOf(1);
+            if (!InitCommand.hasBeenInitialized()) {
+                System.err.println("Error: incus-spawn has not been initialized. Run 'isx init' first.");
+                return CommandResult.valueOf(1);
+            }
             var config = dev.incusspawn.config.SpawnConfig.load();
             var claude = config.getClaude();
             var apiKey = claude.getApiKey();

--- a/src/main/java/dev/incusspawn/proxy/MitmProxy.java
+++ b/src/main/java/dev/incusspawn/proxy/MitmProxy.java
@@ -396,6 +396,8 @@ public class MitmProxy {
         upstreamClient = vertx.createHttpClient(clientOptions);
 
         mitmServer = vertx.createHttpServer(serverOptions);
+        mitmServer.exceptionHandler(err ->
+                System.err.println("MITM server error: " + err.getMessage()));
         mitmServer.requestHandler(this::routeRequest);
         mitmServer.listen()
                 .toCompletionStage().toCompletableFuture().get();
@@ -447,24 +449,29 @@ public class MitmProxy {
     // --- Request routing ---
 
     private void routeRequest(HttpServerRequest clientReq) {
-        var domain = extractDomain(clientReq);
-        if (domain == null) {
-            sendError(clientReq.response(), 502, "Unknown domain");
-            return;
-        }
+        try {
+            var domain = extractDomain(clientReq);
+            if (domain == null) {
+                sendError(clientReq.response(), 502, "Unknown domain");
+                return;
+            }
 
-        if (REGISTRY_DOMAINS.contains(domain)) {
-            handleRegistryRequest(clientReq, domain);
-        } else if (MAVEN_DOMAINS.contains(domain)) {
-            handleMavenRequest(clientReq, domain);
-        } else if (GRADLE_DOMAINS.contains(domain)) {
-            handleGradleRequest(clientReq, domain);
-        } else if (INTERCEPTED_DOMAIN_SET.contains(domain)) {
-            handleApiRequest(clientReq, domain);
-        } else {
-            // Subdomain of an intercepted domain (e.g. cdn01.quay.io) reached us
-            // via dnsmasq wildcard — relay transparently without auth injection.
-            relayRequest(clientReq, domain);
+            if (REGISTRY_DOMAINS.contains(domain)) {
+                handleRegistryRequest(clientReq, domain);
+            } else if (MAVEN_DOMAINS.contains(domain)) {
+                handleMavenRequest(clientReq, domain);
+            } else if (GRADLE_DOMAINS.contains(domain)) {
+                handleGradleRequest(clientReq, domain);
+            } else if (INTERCEPTED_DOMAIN_SET.contains(domain)) {
+                handleApiRequest(clientReq, domain);
+            } else {
+                // Subdomain of an intercepted domain (e.g. cdn01.quay.io) reached us
+                // via dnsmasq wildcard — relay transparently without auth injection.
+                relayRequest(clientReq, domain);
+            }
+        } catch (Exception e) {
+            System.err.println("Unexpected error handling request: " + e.getMessage());
+            sendError(clientReq.response(), 502, "Internal proxy error");
         }
     }
 
@@ -1468,8 +1475,12 @@ public class MitmProxy {
     }
 
     private void sendError(HttpServerResponse resp, int statusCode, String message) {
-        if (!resp.ended() && !resp.closed()) {
-            resp.setStatusCode(statusCode).end(message);
+        try {
+            if (!resp.ended() && !resp.closed()) {
+                resp.setStatusCode(statusCode).end(message);
+            }
+        } catch (Exception e) {
+            System.err.println("Failed to send error response: " + e.getMessage());
         }
     }
 

--- a/src/main/java/dev/incusspawn/proxy/MitmProxy.java
+++ b/src/main/java/dev/incusspawn/proxy/MitmProxy.java
@@ -396,8 +396,10 @@ public class MitmProxy {
         upstreamClient = vertx.createHttpClient(clientOptions);
 
         mitmServer = vertx.createHttpServer(serverOptions);
-        mitmServer.exceptionHandler(err ->
-                System.err.println("MITM server error: " + err.getMessage()));
+        mitmServer.exceptionHandler(err -> {
+            System.err.println("MITM server error: " + err.getMessage());
+            err.printStackTrace(System.err);
+        });
         mitmServer.requestHandler(this::routeRequest);
         mitmServer.listen()
                 .toCompletionStage().toCompletableFuture().get();
@@ -470,7 +472,10 @@ public class MitmProxy {
                 relayRequest(clientReq, domain);
             }
         } catch (Exception e) {
-            System.err.println("Unexpected error handling request: " + e.getMessage());
+            var domain = extractDomain(clientReq);
+            var path = clientReq.path();
+            System.err.println("Unexpected error handling request to " + domain + path + ": " + e.getMessage());
+            e.printStackTrace(System.err);
             sendError(clientReq.response(), 502, "Internal proxy error");
         }
     }
@@ -493,6 +498,7 @@ public class MitmProxy {
                 handleApiRequestWithBody(clientReq, domain, bodyBuffer);
             } catch (Exception e) {
                 System.err.println("API request error: " + e.getMessage());
+                e.printStackTrace(System.err);
                 sendError(clientReq.response(), 502, "Proxy error");
             }
         }).onFailure(err -> {
@@ -1481,6 +1487,7 @@ public class MitmProxy {
             }
         } catch (Exception e) {
             System.err.println("Failed to send error response: " + e.getMessage());
+            e.printStackTrace(System.err);
         }
     }
 


### PR DESCRIPTION
## Summary

- **Skip VM-readiness gate during proxy start** — replaced `requireInit()` (which blocks 60s waiting for Incus daemon) with `hasBeenInitialized()` (just checks config+CA exist). The VM has its own launchd agent; DNS overrides already retry via `configureBridgeDnsWithRetry()`. This breaks the restart loop where each cycle took ~70s (60s wait + 10s throttle).
- **Add exception safety to request handling** — wrapped `routeRequest()` in try-catch and added `mitmServer.exceptionHandler()` for connection-level errors (TLS handshake failures, broken sockets). Prevents unhandled exceptions from killing the Vert.x event loop.
- **Make `sendError()` no-throw** — the safety catch in `routeRequest()` calls `sendError()`, which could itself throw if the response was partially written. Wrapped in try-catch so the last line of defense can't propagate.

## Test plan

- [x] `mvn test` — 551 tests pass
- [ ] `isx proxy start` in foreground — starts without waiting for Incus daemon readiness
- [ ] `isx proxy status` — health endpoint responds
- [ ] Stop VM, start proxy — should fail quickly (no 60s wait), and launchd should retry rapidly until VM is back


🤖 Generated with [Claude Code](https://claude.com/claude-code)