### PR TITLE
Check VM configuration for remotes

### DIFF
--- a/src/main/java/dev/incusspawn/incus/IncusClient.java
+++ b/src/main/java/dev/incusspawn/incus/IncusClient.java
@@ -1,6 +1,7 @@
 package dev.incusspawn.incus;
 
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+import dev.incusspawn.Environment;
 import dev.incusspawn.config.BuildSource;
 
 import java.io.IOException;
@@ -776,6 +777,7 @@ public class IncusClient {
     private static RemoteConfig readIncusRemote(String name) {
         var home = System.getProperty("user.home", "");
         var candidates = List.of(
+                Environment.incusConfigFile(),
                 Path.of(home, ".config", "incus", "config.yml"),
                 Path.of(home, ".local", "share", "incus", "config.yml")
         );


### PR DESCRIPTION
Without it:

```
Building image: tpl-minimal
Launching images:fedora/44...

────────────────────────────────────────────────────────────
Build failed for tpl-minimal: Unknown Incus remote 'images' for image 'images:fedora/44'. Add it with: incus remote add images <url>
  Container status: (unknown)
  cow pool: 38MiB used / 61440MiB total (0% full)
Failed to promote container: Failed to force-stop tpl-minimal-rebuilding
Container 'tpl-minimal-rebuilding' may still exist for manual cleanup.
```