### PR TITLE
Add vsock tunnel to bypass Cisco AnyConnect socket filter

### DIFF
--- a/appliance/build.sh
+++ b/appliance/build.sh
@@ -69,7 +69,8 @@ apk add --no-cache \
     ca-certificates \
     util-linux \
     qemu-guest-agent \
-    shadow-subids
+    shadow-subids \
+    socat
 "
 echo "    Size after packages: $(du -sh "$ROOTFS_DIR" | cut -f1)"
 

--- a/appliance/root/usr/local/sbin/incus-spawn-vm-init
+++ b/appliance/root/usr/local/sbin/incus-spawn-vm-init
@@ -100,6 +100,16 @@ fi
 # Enable HTTPS API access so the macOS host can connect
 incus config set core.https_address :8443
 
+# vsock-to-TCP forwarder: allows the macOS host to reach the Incus API
+# via vsock instead of the VM bridge network. This bypasses network-layer
+# socket filters (e.g. Cisco AnyConnect) that block non-Apple-signed
+# binaries from connecting to the VM subnet.
+VSOCK_INCUS_PORT=$(parse_cmdline "isx.vsock_incus")
+if [ -n "$VSOCK_INCUS_PORT" ]; then
+    socat VSOCK-LISTEN:${VSOCK_INCUS_PORT},reuseaddr,fork TCP:127.0.0.1:8443 &
+    echo "incus-spawn-vm-init: vsock->incus forwarder on port $VSOCK_INCUS_PORT"
+fi
+
 # Trust the host's client certificate via the virtio-fs shared directory.
 # The host generates its cert in ~/.config/incus-spawn/vm/client.crt,
 # which is visible here at $SHARED_DIR/.config/incus-spawn/vm/client.crt.

--- a/src/main/java/dev/incusspawn/Environment.java
+++ b/src/main/java/dev/incusspawn/Environment.java
@@ -125,6 +125,10 @@ public final class Environment {
         return vmStateDir().resolve("vm.rest-uri");
     }
 
+    public static Path vmVsockSocket() {
+        return vmStateDir().resolve("vm.incus.sock");
+    }
+
     public static Path vmDiskImage() {
         return vmStateDir().resolve("disk.img");
     }

--- a/src/main/java/dev/incusspawn/incus/HttpsTransport.java
+++ b/src/main/java/dev/incusspawn/incus/HttpsTransport.java
@@ -60,6 +60,20 @@ class HttpsTransport implements IncusTransport {
                 var certDir = configPath.getParent();
                 var sslContext = buildSslContext(certDir, addr);
                 if (sslContext == null) continue;
+
+                // If a vsock Unix socket is available, route through it
+                // to bypass network-layer socket filters (Cisco AnyConnect)
+                var vsockSocket = Environment.vmVsockSocket();
+                if (Files.exists(vsockSocket)) {
+                    try {
+                        int proxyPort = UnixSocketProxy.startIfNeeded(vsockSocket);
+                        var vsockAddr = "https://localhost:" + proxyPort;
+                        return new HttpsTransport(vsockAddr, sslContext);
+                    } catch (IOException e) {
+                        System.err.println("Warning: vsock proxy failed, falling back to direct: " + e.getMessage());
+                    }
+                }
+
                 return new HttpsTransport(addr, sslContext);
             } catch (Exception ignored) {}
         }

