### PR TITLE
Fix SSH connectivity and add Hostname for JetBrains Gateway

### DIFF
--- a/src/main/java/dev/incusspawn/command/ListCommand.java
+++ b/src/main/java/dev/incusspawn/command/ListCommand.java
@@ -3249,21 +3249,8 @@ public class ListCommand extends BaseCommand {
                 var expandedDevices = node.path("expanded_devices");
                 var rootSize = expandedDevices.path("root").path("size").asText("");
 
-                // Extract first global IPv4 address from state.network
-                var ipv4 = "";
-                var network = node.path("state").path("network");
-                for (var ifaces = network.fields(); ifaces.hasNext(); ) {
-                    var iface = ifaces.next();
-                    if (iface.getKey().equals("lo")) continue;
-                    for (var addr : iface.getValue().path("addresses")) {
-                        if ("inet".equals(addr.path("family").asText())
-                                && "global".equals(addr.path("scope").asText())) {
-                            ipv4 = addr.path("address").asText();
-                            break;
-                        }
-                    }
-                    if (!ipv4.isEmpty()) break;
-                }
+                var extracted = IncusClient.extractIpv4(node.path("state").path("network"));
+                var ipv4 = extracted != null ? extracted : "";
 
                 entryList.add(new InstanceInfo(
                         node.path("name").asText(),

--- a/src/main/java/dev/incusspawn/incus/IncusClient.java
+++ b/src/main/java/dev/incusspawn/incus/IncusClient.java
@@ -1,5 +1,6 @@
 package dev.incusspawn.incus;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import dev.incusspawn.Environment;
 import dev.incusspawn.config.BuildSource;
@@ -550,6 +551,32 @@ public class IncusClient {
         var resp = http().get("/1.0/instances/" + name + "/state");
         if (!resp.isSuccess()) return 0;
         return resp.body().path("metadata").path("memory").path("usage").asLong(0);
+    }
+
+    /**
+     * Extract the first global IPv4 address from an Incus network state node.
+     */
+    public static String extractIpv4(JsonNode networkNode) {
+        for (var ifaces = networkNode.fields(); ifaces.hasNext(); ) {
+            var iface = ifaces.next();
+            if (iface.getKey().equals("lo")) continue;
+            for (var addr : iface.getValue().path("addresses")) {
+                if ("inet".equals(addr.path("family").asText())
+                        && "global".equals(addr.path("scope").asText())) {
+                    return addr.path("address").asText();
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Get the IPv4 address for a running container, or null if unavailable.
+     */
+    public String getContainerIpv4(String name) {
+        var resp = http().get("/1.0/instances/" + name + "/state");
+        if (!resp.isSuccess()) return null;
+        return extractIpv4(resp.body().path("metadata").path("network"));
     }
 
     /**

--- a/src/main/java/dev/incusspawn/lifecycle/InstanceLifecycle.java
+++ b/src/main/java/dev/incusspawn/lifecycle/InstanceLifecycle.java
@@ -77,7 +77,7 @@ public final class InstanceLifecycle {
     public static RuntimeConfig prefetchRuntimeConfig(IncusClient incus, String name) {
         var buildSourceJson = incus.configGet(name, Metadata.BUILD_SOURCE);
         var hasSshKeys = !incus.configGet(name, "user.incus-spawn.ssh-setup").isEmpty()
-                || buildSourceJson.contains("\"ssh\"");
+                || buildSourceJson.contains("\"sshd\"");
         var workdir = incus.configGet(name, Metadata.WORKDIR);
         var shellCommand = incus.configGet(name, Metadata.SHELL_COMMAND);
         var subnetDiag = BridgeSubnetCheck.detectConflictDiagnostic(incus);
@@ -175,6 +175,8 @@ public final class InstanceLifecycle {
             System.out.println("Configuring SSH access...");
             injectSshKeyIfAvailable(incus, name, null);
         }
+
+        configureSshHostEntry(incus, name);
     }
 
     public static void setupRuntime(IncusClient incus, String name,
@@ -259,12 +261,10 @@ public final class InstanceLifecycle {
         }
 
         // Ensure managed key infrastructure exists (creates lazily for pre-existing installs)
-        boolean includeConfigured = false;
         try {
             if (!SshKeyManager.exists()) {
                 SshKeyManager.ensureKeyPairExists();
             }
-            includeConfigured = SshKeyManager.ensureSshConfigInclude();
         } catch (Exception ignored) {}
 
         // Collect keys to inject — managed key plus any personal key
@@ -312,14 +312,23 @@ public final class InstanceLifecycle {
             return;
         }
 
-        // Configure SSH ProxyCommand entry for seamless access
+        System.out.println("  SSH keys injected.");
+    }
+
+    /**
+     * Configure the SSH host entry with Hostname directive. Must be called after
+     * the container is started so the IPv4 address is available.
+     */
+    public static void configureSshHostEntry(IncusClient incus, String name) {
+        if (!SshKeyManager.exists()) return;
+
+        boolean includeConfigured = SshKeyManager.ensureSshConfigInclude();
         boolean hostConfigured = false;
-        if (SshKeyManager.exists()) {
-            try {
-                hostConfigured = SshKeyManager.addHostEntry(name);
-            } catch (Exception e) {
-                System.err.println("  Warning: failed to configure SSH host entry: " + e.getMessage());
-            }
+        try {
+            var ipv4 = incus.getContainerIpv4(name);
+            hostConfigured = SshKeyManager.addHostEntry(name, ipv4);
+        } catch (Exception e) {
+            System.err.println("  Warning: failed to configure SSH host entry: " + e.getMessage());
         }
 
         if (hostConfigured && includeConfigured) {

--- a/src/main/java/dev/incusspawn/ssh/SshKeyManager.java
+++ b/src/main/java/dev/incusspawn/ssh/SshKeyManager.java
@@ -169,6 +169,13 @@ public final class SshKeyManager {
      * @return true if the entry was written successfully
      */
     public static boolean addHostEntry(String instanceName) {
+        return addHostEntry(instanceName, null);
+    }
+
+    /**
+     * @param hostname optional IP/hostname for clients that don't support ProxyCommand
+     */
+    public static boolean addHostEntry(String instanceName, String hostname) {
         try {
             ensureManagedConfigExists();
             var content = Files.readString(Environment.sshConfigFile());
@@ -178,6 +185,9 @@ public final class SshKeyManager {
 
             blocks.add("");
             blocks.add("Host " + instanceName);
+            if (hostname != null && !hostname.isEmpty()) {
+                blocks.add("    Hostname " + hostname);
+            }
             blocks.add("    ProxyCommand \"" + isxPath + "\" ssh-proxy " + instanceName);
             blocks.add("    User agentuser");
             blocks.add("    IdentityFile ~/.config/incus-spawn/ssh/id_ed25519");

--- a/src/test/java/dev/incusspawn/ssh/SshKeyManagerTest.java
+++ b/src/test/java/dev/incusspawn/ssh/SshKeyManagerTest.java
@@ -83,6 +83,27 @@ class SshKeyManagerTest {
     }
 
     @Test
+    void addHostEntryWithHostname() {
+        SshKeyManager.addHostEntry("test-instance", "10.0.0.42");
+
+        var content = assertDoesNotThrow(
+                () -> Files.readString(tempDir.resolve(".config/incus-spawn/ssh/config")));
+        assertTrue(content.contains("Host test-instance"));
+        assertTrue(content.contains("Hostname 10.0.0.42"));
+        assertTrue(content.contains("ProxyCommand"));
+    }
+
+    @Test
+    void addHostEntryWithNullHostnameOmitsDirective() {
+        SshKeyManager.addHostEntry("test-instance", null);
+
+        var content = assertDoesNotThrow(
+                () -> Files.readString(tempDir.resolve(".config/incus-spawn/ssh/config")));
+        assertTrue(content.contains("Host test-instance"));
+        assertFalse(content.contains("Hostname"));
+    }
+
+    @Test
     void addHostEntryReplacesExistingEntry() {
         SshKeyManager.addHostEntry("test-instance");
         SshKeyManager.addHostEntry("test-instance");


### PR DESCRIPTION
## Summary

- Fix `hasSshKeys` detection: checked for `"ssh"` in build source JSON but the tool is named `sshd` — substring `"ssh"` never matches `"sshd"`, so SSH key injection was skipped entirely
- Move SSH host config (`addHostEntry`) to after container start so `getContainerIpv4()` can resolve the IP for the `Hostname` directive
- Add `Hostname <ip>` directive to SSH config entries so JetBrains Gateway (and other clients that don't fully support `ProxyCommand`) can resolve container addresses
- Extract IPv4 parsing into reusable `IncusClient.extractIpv4()` helper

Supersedes #218 — that PR moved SSH config into `~/.ssh/config` directly, which wasn't needed. This fix keeps the Include-based approach (`~/.config/incus-spawn/ssh/config`) and addresses the actual root causes.

Closes #211

## Test plan

- [x] `mvn test` passes (557 tests, 0 failures)
- [x] Branch an instance, verify `~/.config/incus-spawn/ssh/config` contains `Hostname` with the container's bridge IP
- [x] Verify `ssh <instance>` connects successfully via ProxyCommand
- [ ] Verify JetBrains Gateway can connect using the Hostname

🤖 Generated with [Claude Code](https://claude.com/claude-code)