### PR TITLE
Fix install.sh: skip brew block entirely when Homebrew is absent

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -137,8 +137,9 @@ fi
 install -m 755 "$SCRIPT_DIR/src/main/resources/git-remote-isx" "$INSTALL_DIR/git-remote-isx"
 
 # ── Replace Homebrew installation if present ─────────────────────────────
-BREW_ISX="$(brew --prefix 2>/dev/null || true)/bin/isx"
-if [ -x "$BREW_ISX" ] && [ "$INSTALL_DIR/$BINARY_NAME" != "$BREW_ISX" ]; then
+if command -v brew >/dev/null 2>&1 \
+    && BREW_ISX="$(brew --prefix)/bin/isx" \
+    && [ -x "$BREW_ISX" ] && [ "$INSTALL_DIR/$BINARY_NAME" != "$BREW_ISX" ]; then
     echo "Homebrew installation detected at $BREW_ISX"
     echo "Replacing with locally built binary..."
     rm -f "$BREW_ISX"


### PR DESCRIPTION
## Summary

- PR #222 fixed the `set -e` abort when `brew` is absent, but `|| true` causes `brew --prefix` to output nothing, setting `BREW_ISX` to `/bin/isx` — a bogus path that could match an unrelated binary.
- Guard the entire block with `command -v brew` so it is skipped cleanly when Homebrew is not installed.

## Test plan

- [ ] Run `./install.sh` on a machine without Homebrew — the brew block is skipped, script exits 0
- [ ] Run on a machine with Homebrew and an existing brew-installed `isx` — binary is still replaced as before