### PR TITLE
Add default action support for TUI instances

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,8 @@ Package deduplication: `BuildCommand` collects all ancestor packages and subtrac
 
 Resolution via `ToolDefLoader` (later overrides earlier): built-in YAML -> user YAML -> search paths -> project-local YAML. Java CDI tools are used as fallback when no YAML tool matches.
 
+Tools can declare runtime actions (`ActionEntry`) shown in the TUI's F9 actions menu. Both YAML tools (via `actions:` in the YAML) and Java/CDI tools (via `ToolSetup.actions()`) can contribute actions. Templates select a default action via `ImageDef.defaultAction` (`default-action` in YAML), which is run on Enter in the TUI. The reference format is `tool-name` (single action) or `tool-name:action-id` (multiple actions). `default-action` inherits through the parent chain (child overrides parent) and is intentionally excluded from `contentFingerprint()` so changing it doesn't trigger template rebuilds.
+
 **Important**: Built-in YAML files are listed in a hardcoded `BUILTIN_FILES` constant (not classpath scanning) because GraalVM native image makes classpath directory listing unreliable. When adding a built-in image or tool, you must update the corresponding `BUILTIN_FILES` list.
 
 ### Incus Interaction

--- a/README.md
+++ b/README.md
@@ -459,7 +459,7 @@ Pass parameter values using the map form in image definitions (the `idea-backend
 
 ### Tool Actions
 
-Tools can declare runtime actions that appear in the TUI (press **F9** on a running instance, or **Enter** to run the template's default action). Three types: `url` (opens in browser), `command` (runs on the host), `copy-to-clipboard`. Actions support template variables (`${ip}`, `${name}`, `${repo_name}`, `${repo_path}`) and `expand: repos` to generate one action per declared repository:
+Tools can declare runtime actions that appear in the TUI (press **F9** on a running instance, or **Enter** to run the template's default action). Four types: `url` (opens in browser), `command` (runs on the host), `shell` (runs inside the container as an interactive terminal command), `copy-to-clipboard`. Actions support template variables (`${ip}`, `${name}`, `${repo_name}`, `${repo_path}`) and `expand: repos` to generate one action per declared repository:
 
 ```yaml
 actions:

--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ Image schema fields (all optional except `name`):
 - `host-resources` -- host files/directories to share with containers (see below)
 - `workdir` -- default working directory when shelling into a container (see below)
 - `shell-command` -- command to run instead of the login shell (see below)
+- `default-action` -- tool action to run when pressing Enter on an instance in the TUI (see below)
 - `description` -- human-readable description for the TUI
 
 ```shell
@@ -267,6 +268,7 @@ shell-command: claude
 
 - `workdir` -- the directory to `cd` into when opening a shell. Defaults to the first declared repo's path if omitted.
 - `shell-command` -- a command to run instead of the default login shell (e.g. `claude` or `pi`). Falls back to `bash --login` if it fails to start.
+- `default-action` -- a tool action to run when pressing Enter on an instance in the TUI. The value is a tool name (e.g. `claude`) if the tool has a single action, or `tool:action-id` (e.g. `claude:launch`) if the tool has multiple actions. When set, Enter runs the action and F2 opens a shell; when unset, Enter opens a shell. Inherits from parent templates; a child overrides the parent's default action.
 
 ### Pi Coding Agent
 
@@ -457,7 +459,7 @@ Pass parameter values using the map form in image definitions (the `idea-backend
 
 ### Tool Actions
 
-Tools can declare runtime actions that appear in the TUI (press **F9** on a running instance). Three types: `url` (opens in browser), `command` (runs on the host), `copy-to-clipboard`. Actions support template variables (`${ip}`, `${name}`, `${repo_name}`, `${repo_path}`) and `expand: repos` to generate one action per declared repository:
+Tools can declare runtime actions that appear in the TUI (press **F9** on a running instance, or **Enter** to run the template's default action). Three types: `url` (opens in browser), `command` (runs on the host), `copy-to-clipboard`. Actions support template variables (`${ip}`, `${name}`, `${repo_name}`, `${repo_path}`) and `expand: repos` to generate one action per declared repository:
 
 ```yaml
 actions:

--- a/src/main/java/dev/incusspawn/command/BuildCommand.java
+++ b/src/main/java/dev/incusspawn/command/BuildCommand.java
@@ -1371,6 +1371,8 @@ public class BuildCommand extends BaseCommand {
         var effectiveDefaultAction = resolveEffectiveDefaultAction(imageDef, defs);
         if (effectiveDefaultAction != null) {
             incus.configSet(buildName, Metadata.DEFAULT_ACTION, effectiveDefaultAction);
+        } else {
+            incus.configUnset(buildName, Metadata.DEFAULT_ACTION);
         }
     }
 
@@ -1392,7 +1394,7 @@ public class BuildCommand extends BaseCommand {
     static String resolveEffectiveDefaultAction(ImageDef imageDef, Map<String, ImageDef> defs) {
         var current = imageDef;
         while (current != null) {
-            if (current.getDefaultAction() != null && !current.getDefaultAction().isBlank()) {
+            if (current.getDefaultAction() != null) {
                 return current.getDefaultAction();
             }
             if (current.isRoot() || current.getParent() == null) break;

--- a/src/main/java/dev/incusspawn/command/BuildCommand.java
+++ b/src/main/java/dev/incusspawn/command/BuildCommand.java
@@ -1368,6 +1368,10 @@ public class BuildCommand extends BaseCommand {
         if (imageDef.getShellCommand() != null && !imageDef.getShellCommand().isBlank()) {
             incus.configSet(buildName, Metadata.SHELL_COMMAND, imageDef.getShellCommand());
         }
+        var effectiveDefaultAction = resolveEffectiveDefaultAction(imageDef, defs);
+        if (effectiveDefaultAction != null) {
+            incus.configSet(buildName, Metadata.DEFAULT_ACTION, effectiveDefaultAction);
+        }
     }
 
     static String resolveEffectiveWorkdir(ImageDef imageDef, Map<String, ImageDef> defs) {
@@ -1378,6 +1382,18 @@ public class BuildCommand extends BaseCommand {
         while (current != null) {
             if (!current.getRepos().isEmpty()) {
                 return expandHome(current.getRepos().get(0).getPath());
+            }
+            if (current.isRoot() || current.getParent() == null) break;
+            current = defs.get(current.getParent());
+        }
+        return null;
+    }
+
+    static String resolveEffectiveDefaultAction(ImageDef imageDef, Map<String, ImageDef> defs) {
+        var current = imageDef;
+        while (current != null) {
+            if (current.getDefaultAction() != null && !current.getDefaultAction().isBlank()) {
+                return current.getDefaultAction();
             }
             if (current.isRoot() || current.getParent() == null) break;
             current = defs.get(current.getParent());

--- a/src/main/java/dev/incusspawn/command/ListCommand.java
+++ b/src/main/java/dev/incusspawn/command/ListCommand.java
@@ -2584,7 +2584,7 @@ public class ListCommand extends BaseCommand {
         var setup = toolDefLoader.find(toolName);
         if (setup instanceof YamlToolSetup yts) {
             for (var entry : yts.toolDef().getActions()) {
-                if ("command".equals(entry.getType())) {
+                if ("shell".equals(entry.getType())) {
                     if (actionId == null || actionId.equals(entry.getId())) {
                         return entry.getCommand();
                     }
@@ -2597,7 +2597,7 @@ public class ListCommand extends BaseCommand {
             for (var cdiTool : cdiTools) {
                 if (toolName.equals(cdiTool.name())) {
                     for (var entry : cdiTool.actions()) {
-                        if ("command".equals(entry.getType())) {
+                        if ("shell".equals(entry.getType())) {
                             if (actionId == null || actionId.equals(entry.getId())) {
                                 return entry.getCommand();
                             }

--- a/src/main/java/dev/incusspawn/command/ListCommand.java
+++ b/src/main/java/dev/incusspawn/command/ListCommand.java
@@ -25,6 +25,7 @@ import dev.incusspawn.tui.BackgroundTaskManager;
 import dev.incusspawn.tui.InstanceLockManager;
 import dev.incusspawn.tool.ToolAction;
 import dev.incusspawn.tool.ToolDefLoader;
+import dev.incusspawn.tool.ToolSetup;
 import dev.incusspawn.tool.YamlToolAction;
 import dev.incusspawn.tool.YamlToolSetup;
 import dev.incusspawn.tui.ShiftTabBindings;
@@ -83,6 +84,7 @@ public class ListCommand extends BaseCommand {
     private IncusClient incus;
 
     private ToolDefLoader toolDefLoader;
+    private java.util.List<ToolSetup> cdiTools;
 
     private BackgroundTaskManager backgroundTasks;
 
@@ -136,12 +138,15 @@ public class ListCommand extends BaseCommand {
     private ActionContext actionsContext;
     // Actions cache (computed once per data refresh, not per render)
     private java.util.Map<String, java.util.List<ToolAction>> actionsCache = new java.util.HashMap<>();
+    // Default action reference per instance (from ImageDef default-action field)
+    private java.util.Map<String, String> defaultActionRef = new java.util.HashMap<>();
 
     private boolean deferredBuildForBranch;
 
-    private enum PendingAction { NONE, SHELL, BRANCH, BUILD_TEMPLATE, BUILD_THEN_BRANCH, EDIT_TEMPLATE, EXECUTE_ACTION }
+    private enum PendingAction { NONE, SHELL, SHELL_WITH_COMMAND, BRANCH, BUILD_TEMPLATE, BUILD_THEN_BRANCH, EDIT_TEMPLATE, EXECUTE_ACTION }
     private PendingAction pendingAction = PendingAction.NONE;
     private String pendingActionTarget;
+    private String pendingShellCommand;
     private ToolAction pendingToolAction;
     private ActionContext pendingToolActionContext;
     // After returning from a shell/branch, focus this instance in the instances panel
@@ -181,6 +186,7 @@ public class ListCommand extends BaseCommand {
     protected CommandResult doExecute() {
         this.incus = RuntimeServices.incus();
         this.toolDefLoader = RuntimeServices.toolDefLoader();
+        this.cdiTools = RuntimeServices.toolSetups();
         this.backgroundTasks = RuntimeServices.backgroundTasks();
         this.lockManager = RuntimeServices.lockManager();
         reloadData();
@@ -273,6 +279,10 @@ public class ListCommand extends BaseCommand {
                     returnToInstance = pendingActionTarget;
                     shellInto(pendingActionTarget);
                 }
+                case SHELL_WITH_COMMAND -> {
+                    returnToInstance = pendingActionTarget;
+                    shellInto(pendingActionTarget, pendingShellCommand);
+                }
                 case BRANCH -> {
                     returnToInstance = pendingActionTarget;
                     try {
@@ -360,7 +370,7 @@ public class ListCommand extends BaseCommand {
                                     inst.created, inst.runtime, inst.parent, inst.limitsCpu,
                                     inst.limitsMemory, inst.rootSize, inst.ipv4, inst.networkMode,
                                     inst.architecture, inst.buildVersion, inst.definitionSha,
-                                    inst.type, inst.buildSourceJson, "")
+                                    inst.type, inst.buildSourceJson, "", inst.defaultAction)
                             : inst)
                     .toList();
         }
@@ -421,11 +431,15 @@ public class ListCommand extends BaseCommand {
         // Instance panel: exclude template instances (they're shown in the template panel)
         entries = new ArrayList<>();
         actionsCache = new java.util.HashMap<>();
+        defaultActionRef = new java.util.HashMap<>();
         for (var inst : allInstances) {
             if (!templateNames.contains(inst.name)) {
                 entries.add(inst);
-                // Pre-compute actions for each instance
                 actionsCache.put(inst.name, resolveActionsForInstance(inst));
+                var defAction = resolveDefaultActionFromInstanceMetadata(inst);
+                if (defAction != null) {
+                    defaultActionRef.put(inst.name, defAction);
+                }
             }
         }
         buildRowData();
@@ -629,11 +643,16 @@ public class ListCommand extends BaseCommand {
             mode = Mode.CONFIRM_DELETE;
             return true;
         }
-        if (key.isKey(KeyCode.ENTER) || key.isKey(KeyCode.F2)) {
+        if (key.isKey(KeyCode.F2)) {
             if (showProxyErrorIfNeeded(selected.name)) return true;
             pendingAction = PendingAction.SHELL;
             pendingActionTarget = selected.name;
             tui.quit();
+            return true;
+        }
+        if (key.isKey(KeyCode.ENTER)) {
+            if (showProxyErrorIfNeeded(selected.name)) return true;
+            if (dispatchDefaultAction(selected)) tui.quit();
             return true;
         }
         if (key.isKey(KeyCode.F4)) {
@@ -1817,7 +1836,7 @@ public class ListCommand extends BaseCommand {
             mode = Mode.BROWSE;
             return true;
         }
-        if (key.isKey(KeyCode.F2) || key.isKey(KeyCode.ENTER)) {
+        if (key.isKey(KeyCode.F2)) {
             var selected = selectedEntry(instanceTableState);
             if (selected != null) {
                 if (showProxyErrorIfNeeded(selected.name)) return true;
@@ -1825,6 +1844,15 @@ public class ListCommand extends BaseCommand {
                 pendingActionTarget = selected.name;
                 mode = Mode.BROWSE;
                 tui.quit();
+            }
+            return true;
+        }
+        if (key.isKey(KeyCode.ENTER)) {
+            var selected = selectedEntry(instanceTableState);
+            if (selected != null) {
+                if (showProxyErrorIfNeeded(selected.name)) return true;
+                mode = Mode.BROWSE;
+                if (dispatchDefaultAction(selected)) tui.quit();
             }
             return true;
         }
@@ -1890,8 +1918,7 @@ public class ListCommand extends BaseCommand {
         }
         if (key.isKey(KeyCode.ENTER)) {
             var action = actionsList.get(actionsSelectedIndex);
-            // Commands need deferred execution (quit TUI, run, optionally wait for key)
-            if (action instanceof YamlToolAction yamlAction && yamlAction.needsDeferredExecution()) {
+            if (action.needsDeferredExecution()) {
                 pendingAction = PendingAction.EXECUTE_ACTION;
                 pendingToolAction = action;
                 pendingToolActionContext = actionsContext;
@@ -1937,6 +1964,7 @@ public class ListCommand extends BaseCommand {
                 Line.styled("", Style.EMPTY),
                 Line.styled("Keyboard shortcuts:", Style.EMPTY.fg(ModalRenderer.FG).bg(ModalRenderer.BG)),
                 Line.styled("", Style.EMPTY),
+                shortcutRow("Enter", "Default instance action", null, null),
                 shortcutRow("Tab", "Switch panels", "⇧Tab", "Reverse"),
                 shortcutRow("F1", "This dialog", null, null),
                 shortcutRow("F2", "Shell into instance", null, null),
@@ -2402,30 +2430,174 @@ public class ListCommand extends BaseCommand {
         var actions = new ArrayList<ToolAction>();
         var tools = collectInstalledTools(instance);
         java.util.List<ActionContext.RepoInfo> repos = null;
+        var handledTools = new java.util.HashSet<String>();
 
         // YAML-declared actions
         for (var toolName : tools) {
             var setup = toolDefLoader.find(toolName);
             if (setup instanceof YamlToolSetup yts) {
                 var toolDef = yts.toolDef();
+                if (!toolDef.getActions().isEmpty()) {
+                    handledTools.add(toolName);
+                }
                 for (var entry : toolDef.getActions()) {
                     if (YamlToolAction.EXPAND_REPOS.equals(entry.getExpand())) {
-                        // Expand per repo (compute repos once)
                         if (repos == null) repos = collectRepos(instance);
                         for (var repo : repos) {
-                            var action = new YamlToolAction(toolName, entry, repo);
-                            addActionIfAllowed(actions, action, instance);
+                            addActionIfAllowed(actions,
+                                    new YamlToolAction(toolName, entry, repo), instance);
                         }
                     } else {
-                        // Single action
-                        var action = new YamlToolAction(toolName, entry);
-                        addActionIfAllowed(actions, action, instance);
+                        addActionIfAllowed(actions,
+                                new YamlToolAction(toolName, entry), instance);
+                    }
+                }
+            }
+        }
+
+        // CDI tool actions (for tools not already handled by YAML)
+        if (cdiTools != null) {
+            for (var cdiTool : cdiTools) {
+                if (tools.contains(cdiTool.name()) && !handledTools.contains(cdiTool.name())) {
+                    for (var entry : cdiTool.actions()) {
+                        if (YamlToolAction.EXPAND_REPOS.equals(entry.getExpand())) {
+                            if (repos == null) repos = collectRepos(instance);
+                            for (var repo : repos) {
+                                addActionIfAllowed(actions,
+                                        new YamlToolAction(cdiTool.name(), entry, repo), instance);
+                            }
+                        } else {
+                            addActionIfAllowed(actions,
+                                    new YamlToolAction(cdiTool.name(), entry), instance);
+                        }
                     }
                 }
             }
         }
 
         return actions;
+    }
+
+    private String resolveDefaultActionFromInstanceMetadata(InstanceInfo instance) {
+        if (instance.defaultAction != null && !instance.defaultAction.isEmpty()) {
+            return instance.defaultAction;
+        }
+        return null;
+    }
+
+    private java.util.Optional<ToolAction> findDefaultAction(String ref, InstanceInfo instance) {
+        String toolName;
+        String actionId;
+        int colon = ref.indexOf(':');
+        if (colon >= 0) {
+            toolName = ref.substring(0, colon);
+            actionId = ref.substring(colon + 1);
+        } else {
+            toolName = ref;
+            actionId = null;
+        }
+
+        var actions = getActionsForInstance(instance);
+        var matching = actions.stream()
+                .filter(a -> toolName.equals(a.toolName()))
+                .toList();
+
+        if (matching.isEmpty()) {
+            statusMessage = "default-action '" + ref + "': tool not found";
+            return java.util.Optional.empty();
+        }
+
+        if (actionId != null) {
+            var found = matching.stream()
+                    .filter(a -> a.id().map(actionId::equals).orElse(false))
+                    .findFirst();
+            if (found.isEmpty()) {
+                statusMessage = "default-action '" + ref + "': action id not found";
+            }
+            return found;
+        }
+
+        if (matching.size() == 1) return java.util.Optional.of(matching.get(0));
+
+        statusMessage = "default-action '" + ref + "': ambiguous, use tool:action-id";
+        return java.util.Optional.empty();
+    }
+
+    private boolean dispatchDefaultAction(InstanceInfo selected) {
+        var ref = defaultActionRef.get(selected.name);
+        if (ref == null || ref.isBlank()) {
+            pendingAction = PendingAction.SHELL;
+            pendingActionTarget = selected.name;
+            return true;
+        }
+        var result = findDefaultAction(ref, selected);
+        if (result.isEmpty()) {
+            return false;
+        }
+        var defAction = result.get();
+        var cmd = defAction.shellCommand();
+        if (cmd.isPresent()) {
+            pendingAction = PendingAction.SHELL_WITH_COMMAND;
+            pendingShellCommand = cmd.get();
+            pendingActionTarget = selected.name;
+            return true;
+        }
+        if (defAction.needsDeferredExecution()) {
+            pendingAction = PendingAction.EXECUTE_ACTION;
+            pendingToolAction = defAction;
+            pendingToolActionContext = buildActionContext(selected);
+            pendingActionTarget = selected.name;
+            return true;
+        }
+        var execResult = defAction.execute(buildActionContext(selected));
+        statusMessage = execResult.message();
+        return false;
+    }
+
+    private String resolveDefaultCommandFromTemplate(String templateName) {
+        var refValue = incus.configGet(templateName, Metadata.DEFAULT_ACTION);
+        var ref = (refValue == null || refValue.isBlank()) ? null : refValue;
+        if (ref == null) return null;
+
+        String toolName;
+        String actionId;
+        int colon = ref.indexOf(':');
+        if (colon >= 0) {
+            toolName = ref.substring(0, colon);
+            actionId = ref.substring(colon + 1);
+        } else {
+            toolName = ref;
+            actionId = null;
+        }
+
+        // Check YAML tools
+        var setup = toolDefLoader.find(toolName);
+        if (setup instanceof YamlToolSetup yts) {
+            for (var entry : yts.toolDef().getActions()) {
+                if ("command".equals(entry.getType())) {
+                    if (actionId == null || actionId.equals(entry.getId())) {
+                        return entry.getCommand();
+                    }
+                }
+            }
+        }
+
+        // Check CDI tools
+        if (cdiTools != null) {
+            for (var cdiTool : cdiTools) {
+                if (toolName.equals(cdiTool.name())) {
+                    for (var entry : cdiTool.actions()) {
+                        if ("command".equals(entry.getType())) {
+                            if (actionId == null || actionId.equals(entry.getId())) {
+                                return entry.getCommand();
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        return null;
     }
 
     private java.util.Set<String> collectInstalledTools(InstanceInfo instance) {
@@ -3127,7 +3299,14 @@ public class ListCommand extends BaseCommand {
 
         System.out.println("Branch '" + name + "' is ready.");
         System.out.println("Connecting to " + name + "...\n");
-        incus.interactiveShell(name, "agentuser", prefetched.toShellPrep());
+        var shellPrep = prefetched.toShellPrep();
+        var defaultCmd = resolveDefaultCommandFromTemplate(source);
+        if (defaultCmd != null) {
+            shellPrep = new IncusClient.ShellPrep(
+                    shellPrep.workdir(), defaultCmd,
+                    false, shellPrep.subnetDiagnostic(), shellPrep.terminfoHandled());
+        }
+        incus.interactiveShell(name, "agentuser", shellPrep);
         System.out.println();
     }
 
@@ -3236,6 +3415,10 @@ public class ListCommand extends BaseCommand {
     }
 
     private void shellInto(String name) {
+        shellInto(name, null);
+    }
+
+    private void shellInto(String name, String commandOverride) {
         if ("Stopped".equalsIgnoreCase(incus.getInstanceStatus(name))) {
             System.out.println("Starting " + name + "...");
             HostResourceSetup.removeStaleDevices(incus, name);
@@ -3244,7 +3427,15 @@ public class ListCommand extends BaseCommand {
         }
         checkGuiHealth(name);
         System.out.println("Connecting to " + name + "...\n");
-        incus.interactiveShell(name, "agentuser");
+        if (commandOverride != null) {
+            var prep = IncusClient.ShellPrep.from(incus, name);
+            var withCommand = new IncusClient.ShellPrep(
+                    prep.workdir(), commandOverride,
+                    false, prep.subnetDiagnostic(), prep.terminfoHandled());
+            incus.interactiveShell(name, "agentuser", withCommand);
+        } else {
+            incus.interactiveShell(name, "agentuser");
+        }
         System.out.println();
     }
 
@@ -3294,7 +3485,8 @@ public class ListCommand extends BaseCommand {
                         type,
                         Metadata.TYPE_BASE.equals(type)
                                 ? configVal(config, Metadata.BUILD_SOURCE, "") : "",
-                        configVal(config, Metadata.PENDING_OP, "")));
+                        configVal(config, Metadata.PENDING_OP, ""),
+                        configVal(config, Metadata.DEFAULT_ACTION, "")));
             }
             return entryList;
         } catch (Exception e) {
@@ -3333,5 +3525,6 @@ public class ListCommand extends BaseCommand {
                                 String limitsCpu, String limitsMemory, String rootSize,
                                 String ipv4, String networkMode, String architecture,
                                 String buildVersion, String definitionSha,
-                                String type, String buildSourceJson, String pendingOp) {}
+                                String type, String buildSourceJson, String pendingOp,
+                                String defaultAction) {}
 }

--- a/src/main/java/dev/incusspawn/command/ListCommand.java
+++ b/src/main/java/dev/incusspawn/command/ListCommand.java
@@ -2469,16 +2469,19 @@ public class ListCommand extends BaseCommand {
     }
 
     private String resolveDefaultActionRef(InstanceInfo instance) {
-        var parent = instance.parent;
-        if (parent != null && !parent.isEmpty() && !"-".equals(parent)) {
-            var chain = getInheritanceChain(parent);
+        // Walk the template YAML chain (child wins over parent).
+        var chain = getInheritanceChain(instance.parent);
+        if (!chain.isEmpty()) {
             for (int i = chain.size() - 1; i >= 0; i--) {
                 var def = chain.get(i);
-                if (def.getDefaultAction() != null && !def.getDefaultAction().isBlank()) {
+                if (def.getDefaultAction() != null) {
                     return def.getDefaultAction();
                 }
             }
+            return null;
         }
+        // YAML definitions not on disk (e.g. user deleted them after building the template):
+        // fall back to the snapshot stored in Incus metadata at build time.
         if (instance.defaultAction != null && !instance.defaultAction.isEmpty()) {
             return instance.defaultAction;
         }
@@ -2508,13 +2511,18 @@ public class ListCommand extends BaseCommand {
         }
 
         if (actionId != null) {
-            var found = matching.stream()
+            var withId = matching.stream()
                     .filter(a -> a.id().map(actionId::equals).orElse(false))
-                    .findFirst();
-            if (found.isEmpty()) {
+                    .toList();
+            if (withId.isEmpty()) {
                 statusMessage = "default-action '" + ref + "': action id not found";
+                return java.util.Optional.empty();
             }
-            return found;
+            if (withId.size() > 1) {
+                statusMessage = "default-action '" + ref + "': multiple actions match";
+                return java.util.Optional.empty();
+            }
+            return java.util.Optional.of(withId.get(0));
         }
 
         if (matching.size() == 1) return java.util.Optional.of(matching.get(0));
@@ -2558,8 +2566,22 @@ public class ListCommand extends BaseCommand {
     }
 
     private String resolveDefaultCommandFromTemplate(String templateName) {
-        var refValue = incus.configGet(templateName, Metadata.DEFAULT_ACTION);
-        var ref = (refValue == null || refValue.isBlank()) ? null : refValue;
+        String ref = null;
+        // Walk the template YAML chain (child wins over parent).
+        var chain = getInheritanceChain(templateName);
+        if (!chain.isEmpty()) {
+            for (int i = chain.size() - 1; i >= 0; i--) {
+                var def = chain.get(i);
+                if (def.getDefaultAction() != null) {
+                    ref = def.getDefaultAction();
+                    break;
+                }
+            }
+        } else {
+            // YAML definitions not on disk: fall back to Incus metadata snapshot.
+            var refValue = incus.configGet(templateName, Metadata.DEFAULT_ACTION);
+            ref = (refValue == null || refValue.isBlank()) ? null : refValue;
+        }
         if (ref == null) return null;
 
         String toolName;
@@ -2600,7 +2622,10 @@ public class ListCommand extends BaseCommand {
             }
         }
 
-        if (matching.size() == 1) return matching.get(0).getCommand();
+        if (matching.size() == 1) {
+            var cmd = matching.get(0).getCommand();
+            return (cmd == null || cmd.isBlank()) ? null : cmd;
+        }
         return null;
     }
 

--- a/src/main/java/dev/incusspawn/command/ListCommand.java
+++ b/src/main/java/dev/incusspawn/command/ListCommand.java
@@ -436,7 +436,7 @@ public class ListCommand extends BaseCommand {
             if (!templateNames.contains(inst.name)) {
                 entries.add(inst);
                 actionsCache.put(inst.name, resolveActionsForInstance(inst));
-                var defAction = resolveDefaultActionFromInstanceMetadata(inst);
+                var defAction = resolveDefaultActionRef(inst);
                 if (defAction != null) {
                     defaultActionRef.put(inst.name, defAction);
                 }
@@ -2478,7 +2478,17 @@ public class ListCommand extends BaseCommand {
         return actions;
     }
 
-    private String resolveDefaultActionFromInstanceMetadata(InstanceInfo instance) {
+    private String resolveDefaultActionRef(InstanceInfo instance) {
+        var parent = instance.parent;
+        if (parent != null && !parent.isEmpty() && !"-".equals(parent)) {
+            var chain = getInheritanceChain(parent);
+            for (int i = chain.size() - 1; i >= 0; i--) {
+                var def = chain.get(i);
+                if (def.getDefaultAction() != null && !def.getDefaultAction().isBlank()) {
+                    return def.getDefaultAction();
+                }
+            }
+        }
         if (instance.defaultAction != null && !instance.defaultAction.isEmpty()) {
             return instance.defaultAction;
         }

--- a/src/main/java/dev/incusspawn/command/ListCommand.java
+++ b/src/main/java/dev/incusspawn/command/ListCommand.java
@@ -1918,27 +1918,8 @@ public class ListCommand extends BaseCommand {
         }
         if (key.isKey(KeyCode.ENTER)) {
             var action = actionsList.get(actionsSelectedIndex);
-            var cmd = action.shellCommand();
-            if (cmd.isPresent()) {
-                pendingAction = PendingAction.SHELL_WITH_COMMAND;
-                pendingShellCommand = cmd.get();
-                pendingActionTarget = actionsContext.instanceName();
-                mode = Mode.BROWSE;
-                tui.quit();
-                return true;
-            }
-            if (action.needsDeferredExecution()) {
-                pendingAction = PendingAction.EXECUTE_ACTION;
-                pendingToolAction = action;
-                pendingToolActionContext = actionsContext;
-                mode = Mode.BROWSE;
-                tui.quit();
-                return true;
-            }
-            // Inline execution for URL and copy-to-clipboard
-            var result = action.execute(actionsContext);
-            statusMessage = result.message();
             mode = Mode.BROWSE;
+            if (dispatchAction(action, actionsContext)) tui.quit();
             return true;
         }
         return false;
@@ -2553,22 +2534,25 @@ public class ListCommand extends BaseCommand {
         if (result.isEmpty()) {
             return false;
         }
-        var defAction = result.get();
-        var cmd = defAction.shellCommand();
+        return dispatchAction(result.get(), buildActionContext(selected));
+    }
+
+    private boolean dispatchAction(ToolAction action, ActionContext context) {
+        var cmd = action.shellCommand(context);
         if (cmd.isPresent()) {
             pendingAction = PendingAction.SHELL_WITH_COMMAND;
             pendingShellCommand = cmd.get();
-            pendingActionTarget = selected.name;
+            pendingActionTarget = context.instanceName();
             return true;
         }
-        if (defAction.needsDeferredExecution()) {
+        if (action.needsDeferredExecution()) {
             pendingAction = PendingAction.EXECUTE_ACTION;
-            pendingToolAction = defAction;
-            pendingToolActionContext = buildActionContext(selected);
-            pendingActionTarget = selected.name;
+            pendingToolAction = action;
+            pendingToolActionContext = context;
+            pendingActionTarget = context.instanceName();
             return true;
         }
-        var execResult = defAction.execute(buildActionContext(selected));
+        var execResult = action.execute(context);
         statusMessage = execResult.message();
         return false;
     }

--- a/src/main/java/dev/incusspawn/command/ListCommand.java
+++ b/src/main/java/dev/incusspawn/command/ListCommand.java
@@ -1918,6 +1918,15 @@ public class ListCommand extends BaseCommand {
         }
         if (key.isKey(KeyCode.ENTER)) {
             var action = actionsList.get(actionsSelectedIndex);
+            var cmd = action.shellCommand();
+            if (cmd.isPresent()) {
+                pendingAction = PendingAction.SHELL_WITH_COMMAND;
+                pendingShellCommand = cmd.get();
+                pendingActionTarget = actionsContext.instanceName();
+                mode = Mode.BROWSE;
+                tui.quit();
+                return true;
+            }
             if (action.needsDeferredExecution()) {
                 pendingAction = PendingAction.EXECUTE_ACTION;
                 pendingToolAction = action;

--- a/src/main/java/dev/incusspawn/command/ListCommand.java
+++ b/src/main/java/dev/incusspawn/command/ListCommand.java
@@ -2573,26 +2573,26 @@ public class ListCommand extends BaseCommand {
             actionId = null;
         }
 
-        // Check YAML tools
+        var matching = new java.util.ArrayList<dev.incusspawn.tool.ToolDef.ActionEntry>();
+
         var setup = toolDefLoader.find(toolName);
         if (setup instanceof YamlToolSetup yts) {
             for (var entry : yts.toolDef().getActions()) {
                 if ("shell".equals(entry.getType())) {
                     if (actionId == null || actionId.equals(entry.getId())) {
-                        return entry.getCommand();
+                        matching.add(entry);
                     }
                 }
             }
         }
 
-        // Check CDI tools
         if (cdiTools != null) {
             for (var cdiTool : cdiTools) {
                 if (toolName.equals(cdiTool.name())) {
                     for (var entry : cdiTool.actions()) {
                         if ("shell".equals(entry.getType())) {
                             if (actionId == null || actionId.equals(entry.getId())) {
-                                return entry.getCommand();
+                                matching.add(entry);
                             }
                         }
                     }
@@ -2600,6 +2600,7 @@ public class ListCommand extends BaseCommand {
             }
         }
 
+        if (matching.size() == 1) return matching.get(0).getCommand();
         return null;
     }
 

--- a/src/main/java/dev/incusspawn/config/ImageDef.java
+++ b/src/main/java/dev/incusspawn/config/ImageDef.java
@@ -110,6 +110,8 @@ public class ImageDef {
     private String workdir;
     @JsonProperty("shell-command")
     private String shellCommand;
+    @JsonProperty("default-action")
+    private String defaultAction;
 
     @JsonIgnore
     private String source = "unknown";
@@ -152,6 +154,8 @@ public class ImageDef {
     public void setWorkdir(String workdir) { this.workdir = workdir; }
     public String getShellCommand() { return shellCommand; }
     public void setShellCommand(String shellCommand) { this.shellCommand = shellCommand; }
+    public String getDefaultAction() { return defaultAction; }
+    public void setDefaultAction(String defaultAction) { this.defaultAction = defaultAction; }
     public String getSource() { return source; }
     public void setSource(String source) { this.source = source; }
 

--- a/src/main/java/dev/incusspawn/config/ImageDef.java
+++ b/src/main/java/dev/incusspawn/config/ImageDef.java
@@ -436,6 +436,7 @@ public class ImageDef {
             var def = loadResource(RESOURCE_DIR + filename, warnings);
             if (def != null) {
                 def.setSource("built-in");
+                validate(def, filename, warnings);
                 defs.put(def.getName(), def);
             }
         }
@@ -455,6 +456,7 @@ public class ImageDef {
                             var def = YAML.readValue(is, ImageDef.class);
                             if (def.getName() != null) {
                                 def.setSource(path.toAbsolutePath().normalize().toString());
+                                validate(def, path.getFileName().toString(), warnings);
                                 defs.put(def.getName(), def);
                             }
                         } catch (IOException e) {
@@ -464,6 +466,13 @@ public class ImageDef {
                     });
         } catch (IOException e) {
             warnings.accept("Warning: failed to scan " + dir + ": " + e.getMessage());
+        }
+    }
+
+    private static void validate(ImageDef def, String source, Consumer<String> warnings) {
+        if (def.getDefaultAction() != null && def.getDefaultAction().isBlank()) {
+            warnings.accept(source + ": 'default-action' is blank; remove it or set a valid tool reference");
+            def.setDefaultAction(null);
         }
     }
 

--- a/src/main/java/dev/incusspawn/incus/Metadata.java
+++ b/src/main/java/dev/incusspawn/incus/Metadata.java
@@ -28,6 +28,7 @@ public final class Metadata {
     public static final String KVM_ENABLED = PREFIX + "kvm-enabled";
     public static final String WORKDIR = PREFIX + "workdir";
     public static final String SHELL_COMMAND = PREFIX + "shell-command";
+    public static final String DEFAULT_ACTION = PREFIX + "default-action";
     public static final String PENDING_OP = PREFIX + "pending-op";
     public static final String STATIC_IP = PREFIX + "static-ip";
     public static final String STATIC_GATEWAY = PREFIX + "static-gateway";

--- a/src/main/java/dev/incusspawn/tool/ClaudeSetup.java
+++ b/src/main/java/dev/incusspawn/tool/ClaudeSetup.java
@@ -32,7 +32,7 @@ public class ClaudeSetup implements ToolSetup {
     public List<ToolDef.ActionEntry> actions() {
         var a = new ToolDef.ActionEntry();
         a.setLabel("Claude Code");
-        a.setType("command");
+        a.setType("shell");
         a.setCommand("if find ~/.claude/projects -maxdepth 2 -name '*.jsonl' 2>/dev/null | grep -q .; then claude --continue; else claude; fi");
         a.setAutoReturn(true);
         return List.of(a);

--- a/src/main/java/dev/incusspawn/tool/ClaudeSetup.java
+++ b/src/main/java/dev/incusspawn/tool/ClaudeSetup.java
@@ -6,6 +6,7 @@ import dev.incusspawn.incus.Container;
 
 import java.io.IOException;
 import java.nio.file.Files;
+import java.util.List;
 
 public class ClaudeSetup implements ToolSetup {
 
@@ -25,6 +26,16 @@ public class ClaudeSetup implements ToolSetup {
     @Override
     public String name() {
         return "claude";
+    }
+
+    @Override
+    public List<ToolDef.ActionEntry> actions() {
+        var a = new ToolDef.ActionEntry();
+        a.setLabel("Claude Code");
+        a.setType("command");
+        a.setCommand("if find ~/.claude/projects -maxdepth 2 -name '*.jsonl' 2>/dev/null | grep -q .; then claude --continue; else claude; fi");
+        a.setAutoReturn(true);
+        return List.of(a);
     }
 
     @Override

--- a/src/main/java/dev/incusspawn/tool/ToolAction.java
+++ b/src/main/java/dev/incusspawn/tool/ToolAction.java
@@ -42,7 +42,7 @@ public interface ToolAction {
      * If this action runs a command inside the container, returns the shell command string.
      * Empty for non-command actions (url, clipboard, etc.).
      */
-    default java.util.Optional<String> shellCommand() {
+    default java.util.Optional<String> shellCommand(ActionContext context) {
         return java.util.Optional.empty();
     }
 

--- a/src/main/java/dev/incusspawn/tool/ToolAction.java
+++ b/src/main/java/dev/incusspawn/tool/ToolAction.java
@@ -13,6 +13,13 @@ public interface ToolAction {
     String toolName();
 
     /**
+     * Stable identifier for referencing this action (e.g. from {@code default-action}).
+     */
+    default java.util.Optional<String> id() {
+        return java.util.Optional.empty();
+    }
+
+    /**
      * Human-readable label shown in the actions menu (e.g., "Open in Gateway").
      */
     String label();
@@ -22,6 +29,21 @@ public interface ToolAction {
      */
     default boolean requiresRunning() {
         return true;
+    }
+
+    /**
+     * Whether this action must be executed after leaving the TUI (e.g. interactive commands).
+     */
+    default boolean needsDeferredExecution() {
+        return false;
+    }
+
+    /**
+     * If this action runs a command inside the container, returns the shell command string.
+     * Empty for non-command actions (url, clipboard, etc.).
+     */
+    default java.util.Optional<String> shellCommand() {
+        return java.util.Optional.empty();
     }
 
     /**

--- a/src/main/java/dev/incusspawn/tool/ToolDef.java
+++ b/src/main/java/dev/incusspawn/tool/ToolDef.java
@@ -138,7 +138,10 @@ public class ToolDef {
         private String text;
         @JsonProperty("auto_return")
         private boolean autoReturn = false;
+        private String id;
 
+        public String getId() { return id; }
+        public void setId(String id) { this.id = id; }
         public String getLabel() { return label; }
         public void setLabel(String label) { this.label = label; }
         public String getType() { return type; }

--- a/src/main/java/dev/incusspawn/tool/ToolSetup.java
+++ b/src/main/java/dev/incusspawn/tool/ToolSetup.java
@@ -29,6 +29,9 @@ public interface ToolSetup {
         return java.util.Map.of();
     }
 
+    /** Runtime actions this tool contributes to the TUI actions menu. */
+    default java.util.List<ToolDef.ActionEntry> actions() { return java.util.List.of(); }
+
     /**
      * Install and configure this tool inside the given container. Packages are already installed.
      *

--- a/src/main/java/dev/incusspawn/tool/YamlToolAction.java
+++ b/src/main/java/dev/incusspawn/tool/YamlToolAction.java
@@ -33,6 +33,11 @@ public class YamlToolAction implements ToolAction {
     }
 
     @Override
+    public java.util.Optional<String> id() {
+        return java.util.Optional.ofNullable(entry.getId());
+    }
+
+    @Override
     public String label() {
         return interpolate(entry.getLabel(), null);
     }
@@ -50,6 +55,14 @@ public class YamlToolAction implements ToolAction {
         return isUrl() ? interpolate(entry.getUrl(), context) : null;
     }
 
+    @Override
+    public java.util.Optional<String> shellCommand() {
+        return TYPE_COMMAND.equals(entry.getType())
+                ? java.util.Optional.ofNullable(entry.getCommand())
+                : java.util.Optional.empty();
+    }
+
+    @Override
     public boolean needsDeferredExecution() {
         return TYPE_COMMAND.equals(entry.getType());
     }

--- a/src/main/java/dev/incusspawn/tool/YamlToolAction.java
+++ b/src/main/java/dev/incusspawn/tool/YamlToolAction.java
@@ -35,7 +35,10 @@ public class YamlToolAction implements ToolAction {
 
     @Override
     public java.util.Optional<String> id() {
-        return java.util.Optional.ofNullable(entry.getId());
+        var baseId = entry.getId();
+        if (baseId == null) return java.util.Optional.empty();
+        if (repo != null) return java.util.Optional.of(baseId + "/" + repo.name());
+        return java.util.Optional.of(baseId);
     }
 
     @Override

--- a/src/main/java/dev/incusspawn/tool/YamlToolAction.java
+++ b/src/main/java/dev/incusspawn/tool/YamlToolAction.java
@@ -57,10 +57,10 @@ public class YamlToolAction implements ToolAction {
     }
 
     @Override
-    public java.util.Optional<String> shellCommand() {
-        return TYPE_SHELL.equals(entry.getType())
-                ? java.util.Optional.ofNullable(entry.getCommand())
-                : java.util.Optional.empty();
+    public java.util.Optional<String> shellCommand(ActionContext context) {
+        if (!TYPE_SHELL.equals(entry.getType())) return java.util.Optional.empty();
+        var cmd = interpolate(entry.getCommand(), context);
+        return (cmd == null || cmd.isBlank()) ? java.util.Optional.empty() : java.util.Optional.of(cmd);
     }
 
     @Override

--- a/src/main/java/dev/incusspawn/tool/YamlToolAction.java
+++ b/src/main/java/dev/incusspawn/tool/YamlToolAction.java
@@ -10,6 +10,7 @@ public class YamlToolAction implements ToolAction {
 
     private static final String TYPE_URL = "url";
     private static final String TYPE_COMMAND = "command";
+    private static final String TYPE_SHELL = "shell";
     private static final String TYPE_COPY_TO_CLIPBOARD = "copy-to-clipboard";
     public static final String EXPAND_REPOS = "repos";
 
@@ -57,14 +58,14 @@ public class YamlToolAction implements ToolAction {
 
     @Override
     public java.util.Optional<String> shellCommand() {
-        return TYPE_COMMAND.equals(entry.getType())
+        return TYPE_SHELL.equals(entry.getType())
                 ? java.util.Optional.ofNullable(entry.getCommand())
                 : java.util.Optional.empty();
     }
 
     @Override
     public boolean needsDeferredExecution() {
-        return TYPE_COMMAND.equals(entry.getType());
+        return TYPE_COMMAND.equals(entry.getType()) || TYPE_SHELL.equals(entry.getType());
     }
 
     public boolean shouldAutoReturn() {
@@ -81,6 +82,7 @@ public class YamlToolAction implements ToolAction {
         return switch (type) {
             case TYPE_URL -> executeUrl(context);
             case TYPE_COMMAND -> executeCommand(context);
+            case TYPE_SHELL -> ActionResult.error("Shell actions must be dispatched via interactiveShell");
             case TYPE_COPY_TO_CLIPBOARD -> executeCopyToClipboard(context);
             default -> ActionResult.error("Unknown action type: " + type);
         };

--- a/src/test/java/dev/incusspawn/command/BuildCommandTest.java
+++ b/src/test/java/dev/incusspawn/command/BuildCommandTest.java
@@ -591,6 +591,59 @@ class BuildCommandTest {
                 BuildCommand.resolveEffectiveWorkdir(imageDef, java.util.Map.of()));
     }
 
+    // --- resolveEffectiveDefaultAction ---
+
+    @Test
+    void resolveEffectiveDefaultActionExplicit() {
+        var imageDef = new ImageDef();
+        imageDef.setName("tpl-test");
+        imageDef.setDefaultAction("claude");
+
+        assertEquals("claude",
+                BuildCommand.resolveEffectiveDefaultAction(imageDef, java.util.Map.of()));
+    }
+
+    @Test
+    void resolveEffectiveDefaultActionNone() {
+        var imageDef = new ImageDef();
+        imageDef.setName("tpl-test");
+
+        assertNull(BuildCommand.resolveEffectiveDefaultAction(imageDef, java.util.Map.of()));
+    }
+
+    @Test
+    void resolveEffectiveDefaultActionFromParent() {
+        var parent = new ImageDef();
+        parent.setName("tpl-parent");
+        parent.setDefaultAction("claude");
+
+        var child = new ImageDef();
+        child.setName("tpl-child");
+        child.setParent("tpl-parent");
+
+        var defs = java.util.Map.of("tpl-parent", parent, "tpl-child", child);
+        assertEquals("claude",
+                BuildCommand.resolveEffectiveDefaultAction(child, defs));
+    }
+
+    @Test
+    void resolveEffectiveDefaultActionChildOverridesParent() {
+        var parent = new ImageDef();
+        parent.setName("tpl-parent");
+        parent.setDefaultAction("pi");
+
+        var child = new ImageDef();
+        child.setName("tpl-child");
+        child.setParent("tpl-parent");
+        child.setDefaultAction("claude");
+
+        var defs = java.util.Map.of("tpl-parent", parent, "tpl-child", child);
+        assertEquals("claude",
+                BuildCommand.resolveEffectiveDefaultAction(child, defs));
+    }
+
+
+
     private static ToolSetup simpleToolSetup(String toolName) {
         return new ToolSetup() {
             @Override public String name() { return toolName; }


### PR DESCRIPTION
## Summary

- Tools can now declare runtime actions (CDI tools via `ToolSetup.actions()`, YAML tools via `actions:` entries with optional `id` field)
- Templates select a default action via the new `default-action` ImageDef field, which runs on Enter in the TUI (F2 remains explicit shell)
- Default action inherits through the parent template chain (child overrides parent) and is excluded from the content fingerprint to avoid unnecessary rebuilds
- Built-in `claude` tool contributes a "Claude Code" command action that resumes the most recent session when one exists, or starts a new session otherwise

## Test plan

- [x] `mvn test` — all 564 tests pass
- [x] Create template YAML with `default-action: claude` and `tools: [claude]`, build, branch, press Enter → executes Claude Code
- [x] Press F2 → always opens shell
- [x] Press F9 → full actions list including Claude Code
- [x] F1 → shows Enter shortcut
- [x] Template without `default-action` → Enter opens shell as before
- [ ] Template inheriting `default-action` from parent → Enter runs parent's default action