### PR TITLE
Detect VPN subnet conflicts in policy routing tables

### DIFF
--- a/src/main/java/dev/incusspawn/incus/BridgeSubnetCheck.java
+++ b/src/main/java/dev/incusspawn/incus/BridgeSubnetCheck.java
@@ -22,7 +22,7 @@ public final class BridgeSubnetCheck {
 
     public static List<String> getHostRoutes() {
         try {
-            var pb = new ProcessBuilder("ip", "route", "show");
+            var pb = new ProcessBuilder("ip", "route", "show", "table", "all");
             pb.redirectErrorStream(true);
             var process = pb.start();
             var output = new String(process.getInputStream().readAllBytes()).strip();

--- a/src/test/java/dev/incusspawn/incus/BridgeSubnetCheckTest.java
+++ b/src/test/java/dev/incusspawn/incus/BridgeSubnetCheckTest.java
@@ -113,6 +113,49 @@ class BridgeSubnetCheckTest {
         assertNull(diagnostic);
     }
 
+    // VPN routes in a policy routing table (e.g. table 75) must be detected as
+    // conflicts, since they override main-table routes via ip rule priority.
+    @Test
+    void findConflictingRouteDetectsVpnInPolicyRoutingTable() {
+        var routes = List.of(
+                "default via 192.168.0.254 dev wlp9s0f0 proto dhcp src 192.168.0.24 metric 600",
+                "10.26.206.0/24 dev incusbr0 proto kernel scope link src 10.26.206.1 metric 426",
+                "192.168.0.0/24 dev wlp9s0f0 proto kernel scope link src 192.168.0.24 metric 600",
+                "10.0.0.0/8 via 10.44.48.1 dev tun0 table 75 proto static metric 50",
+                "10.44.48.0/20 dev tun0 table 75 proto kernel scope link src 10.44.48.62 metric 50",
+                "local 10.26.206.1 dev incusbr0 table local proto kernel scope host src 10.26.206.1",
+                "broadcast 10.26.206.255 dev incusbr0 table local proto kernel scope link src 10.26.206.1",
+                "local 10.44.48.62 dev tun0 table local proto kernel scope host src 10.44.48.62");
+        var conflict = BridgeSubnetCheck.findConflictingRoute("10.26.206.1/24", routes);
+        assertNotNull(conflict);
+        assertTrue(conflict.contains("10.0.0.0/8"));
+    }
+
+    // Candidate subnet selection must also consider routes from policy routing
+    // tables, not just the main table, to avoid picking a subnet claimed by a VPN.
+    @Test
+    void findNonConflictingSubnetWorksWithPolicyRoutingTables() {
+        var routes = List.of(
+                "default via 192.168.0.254 dev wlp9s0f0 proto dhcp",
+                "10.0.0.0/8 via 10.44.48.1 dev tun0 table 75 proto static",
+                "local 10.26.206.1 dev incusbr0 table local proto kernel scope host",
+                "broadcast 10.26.206.255 dev incusbr0 table local proto kernel scope link");
+        var subnet = BridgeSubnetCheck.findNonConflictingSubnet("10.26.206.1/24", routes);
+        assertEquals("172.20.0.1/24", subnet);
+    }
+
+    // Entries from the kernel's local table (local, broadcast) must not trigger
+    // false-positive conflicts when processing `ip route show table all` output.
+    @Test
+    void findConflictingRouteSkipsLocalTableEntries() {
+        var routes = List.of(
+                "local 10.166.11.1 dev incusbr0 table local proto kernel scope host src 10.166.11.1",
+                "broadcast 10.166.11.255 dev incusbr0 table local proto kernel scope link src 10.166.11.1",
+                "local 127.0.0.0/8 dev lo table local proto kernel scope host src 127.0.0.1");
+        var conflict = BridgeSubnetCheck.findConflictingRoute("10.166.11.1/24", routes);
+        assertNull(conflict);
+    }
+
     @Test
     void findConflictingRouteHandlesEmptyRoutes() {
         var conflict = BridgeSubnetCheck.findConflictingRoute("10.166.11.1/24", List.of());


### PR DESCRIPTION
BridgeSubnetCheck.getHostRoutes() only queried the main routing table (ip route show), missing VPN routes placed in separate policy routing tables (e.g. table 75 via ip rule). This caused the bridge subnet 10.26.206.0/24 to go undetected as overlapping with a VPN's 10.0.0.0/8 route, breaking container networking when the VPN was active.

Switch to 'ip route show table all' so conflicts in any routing table are detected. The existing filtering logic already handles the extra local/broadcast entries this produces.