--- a/src/main/java/dev/incusspawn/incus/UnixSocketProxy.java
+++ b/src/main/java/dev/incusspawn/incus/UnixSocketProxy.java
@@ -1,0 +1,80 @@
+package dev.incusspawn.incus;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.StandardProtocolFamily;
+import java.net.UnixDomainSocketAddress;
+import java.nio.ByteBuffer;
+import java.nio.channels.ServerSocketChannel;
+import java.nio.channels.SocketChannel;
+import java.nio.file.Path;
+
+/**
+ * Lightweight TCP-to-Unix-socket proxy. Listens on {@code localhost:<port>}
+ * and forwards each connection to a Unix domain socket (the vfkit vsock
+ * endpoint). This allows the standard {@link java.net.http.HttpClient} and
+ * WebSocket APIs to reach the Incus HTTPS API inside the VM without any
+ * TCP connection to the VM subnet — bypassing network-layer socket filters
+ * such as Cisco AnyConnect.
+ */
+public final class UnixSocketProxy {
+
+    private static volatile int activePort;
+
+    private UnixSocketProxy() {}
+
+    /**
+     * Start the proxy if not already running. Returns the localhost port.
+     */
+    public static synchronized int startIfNeeded(Path unixSocketPath) throws IOException {
+        if (activePort > 0) return activePort;
+
+        var serverChannel = ServerSocketChannel.open();
+        serverChannel.bind(new InetSocketAddress("localhost", 0));
+        int port = ((InetSocketAddress) serverChannel.getLocalAddress()).getPort();
+
+        Thread.ofVirtual().name("vsock-proxy-accept").start(() -> {
+            try {
+                while (serverChannel.isOpen()) {
+                    var client = serverChannel.accept();
+                    Thread.ofVirtual().name("vsock-proxy-conn").start(() ->
+                            bridge(client, unixSocketPath));
+                }
+            } catch (IOException e) {
+                if (serverChannel.isOpen()) {
+                    System.err.println("vsock proxy accept error: " + e.getMessage());
+                }
+            }
+        });
+
+        activePort = port;
+        return port;
+    }
+
+    private static void bridge(SocketChannel client, Path unixSocketPath) {
+        try (client) {
+            try (var upstream = SocketChannel.open(StandardProtocolFamily.UNIX)) {
+                upstream.connect(UnixDomainSocketAddress.of(unixSocketPath));
+                var t = Thread.ofVirtual().name("vsock-proxy-up").start(() ->
+                        pipe(upstream, client));
+                pipe(client, upstream);
+                t.join();
+            }
+        } catch (IOException | InterruptedException ignored) {
+        }
+    }
+
+    private static void pipe(SocketChannel from, SocketChannel to) {
+        var buf = ByteBuffer.allocate(16384);
+        try {
+            while (from.read(buf) >= 0) {
+                buf.flip();
+                while (buf.hasRemaining()) to.write(buf);
+                buf.clear();
+            }
+        } catch (IOException ignored) {
+        } finally {
+            try { to.shutdownOutput(); } catch (IOException ignored) {}
+        }
+    }
+}

--- a/src/main/java/dev/incusspawn/vm/IncusRemoteSetup.java
+++ b/src/main/java/dev/incusspawn/vm/IncusRemoteSetup.java
@@ -6,11 +6,15 @@ import java.io.IOException;
 import java.math.BigInteger;
 import java.net.InetSocketAddress;
 import java.net.Socket;
+import java.net.StandardProtocolFamily;
+import java.net.UnixDomainSocketAddress;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.nio.channels.SocketChannel;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.security.KeyPairGenerator;
 import java.security.SecureRandom;
