### PR TITLE
Add read-write host mount support

### DIFF
--- a/appliance/root/etc/init.d/rcS
+++ b/appliance/root/etc/init.d/rcS
@@ -24,9 +24,9 @@ mount -o remount,noatime,commit=300,compress=zstd:1 /
 #-- Expand btrfs to fill disk (disk may have been extended after image creation) --#
 btrfs filesystem resize max / 2>/dev/null || true
 
-#-- Mount host filesystem via virtio-fs (macOS shares ~ read-only) --#
+#-- Mount host filesystem via virtio-fs --#
 mkdir -p /host
-mount -t virtiofs -o ro hostfs /host 2>/dev/null || true
+mount -t virtiofs -o rw hostfs /host 2>/dev/null || true
 
 #-- Hostname --#
 hostname -F /etc/hostname

--- a/src/main/java/dev/incusspawn/command/BranchCommand.java
+++ b/src/main/java/dev/incusspawn/command/BranchCommand.java
@@ -21,6 +21,7 @@ import org.aesh.command.option.Argument;
 import org.aesh.command.option.Option;
 
 import java.nio.file.Path;
+import java.util.List;
 
 @CommandDefinition(
         name = "branch",
@@ -49,6 +50,9 @@ public class BranchCommand extends BaseCommand {
 
     @Option(name = "inbox", description = "Host directory to mount read-only at /home/agentuser/inbox")
     Path inbox;
+
+    @Option(name = "mount", description = "Host directory to mount read-write (host-path:container-path or host-path)")
+    List<String> mounts;
 
     @Option(name = "cpu", description = "CPU core limit (default: adaptive)")
     Integer cpuLimit;
@@ -133,7 +137,7 @@ public class BranchCommand extends BaseCommand {
 
         System.out.println("Starting container...");
         incus.start(name);
-        InstanceLifecycle.setupRuntime(incus, name, networkMode, inbox, prefetched);
+        InstanceLifecycle.setupRuntime(incus, name, networkMode, inbox, mounts, prefetched);
 
         System.out.println("Branch '" + name + "' is ready.\n");
         incus.interactiveShell(name, "agentuser", prefetched.toShellPrep());

--- a/src/main/java/dev/incusspawn/command/BranchCommand.java
+++ b/src/main/java/dev/incusspawn/command/BranchCommand.java
@@ -54,6 +54,9 @@ public class BranchCommand extends BaseCommand {
     @Option(name = "mount", description = "Host directory to mount read-write (host-path:container-path or host-path)")
     List<String> mounts;
 
+    @Option(name = "port", description = "Forward a host port into the container (e.g. 29170)")
+    List<Integer> ports;
+
     @Option(name = "cpu", description = "CPU core limit (default: adaptive)")
     Integer cpuLimit;
 
@@ -137,7 +140,7 @@ public class BranchCommand extends BaseCommand {
 
         System.out.println("Starting container...");
         incus.start(name);
-        InstanceLifecycle.setupRuntime(incus, name, networkMode, inbox, mounts, prefetched);
+        InstanceLifecycle.setupRuntime(incus, name, networkMode, inbox, mounts, ports, prefetched);
 
         System.out.println("Branch '" + name + "' is ready.\n");
         incus.interactiveShell(name, "agentuser", prefetched.toShellPrep());

--- a/src/main/java/dev/incusspawn/config/HostResourceSetup.java
+++ b/src/main/java/dev/incusspawn/config/HostResourceSetup.java
@@ -59,7 +59,7 @@ public final class HostResourceSetup {
         return hostPath;
     }
 
-    static String deviceName(String containerPath) {
+    public static String deviceName(String containerPath) {
         var stripped = containerPath.startsWith("/") ? containerPath.substring(1) : containerPath;
         var name = "hr-" + stripped.replaceAll("[^a-zA-Z0-9]", "-");
         if (name.length() > 64) {
@@ -114,6 +114,7 @@ public final class HostResourceSetup {
             switch (hr.getMode()) {
                 case "copy" -> applyCopy(container, hr);
                 case "readonly" -> applyReadonly(incus, container.name(), hr);
+                case "readwrite" -> applyReadwrite(incus, container.name(), hr);
                 case "overlay" -> {
                     if (Environment.isMacOS()) {
                         throw new IllegalStateException(
@@ -157,6 +158,10 @@ public final class HostResourceSetup {
                 case "readonly" -> {
                     removeExistingDevice(incus, container, deviceNameForMode(hr));
                     applyReadonly(incus, container, hr);
+                }
+                case "readwrite" -> {
+                    removeExistingDevice(incus, container, deviceNameForMode(hr));
+                    applyReadwrite(incus, container, hr);
                 }
                 case "overlay" -> {
                     if (Environment.isMacOS()) {
@@ -263,6 +268,21 @@ public final class HostResourceSetup {
         addShiftIfSupported(args);
         incus.deviceAdd(container, devName, "disk", args.toArray(String[]::new));
         System.out.println("  Mounted " + hr.getSource() + " -> " + containerPath + " (readonly)");
+    }
+
+    private static void applyReadwrite(IncusClient incus, String container, ImageDef.HostResource hr) {
+        var expandedSource = expandHostTilde(hr.getSource());
+        if (!Files.exists(Path.of(expandedSource))) {
+            System.err.println("Warning: host-resource source not found: " + hr.getSource() + " (skipping)");
+            return;
+        }
+        var containerPath = resolveContainerPath(hr.getSource(), hr.getPath());
+        var devName = deviceName(containerPath);
+        var args = new java.util.ArrayList<>(java.util.List.of(
+                "source=" + translateForVm(expandedSource),
+                "path=" + containerPath));
+        incus.deviceAdd(container, devName, "disk", args.toArray(String[]::new));
+        System.out.println("  Mounted " + hr.getSource() + " -> " + containerPath + " (readwrite)");
     }
 
     private static void applyOverlay(IncusClient incus, Container container, ImageDef.HostResource hr) {

--- a/src/main/java/dev/incusspawn/lifecycle/InstanceLifecycle.java
+++ b/src/main/java/dev/incusspawn/lifecycle/InstanceLifecycle.java
@@ -140,12 +140,13 @@ public final class InstanceLifecycle {
     public static void setupRuntime(IncusClient incus, String name,
                                    NetworkMode networkMode, Path inboxPath,
                                    RuntimeConfig prefetched) {
-        setupRuntime(incus, name, networkMode, inboxPath, null, prefetched);
+        setupRuntime(incus, name, networkMode, inboxPath, null, null, prefetched);
     }
 
     public static void setupRuntime(IncusClient incus, String name,
                                    NetworkMode networkMode, Path inboxPath,
                                    java.util.List<String> rwMounts,
+                                   java.util.List<Integer> forwardPorts,
                                    RuntimeConfig prefetched) {
         if (networkMode == NetworkMode.PROXY_ONLY) {
             applyProxyOnlyFirewall(incus, name);
@@ -182,6 +183,17 @@ public final class InstanceLifecycle {
                 incus.deviceAdd(name, devName, "disk",
                         "source=" + dev.incusspawn.config.HostResourceSetup.translateForVm(hostPath),
                         "path=" + containerPath);
+            }
+        }
+
+        if (forwardPorts != null) {
+            var gatewayIp = dev.incusspawn.proxy.MitmProxy.resolveGatewayIp(incus);
+            for (var port : forwardPorts) {
+                var devName = "port-" + port;
+                System.out.println("Forwarding port " + port + " from host (" + gatewayIp + ") into container");
+                incus.deviceAdd(name, devName, "proxy",
+                        "listen=tcp:0.0.0.0:" + port,
+                        "connect=tcp:" + gatewayIp + ":" + port);
             }
         }
 

--- a/src/main/java/dev/incusspawn/lifecycle/InstanceLifecycle.java
+++ b/src/main/java/dev/incusspawn/lifecycle/InstanceLifecycle.java
@@ -140,6 +140,13 @@ public final class InstanceLifecycle {
     public static void setupRuntime(IncusClient incus, String name,
                                    NetworkMode networkMode, Path inboxPath,
                                    RuntimeConfig prefetched) {
+        setupRuntime(incus, name, networkMode, inboxPath, null, prefetched);
+    }
+
+    public static void setupRuntime(IncusClient incus, String name,
+                                   NetworkMode networkMode, Path inboxPath,
+                                   java.util.List<String> rwMounts,
+                                   RuntimeConfig prefetched) {
         if (networkMode == NetworkMode.PROXY_ONLY) {
             applyProxyOnlyFirewall(incus, name);
         }
@@ -156,6 +163,25 @@ public final class InstanceLifecycle {
             } else {
                 System.err.println("Warning: inbox path '" + inboxPath +
                         "' is not a directory, skipping.");
+            }
+        }
+
+        if (rwMounts != null) {
+            for (var mount : rwMounts) {
+                var parts = mount.split(":", 2);
+                var hostPath = dev.incusspawn.config.HostResourceSetup.expandHostTilde(parts[0]);
+                var containerPath = parts.length > 1
+                        ? dev.incusspawn.config.HostResourceSetup.resolveContainerPath(parts[0], parts[1])
+                        : dev.incusspawn.config.HostResourceSetup.resolveContainerPath(parts[0], null);
+                if (!java.nio.file.Files.isDirectory(Path.of(hostPath))) {
+                    System.err.println("Warning: mount path '" + parts[0] + "' is not a directory, skipping.");
+                    continue;
+                }
+                var devName = dev.incusspawn.config.HostResourceSetup.deviceName(containerPath);
+                System.out.println("Mounting " + parts[0] + " -> " + containerPath + " (readwrite)");
+                incus.deviceAdd(name, devName, "disk",
+                        "source=" + dev.incusspawn.config.HostResourceSetup.translateForVm(hostPath),
+                        "path=" + containerPath);
             }
         }
 


### PR DESCRIPTION
## Problem

isx currently has no way for containers to:
1. Write files visible to the host (for real-time code review in host IDE)
2. Access host services like IDE MCP servers

This blocks the workflow where an AI agent runs inside a container editing code while the developer reviews changes in their host IDE with full code intelligence.

Closes #237

## Changes

### 1. Read-write host mounts (`--mount`)

**VM-side**: Mount virtio-fs read-write instead of read-only in `rcS`. Per-container access control is handled by Incus disk device `readonly=true/false`.

**Host-side**: New `readwrite` mode in `HostResourceSetup` — same as `readonly` but without `readonly=true` and without `shift=true`. New `--mount` CLI flag on `isx branch`:

```bash
isx branch mywork --mount ~/code/myproject:/home/agentuser/myproject
```

Also works in template YAML:
```yaml
host-resources:
  - source: ~/code/myproject
    path: ~/myproject
    mode: readwrite
```

### 2. Host port forwarding (`--port`)

Forwards host ports into the container via Incus proxy devices. Primary use case: exposing host IDE MCP servers to Claude Code inside the container.

```bash
isx branch mywork --port 29170 --mount ~/code/myproject
```

This makes the host's IntelliJ index-mcp-plugin (on port 29170) accessible at `localhost:29170` inside the container.

## Files changed

| File | Change |
|------|--------|
| `appliance/root/etc/init.d/rcS` | `ro` → `rw` for virtio-fs mount |
| `HostResourceSetup.java` | Add `applyReadwrite()`, wire into switch statements, make `deviceName()` public |
| `BranchCommand.java` | Add `--mount` and `--port` options |
| `InstanceLifecycle.java` | New overload with mount and port support |

## Example: full host IDE integration

```bash
isx branch casehub-work \
  --mount ~/claude/casehub:/home/agentuser/casehub \
  --port 29170
```

Container's Claude Code edits `~/casehub` → changes visible instantly in host IntelliJ. Port 29170 gives Claude Code access to IntelliJ's semantic code intelligence via MCP.


🤖 Generated with [Claude Code](https://claude.com/claude-code)