### PR TITLE
Fix install.sh silent failure when Homebrew is not installed

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -137,7 +137,7 @@ fi
 install -m 755 "$SCRIPT_DIR/src/main/resources/git-remote-isx" "$INSTALL_DIR/git-remote-isx"
 
 # ── Replace Homebrew installation if present ─────────────────────────────
-BREW_ISX="$(brew --prefix 2>/dev/null)/bin/isx"
+BREW_ISX="$(brew --prefix 2>/dev/null || true)/bin/isx"
 if [ -x "$BREW_ISX" ] && [ "$INSTALL_DIR/$BINARY_NAME" != "$BREW_ISX" ]; then
     echo "Homebrew installation detected at $BREW_ISX"
     echo "Replacing with locally built binary..."


### PR DESCRIPTION
## Summary

- `brew --prefix` exits non-zero when Homebrew is absent. Under `set -e` this killed the script after a successful install, with no error message (stderr was redirected to `/dev/null`).
- Add `|| true` so the subshell doesn't propagate the failure.

## Test plan

- [ ] Run `INSTALL_DIR=/tmp/isx-test ./install.sh` on a machine without Homebrew — should exit 0
- [ ] Run on a machine with Homebrew — existing behavior preserved