### PR TITLE
Configure bridge DNS at install time and auto-heal from TUI

### DIFF
--- a/src/main/java/dev/incusspawn/command/ListCommand.java
+++ b/src/main/java/dev/incusspawn/command/ListCommand.java
@@ -16,6 +16,7 @@ import dev.incusspawn.lifecycle.KvmPassthrough;
 import dev.incusspawn.lifecycle.InstanceLifecycle;
 import dev.incusspawn.lifecycle.InstanceType;
 import dev.incusspawn.proxy.CertificateAuthority;
+import dev.incusspawn.proxy.MitmProxy;
 import dev.incusspawn.proxy.ProxyHealthCheck;
 import dev.incusspawn.proxy.ProxyService;
 import dev.incusspawn.ssh.SshKeyManager;
@@ -3068,10 +3069,32 @@ public class ListCommand extends BaseCommand {
     }
 
     private volatile boolean proxyRestartInProgress;
+    private volatile boolean dnsVerified;
+
+    private void tryFixStaleDns() {
+        if (dnsVerified) return;
+        dnsVerified = true;
+        if (MitmProxy.isBridgeDnsComplete(incus)) return;
+        setStatusMessage("Updating bridge DNS overrides...");
+        var thread = new Thread(() -> {
+            try {
+                MitmProxy.writeBridgeDns(incus);
+                setStatusMessage("Bridge DNS overrides updated");
+            } catch (Exception e) {
+                setStatusMessage("DNS update failed: " + e.getMessage());
+                dnsVerified = false;
+            }
+        }, "dns-auto-heal");
+        thread.setDaemon(true);
+        thread.start();
+    }
 
     private boolean showProxyError() {
         var proxyStatus = ProxyHealthCheck.check(incus);
-        if (proxyStatus == ProxyHealthCheck.ProxyStatus.RUNNING) return false;
+        if (proxyStatus == ProxyHealthCheck.ProxyStatus.RUNNING) {
+            tryFixStaleDns();
+            return false;
+        }
         if (proxyStatus == ProxyHealthCheck.ProxyStatus.WAITING_FOR_DNS) {
             setStatusMessage("Proxy running, waiting for DNS configuration...");
             return true;

--- a/src/main/java/dev/incusspawn/command/ProxyCommand.java
+++ b/src/main/java/dev/incusspawn/command/ProxyCommand.java
@@ -120,7 +120,9 @@ public class ProxyCommand extends BaseCommand {
             System.out.println("Starting MITM authentication proxy...");
             System.out.println("  Version:       " + build.version() + " (" + build.gitSha() + ")");
             System.out.println("  Runtime:       " + build.runtime());
-            System.out.println("  Incus:         " + build.incusClient() + " (client) / " + build.incusServer() + " (server)");
+            if (!Environment.isMacOS()) {
+                System.out.println("  Incus:         " + build.incusClient() + " (client) / " + build.incusServer() + " (server)");
+            }
             System.out.println("  Gateway IP:    " + gatewayIp);
             System.out.println("  MITM port:     " + port);
             System.out.println("  Health port:   " + healthPort);
@@ -164,8 +166,25 @@ public class ProxyCommand extends BaseCommand {
                 proxy.stop();
             }));
 
+            Runnable dnsCallback;
+            if (Environment.isMacOS()) {
+                // On macOS, DNS is configured at install time (from Terminal, where the
+                // native binary can reach the VM). Under launchd, macOS Sequoia blocks
+                // bridge access from ad-hoc-signed binaries, so don't retry on failure.
+                dnsCallback = () -> {
+                    try {
+                        MitmProxy.configureBridgeDns(incus);
+                        ProxyLog.info("DNS overrides configured");
+                    } catch (Exception e) {
+                        ProxyLog.info("Using install-time DNS configuration (VM API not reachable from launchd)");
+                    }
+                    proxy.setDnsConfigured(true);
+                };
+            } else {
+                dnsCallback = () -> MitmProxy.configureBridgeDnsWithRetry(incus, () -> proxy.setDnsConfigured(true));
+            }
             try {
-                proxy.start(() -> MitmProxy.configureBridgeDnsWithRetry(incus, () -> proxy.setDnsConfigured(true)));
+                proxy.start(dnsCallback);
             } catch (Exception e) {
                 ProxyLog.error("Failed to start: " + e.getMessage());
                 System.err.println("Is another proxy already running? Check port " + port + ".");

--- a/src/main/java/dev/incusspawn/proxy/MitmProxy.java
+++ b/src/main/java/dev/incusspawn/proxy/MitmProxy.java
@@ -252,6 +252,12 @@ public class MitmProxy {
      * containers never silently bypass the proxy.
      */
     public static void configureBridgeDns(IncusClient incus) {
+        writeBridgeDns(incus);
+        System.out.println("  DNS overrides: " + interceptedDomains().size() +
+                " domains -> " + resolveGatewayIp(incus) + " (via bridge dnsmasq)");
+    }
+
+    public static void writeBridgeDns(IncusClient incus) {
         var gatewayIp = resolveGatewayIp(incus);
         var overrides = interceptedDomains().stream()
                 .sorted()
@@ -267,8 +273,6 @@ public class MitmProxy {
         var dnsmasqConfig = servers.isEmpty() ? overrides : servers + "\n" + overrides;
 
         incus.networkConfigSet("incusbr0", "raw.dnsmasq", dnsmasqConfig);
-        System.out.println("  DNS overrides: " + interceptedDomains().size() +
-                " domains -> " + gatewayIp + " (via bridge dnsmasq)");
     }
 
     /**
@@ -338,6 +342,13 @@ public class MitmProxy {
         } catch (Exception e) {
             return "";
         }
+    }
+
+    public static boolean isBridgeDnsComplete(IncusClient incus) {
+        var overrides = getDnsOverrides(incus);
+        if (overrides.isEmpty()) return true;
+        return interceptedDomains().stream()
+                .allMatch(d -> overrides.contains("address=/" + d + "/"));
     }
 
     // --- Lifecycle ---

--- a/src/main/java/dev/incusspawn/proxy/ProxyService.java
+++ b/src/main/java/dev/incusspawn/proxy/ProxyService.java
@@ -496,6 +496,17 @@ public final class ProxyService {
         runQuiet("launchctl", "bootout", "gui/" + uid, vmPlistFile().toString());
         runQuiet("launchctl", "bootstrap", "gui/" + uid, vmPlistFile().toString());
 
+        // Configure bridge DNS now (from Terminal) so the launchd proxy service
+        // doesn't need to reach the Incus VM API at startup — macOS Sequoia blocks
+        // local network access from ad-hoc-signed binaries under launchd.
+        System.out.println("  Configuring bridge DNS...");
+        try {
+            MitmProxy.configureBridgeDns(new IncusClient());
+        } catch (Exception e) {
+            System.err.println("  Warning: could not configure bridge DNS: " + e.getMessage());
+            System.err.println("  Is the VM running? The proxy will retry DNS at startup.");
+        }
+
         System.out.println("  Installing proxy service...");
         runQuiet("launchctl", "bootout", "gui/" + uid, proxyPlistFile().toString());
         waitForProxyExit();


### PR DESCRIPTION
## Summary

- **DNS at install time**: On macOS, `isx proxy install` now configures bridge DNS before starting the launchd service. This avoids the macOS Sequoia Local Network Privacy issue where the native binary can't reach the VM bridge from launchd (ad-hoc-signed binaries are blocked by NECP). The proxy starts with `dnsConfigured=true` immediately.
- **TUI auto-heal**: When the TUI detects the proxy is running but bridge DNS is missing domains (e.g. after a CLI update adds new intercepted domains), it silently reconfigures DNS. Works on all platforms — the TUI runs from Terminal with full bridge access. Checks once per session, retries on transient failures.
- **Skip Incus version on macOS proxy start**: Avoids a 5s timeout when the VM API isn't reachable from launchd.

## Test plan

- [ ] `mvn test` passes (555 tests, 0 failures)
- [ ] `isx proxy install` on macOS configures DNS before starting launchd service
- [ ] Proxy starts cleanly under launchd without "No route to host" errors
- [ ] TUI shows "Bridge DNS overrides updated" status when domains are missing
- [ ] TUI does not re-check DNS after first successful verification
- [ ] On API errors (VM unreachable), TUI skips DNS fix attempt gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)