### PR TITLE
Fix vsock tunnel routing for all isx commands

### DIFF
--- a/src/main/java/dev/incusspawn/incus/HttpsTransport.java
+++ b/src/main/java/dev/incusspawn/incus/HttpsTransport.java
@@ -60,6 +60,17 @@ class HttpsTransport implements IncusTransport {
                 var certDir = configPath.getParent();
                 var sslContext = buildSslContext(certDir, addr);
                 if (sslContext == null) continue;
+
+                var vsockSocket = Environment.vmVsockSocket();
+                if (Files.exists(vsockSocket)) {
+                    try {
+                        int proxyPort = UnixSocketProxy.startIfNeeded(vsockSocket);
+                        return new HttpsTransport("https://localhost:" + proxyPort, sslContext);
+                    } catch (java.io.IOException e) {
+                        System.err.println("Warning: vsock proxy failed, falling back to direct: " + e.getMessage());
+                    }
+                }
+
                 return new HttpsTransport(addr, sslContext);
             } catch (Exception ignored) {}
         }

--- a/src/main/java/dev/incusspawn/incus/IncusApi.java
+++ b/src/main/java/dev/incusspawn/incus/IncusApi.java
@@ -44,15 +44,18 @@ class IncusApi {
      * Returns an IncusApi instance if a probe request succeeds, or null if nothing is accessible.
      */
     static IncusApi tryConnect() {
-        var socketCandidates = new ArrayList<>(UnixSocketTransport.SOCKET_CANDIDATES);
-        var vsockSocket = Environment.vmVsockSocket();
-        if (Files.exists(vsockSocket)) {
-            socketCandidates.add(vsockSocket.toString());
-        }
-        for (var candidate : socketCandidates) {
+        for (var candidate : UnixSocketTransport.SOCKET_CANDIDATES) {
             if (!Files.exists(Path.of(candidate))) continue;
             try {
                 var http = new IncusApi(new UnixSocketTransport(candidate));
+                if (http.get("/1.0").isSuccess()) return http;
+            } catch (IncusException ignored) {}
+        }
+        // Try HTTPS transport (includes vsock proxy for macOS)
+        var https = HttpsTransport.fromClientConfig();
+        if (https != null) {
+            try {
+                var http = new IncusApi(https);
                 if (http.get("/1.0").isSuccess()) return http;
             } catch (IncusException ignored) {}
         }

--- a/src/main/java/dev/incusspawn/incus/UnixSocketProxy.java
+++ b/src/main/java/dev/incusspawn/incus/UnixSocketProxy.java
@@ -1,0 +1,80 @@
+package dev.incusspawn.incus;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.StandardProtocolFamily;
+import java.net.UnixDomainSocketAddress;
+import java.nio.ByteBuffer;
+import java.nio.channels.ServerSocketChannel;
+import java.nio.channels.SocketChannel;
+import java.nio.file.Path;
+
+/**
+ * Lightweight TCP-to-Unix-socket proxy. Listens on {@code localhost:<port>}
+ * and forwards each connection to a Unix domain socket (the vfkit vsock
+ * endpoint). This allows the standard {@link java.net.http.HttpClient} and
+ * WebSocket APIs to reach the Incus HTTPS API inside the VM without any
+ * TCP connection to the VM subnet — bypassing network-layer socket filters
+ * such as Cisco AnyConnect.
+ */
+public final class UnixSocketProxy {
+
+    private static volatile int activePort;
+
+    private UnixSocketProxy() {}
+
+    /**
+     * Start the proxy if not already running. Returns the localhost port.
+     */
+    public static synchronized int startIfNeeded(Path unixSocketPath) throws IOException {
+        if (activePort > 0) return activePort;
+
+        var serverChannel = ServerSocketChannel.open();
+        serverChannel.bind(new InetSocketAddress("localhost", 0));
+        int port = ((InetSocketAddress) serverChannel.getLocalAddress()).getPort();
+
+        Thread.ofVirtual().name("vsock-proxy-accept").start(() -> {
+            try {
+                while (serverChannel.isOpen()) {
+                    var client = serverChannel.accept();
+                    Thread.ofVirtual().name("vsock-proxy-conn").start(() ->
+                            bridge(client, unixSocketPath));
+                }
+            } catch (IOException e) {
+                if (serverChannel.isOpen()) {
+                    System.err.println("vsock proxy accept error: " + e.getMessage());
+                }
+            }
+        });
+
+        activePort = port;
+        return port;
+    }
+
+    private static void bridge(SocketChannel client, Path unixSocketPath) {
+        try (client) {
+            try (var upstream = SocketChannel.open(StandardProtocolFamily.UNIX)) {
+                upstream.connect(UnixDomainSocketAddress.of(unixSocketPath));
+                var t = Thread.ofVirtual().name("vsock-proxy-up").start(() ->
+                        pipe(upstream, client));
+                pipe(client, upstream);
+                t.join();
+            }
+        } catch (IOException | InterruptedException ignored) {
+        }
+    }
+
+    private static void pipe(SocketChannel from, SocketChannel to) {
+        var buf = ByteBuffer.allocate(16384);
+        try {
+            while (from.read(buf) >= 0) {
+                buf.flip();
+                while (buf.hasRemaining()) to.write(buf);
+                buf.clear();
+            }
+        } catch (IOException ignored) {
+        } finally {
+            try { to.shutdownOutput(); } catch (IOException ignored) {}
+        }
+    }
+}

--- a/src/main/java/dev/incusspawn/vm/IncusRemoteSetup.java
+++ b/src/main/java/dev/incusspawn/vm/IncusRemoteSetup.java
@@ -81,9 +81,20 @@ public final class IncusRemoteSetup {
 
         // Try vsock first (bypasses VPN socket filters like Cisco AnyConnect)
         var vsockSocket = Environment.vmVsockSocket();
-        if (Files.exists(vsockSocket) && VmManager.waitUntilReady(30)) {
-            System.err.println("  Incus reachable via vsock tunnel");
-        } else {
+        boolean reachableViaVsock = false;
+        if (Files.exists(vsockSocket)) {
+            try {
+                int proxyPort = dev.incusspawn.incus.UnixSocketProxy.startIfNeeded(vsockSocket);
+                if (waitForPort("localhost", proxyPort, 30)) {
+                    System.err.println("  Incus reachable via vsock tunnel");
+                    saveServerCertViaProxy(proxyPort);
+                    reachableViaVsock = true;
+                }
+            } catch (Exception e) {
+                System.err.println("  vsock proxy failed: " + e.getMessage());
+            }
+        }
+        if (!reachableViaVsock) {
             System.err.println("  Waiting for Incus HTTPS API on " + vmIp + ":" + INCUS_PORT + "...");
             if (!waitForPort(vmIp, INCUS_PORT, 60)) {
                 throw new IOException("Incus HTTPS API not reachable at " + vmIp + ":" + INCUS_PORT
@@ -177,6 +188,23 @@ public final class IncusRemoteSetup {
             }
         } catch (Exception e) {
             System.err.println("  Warning: could not save server certificate: " + e.getMessage());
+        }
+    }
+
+    private static void saveServerCertViaProxy(int proxyPort) {
+        try {
+            var sslContext = SSLContext.getInstance("TLS");
+            var capturingTm = new CertCapturingTrustManager();
+            sslContext.init(null, new TrustManager[]{capturingTm}, null);
+            var client = HttpClient.newBuilder().sslContext(sslContext).connectTimeout(Duration.ofSeconds(5)).build();
+            var request = HttpRequest.newBuilder().uri(URI.create("https://localhost:" + proxyPort + "/1.0")).GET().timeout(Duration.ofSeconds(5)).build();
+            client.send(request, HttpResponse.BodyHandlers.discarding());
+            if (capturingTm.captured != null) {
+                var certPath = Environment.incusServerCertsDir().resolve(REMOTE_NAME + ".crt");
+                Files.writeString(certPath, toPem("CERTIFICATE", capturingTm.captured.getEncoded()));
+            }
+        } catch (Exception e) {
+            System.err.println("  Warning: could not save server certificate via vsock: " + e.getMessage());
         }
     }
 


### PR DESCRIPTION
## Problem

The vsock tunnel merged in #224 and reworked in #227 doesn't work end-to-end on machines with Cisco AnyConnect. Commands like `isx build`, `isx init`, and `isx branch` fail with "No route to host" or "Incus daemon not reachable" despite the vsock socket being available.

Related: #233

## Root causes (3 issues)

### 1. HttpsTransport doesn't use vsock proxy
`HttpsTransport.fromClientConfig()` connects directly to the VM IP from config.yml. On machines where the Cisco socket filter blocks TCP to the VM subnet, this fails. Fixed by detecting the vsock socket file and routing through `UnixSocketProxy` (localhost TCP → Unix socket → vsock → VM).

### 2. IncusRemoteSetup.configure() chicken-and-egg
`configure()` calls `VmManager.waitUntilReady()` → `IncusClient.isReachable()` → needs config.yml → but config.yml hasn't been written yet. Fixed by starting the `UnixSocketProxy` directly and using `waitForPort("localhost", proxyPort)` instead.

### 3. IncusApi.tryConnect() misuses vsock socket
`tryConnect()` adds the vsock socket to `UnixSocketTransport` candidates, but vsock sockets speak TLS, not raw Incus protocol. The connection fails silently. Fixed by trying `HttpsTransport.fromClientConfig()` (which includes the vsock proxy) after Unix socket candidates.

## Files changed

| File | Change |
|------|--------|
| `UnixSocketProxy.java` | **New**: localhost TCP ↔ Unix socket bridge |
| `HttpsTransport.java` | Route through vsock proxy when socket exists |
| `IncusRemoteSetup.java` | Use proxy for initial setup + cert capture |
| `IncusApi.java` | Fall back to HTTPS transport in tryConnect() |


🤖 Generated with [Claude Code](https://claude.com/claude-code)