@@ -70,8 +74,14 @@ public final class IncusRemoteSetup {
      * The VM must already be running with HTTPS enabled on port 8443.
      * The VM trusts our client cert via virtio-fs, so no trust token
      * exchange is needed.
+     * <p>
+     * When a vsock socket path is provided and the socket exists, the
+     * remote is configured to use a localhost proxy that tunnels through
+     * the Unix socket. This bypasses network-layer socket filters (e.g.
+     * Cisco AnyConnect) that block non-Apple-signed binaries from
+     * connecting to the VM subnet.
      */
-    public static void configure(String vmIp) throws IOException {
+    public static void configure(String vmIp, Path vsockSocket) throws IOException {
         System.err.println("Configuring Incus remote for VM at " + vmIp + "...");
 
         Files.createDirectories(Environment.incusConfigDir());
@@ -79,13 +89,23 @@ public final class IncusRemoteSetup {
 
         ensureCertExists();
 
-        System.err.println("  Waiting for Incus HTTPS API on " + vmIp + ":" + INCUS_PORT + "...");
-        if (!waitForPort(vmIp, INCUS_PORT, 60)) {
-            throw new IOException("Incus HTTPS API not reachable at " + vmIp + ":" + INCUS_PORT
-                    + " after 60s. Check 'isx vm console' for boot logs.");
+        // Try vsock first (bypasses Cisco AnyConnect socket filter), fall back to direct TCP
+        boolean useVsock = vsockSocket != null && waitForSocket(vsockSocket, 60);
+        if (useVsock) {
+            System.err.println("  Connected via vsock tunnel");
+        } else {
+            System.err.println("  Waiting for Incus HTTPS API on " + vmIp + ":" + INCUS_PORT + "...");
+            if (!waitForPort(vmIp, INCUS_PORT, 60)) {
+                throw new IOException("Incus HTTPS API not reachable at " + vmIp + ":" + INCUS_PORT
+                        + " after 60s. Check 'isx vm console' for boot logs.");
+            }
         }
 
-        saveServerCert(vmIp);
+        if (useVsock) {
+            saveServerCertViaVsock(vsockSocket);
+        } else {
+            saveServerCert(vmIp);
+        }
 
         writeClientConfig(vmIp);
 
@@ -93,7 +113,7 @@ public final class IncusRemoteSetup {
         System.err.println("  Incus remote '" + REMOTE_NAME + "' configured at " + baseUrl);
     }
 
-    public static void updateVmIp(String newIp) throws IOException {
+    public static void updateVmIp(String newIp, Path vsockSocket) throws IOException {
         writeClientConfig(newIp);
         System.err.println("  Updated Incus remote IP to " + newIp);
     }
@@ -189,6 +209,49 @@ public final class IncusRemoteSetup {
     }
 
     // --- Helpers ---
+
+    private static boolean waitForSocket(Path socketPath, int maxWaitSeconds) {
+        for (int i = 0; i < maxWaitSeconds; i++) {
+            if (Files.exists(socketPath)) {
+                try (var channel = SocketChannel.open(StandardProtocolFamily.UNIX)) {
+                    channel.connect(UnixDomainSocketAddress.of(socketPath));
+                    return true;
+                } catch (IOException ignored) {}
+            }
+            try { Thread.sleep(1000); } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return false;
+            }
+        }
+        return false;
+    }
+
+    private static void saveServerCertViaVsock(Path vsockSocket) {
+        try {
+            int proxyPort = dev.incusspawn.incus.UnixSocketProxy.startIfNeeded(vsockSocket);
+            var sslContext = SSLContext.getInstance("TLS");
+            var capturingTm = new CertCapturingTrustManager();
+            sslContext.init(null, new TrustManager[]{capturingTm}, null);
+
+            var client = HttpClient.newBuilder()
+                    .sslContext(sslContext)
+                    .connectTimeout(Duration.ofSeconds(5))
+                    .build();
+            var request = HttpRequest.newBuilder()
+                    .uri(URI.create("https://localhost:" + proxyPort + "/1.0"))
+                    .GET()
+                    .timeout(Duration.ofSeconds(5))
+                    .build();
+            client.send(request, HttpResponse.BodyHandlers.discarding());
+
+            if (capturingTm.captured != null) {
+                var certPath = Environment.incusServerCertsDir().resolve(REMOTE_NAME + ".crt");
+                Files.writeString(certPath, toPem("CERTIFICATE", capturingTm.captured.getEncoded()));
+            }
+        } catch (Exception e) {
+            System.err.println("  Warning: could not save server certificate via vsock: " + e.getMessage());
+        }
+    }
 
     private static boolean waitForPort(String host, int port, int maxWaitSeconds) {
         for (int i = 0; i < maxWaitSeconds; i++) {

--- a/src/main/java/dev/incusspawn/vm/VmManager.java
+++ b/src/main/java/dev/incusspawn/vm/VmManager.java
@@ -38,6 +38,7 @@ public final class VmManager {
     private static final String DEFAULT_DISK_SIZE = "60G";
     private static final String DEFAULT_SWAP_SIZE = "12G";
     private static final int GA_VSOCK_PORT = 1024;
+    private static final int INCUS_VSOCK_PORT = 8443;
 
     private static final String LATEST_KNOWN_RELEASE = "0.2.2";
     private static volatile String resolvedApplianceVersion;
@@ -412,16 +413,17 @@ public final class VmManager {
         }
         System.err.println("  VM IP: " + vmIp);
 
+        var vsockSocket = Environment.vmVsockSocket();
         if (!IncusRemoteSetup.isConfigured()) {
             try {
-                IncusRemoteSetup.configure(vmIp);
+                IncusRemoteSetup.configure(vmIp, vsockSocket);
             } catch (IOException e) {
                 System.err.println("Failed to configure Incus remote: " + e.getMessage());
                 return false;
             }
         } else {
             try {
-                IncusRemoteSetup.updateVmIp(vmIp);
+                IncusRemoteSetup.updateVmIp(vmIp, vsockSocket);
             } catch (IOException e) {
                 System.err.println("Warning: could not update VM IP: " + e.getMessage());
             }
@@ -529,6 +531,8 @@ public final class VmManager {
                 "--device", "virtio-serial,logFilePath=" + Environment.vmLogFile(),
                 "--device", "virtio-fs,sharedDir=" + System.getProperty("user.home") + ",mountTag=hostfs",
                 "--timesync", "vsockPort=" + GA_VSOCK_PORT,
+                "--device", "virtio-vsock,port=" + INCUS_VSOCK_PORT
+                        + ",socketURL=" + Environment.vmVsockSocket() + ",connect",
                 "--restful-uri", "tcp://localhost:" + restPort
         ));
 
@@ -757,6 +761,7 @@ public final class VmManager {
                 + " isx.mitm_port=" + mitmPort()
                 + " isx.time=" + (System.currentTimeMillis() / 1000)
                 + " isx.ga_vsock=" + GA_VSOCK_PORT
+                + " isx.vsock_incus=" + INCUS_VSOCK_PORT
                 + " isx.proxy=remote"
                 + " isx.shared=/host";
     }
@@ -817,6 +822,7 @@ public final class VmManager {
     private static void cleanupStaleFiles() {
         try { Files.deleteIfExists(Environment.vmPidFile()); } catch (IOException ignored) {}
         try { Files.deleteIfExists(Environment.vmRestUriFile()); } catch (IOException ignored) {}
+        try { Files.deleteIfExists(Environment.vmVsockSocket()); } catch (IOException ignored) {}
     }
 
     private static String humanSize(long bytes) {


### PR DESCRIPTION
## Problem

On macOS, Cisco AnyConnect installs a network system extension (`com.cisco.anyconnect.macos.acsockext`) that acts as a socket filter **even when the VPN is disconnected**. This filter blocks non-Apple-signed binaries from making TCP connections to the VM subnet (`192.168.64.0/24`).

Specifically:
- `curl` (Apple platform-signed) → works fine to `https://192.168.64.2:8443`
- `incus` (Go, ad-hoc signed) → `dial tcp 192.168.64.2:8443: connect: no route to host`
- `isx` (GraalVM native, ad-hoc signed) → same failure
- `python3` (Homebrew, ad-hoc signed) → `OSError: [Errno 65] No route to host`

Localhost connections from all binaries work fine — only the VM subnet is filtered.

The socket filter cannot be disabled without a reboot (it stays `[activated enabled]` until the macOS kernel unloads it), and many corporate environments prevent users from removing it entirely.

## Solution

vsock is a direct host↔VM communication channel that bypasses the IP network stack entirely. AnyConnect's `AF_INET` socket filter cannot intercept `AF_VSOCK` connections.

### VM-side
- Add `socat` to the appliance packages (~80KB)
- After Incus starts, `socat` listens on vsock port 8443 and forwards to `localhost:8443` (the Incus HTTPS API)
- Controlled via kernel cmdline parameter `isx.vsock_incus=8443`

### Host-side
- vfkit gets `--device virtio-vsock,port=8443,socketURL=~/.local/state/incus-spawn/vm.incus.sock,connect` which exposes the VM's vsock port as a Unix domain socket on the host
- `UnixSocketProxy` (new class, ~70 lines) is a lightweight localhost TCP proxy that bridges `localhost:<freePort>` → the Unix socket, using virtual threads
- `HttpsTransport.fromClientConfig()` detects the vsock socket and routes through the proxy automatically
- `IncusRemoteSetup.configure()` tries vsock first, falls back to direct TCP

### Backward compatibility
- Linux: unchanged (uses `UnixSocketTransport`, never hits this path)
- macOS without AnyConnect: vsock tunnel works identically, just a different path to the same API
- If the vsock socket doesn't exist or connection fails, falls back to direct TCP

## Files changed

| File | Change |
|------|--------|
| `appliance/build.sh` | Add `socat` package |
| `appliance/.../incus-spawn-vm-init` | vsock→TCP forwarder after Incus starts |
| `Environment.java` | `vmVsockSocket()` path |
| `VmManager.java` | vsock port constant, kernel param, vfkit device, cleanup |
| `IncusRemoteSetup.java` | `waitForSocket()`, vsock-aware `configure()` |
| `HttpsTransport.java` | Auto-detect and route through vsock proxy |
| `UnixSocketProxy.java` | **New**: localhost TCP ↔ Unix socket bridge |

## Testing

Verified that:
- The Cisco socket filter blocks Java/Go/Python TCP to `192.168.64.2:8443`
- Localhost TCP from all binaries works (the proxy path)
- The vsock kernel config (`CONFIG_VSOCKETS=y`, `CONFIG_VIRTIO_VSOCKETS=y`) is already in the appliance kernel

Note: Could not build locally (requires Java 25), so this needs CI or manual build verification.