### PR TITLE
RFC: Claude Code memory portability across host and container

### DIFF
--- a/src/main/resources/tools/claude-memory-sync.yaml
+++ b/src/main/resources/tools/claude-memory-sync.yaml
@@ -1,0 +1,182 @@
+name: claude-memory-sync
+description: Sync Claude Code project memory from host to container at session boundaries
+
+parameters:
+  pathmap:
+    type: string
+    description: >
+      Comma-separated host_rel:container_rel path pairs relative to home.
+      Maps host project directories to their container equivalents so that
+      Claude Code memory can be copied between path-encoded directories.
+      Example: "claude/casehub:casehub,.hortora:.hortora"
+
+run_as_user:
+  - |
+    mkdir -p ~/.claude/bin
+    cat > ~/.claude/bin/memory-sync.sh << 'SYNCEOF'
+    #!/bin/bash
+    set -euo pipefail
+    HOST_CLAUDE="/mnt/host-claude"
+    CLAUDE="$HOME/.claude"
+    MAP="$CLAUDE/memory-map.json"
+    PATHMAP="%%PATHMAP%%"
+
+    [ -d "$HOST_CLAUDE/projects" ] || exit 0
+
+    python3 - "$@" << 'PYEOF'
+    import json, os, shutil, sys
+
+    host_claude = "/mnt/host-claude"
+    claude_dir = os.path.expanduser("~/.claude")
+    home = os.path.expanduser("~")
+    map_path = os.path.join(claude_dir, "memory-map.json")
+    pathmap_raw = os.environ.get("PATHMAP", "")
+    verbose = "--verbose" in sys.argv or "--dry-run" in sys.argv
+    dry_run = "--dry-run" in sys.argv
+
+    def encode_path(p):
+        return p.replace("/", "-")
+
+    def discover_host_home():
+        d = os.path.join(host_claude, "projects")
+        if not os.path.isdir(d):
+            return None
+        dirs = [e for e in os.listdir(d) if os.path.isdir(os.path.join(d, e))]
+        if not dirs:
+            return None
+        shortest = min(dirs, key=len)
+        return "/" + shortest.lstrip("-").replace("-", "/")
+
+    def find_repos(base):
+        if not os.path.isdir(base):
+            return []
+        return [os.path.join(base, e) for e in os.listdir(base)
+                if os.path.isdir(os.path.join(base, e, ".git"))]
+
+    def build_mappings():
+        host_home = discover_host_home()
+        if not host_home:
+            return []
+        mappings = [{
+            "host_dir": encode_path(host_home),
+            "container_dir": encode_path(home),
+            "label": "~ (home/global)",
+            "match_type": "home"
+        }]
+        if not pathmap_raw.strip():
+            return mappings
+        for pair in pathmap_raw.split(","):
+            pair = pair.strip()
+            if ":" not in pair:
+                continue
+            host_rel, container_rel = pair.split(":", 1)
+            host_base = os.path.join(host_home, host_rel)
+            container_base = os.path.join(home, container_rel)
+            for repo in find_repos(container_base):
+                name = os.path.basename(repo)
+                host_path = os.path.join(host_base, name)
+                h_enc = encode_path(host_path)
+                c_enc = encode_path(repo)
+                if os.path.isdir(os.path.join(host_claude, "projects", h_enc, "memory")):
+                    mappings.append({
+                        "host_dir": h_enc, "container_dir": c_enc,
+                        "label": os.path.relpath(repo, home), "match_type": "pathmap"
+                    })
+        return mappings
+
+    # Regenerate mapping if stale (only home mapping or missing repos)
+    need_regen = True
+    if os.path.isfile(map_path):
+        with open(map_path) as f:
+            existing = json.load(f)
+        if any(m.get("match_type") == "pathmap" for m in existing.get("mappings", [])):
+            need_regen = False
+
+    if need_regen:
+        mappings = build_mappings()
+        os.makedirs(claude_dir, exist_ok=True)
+        with open(map_path, "w") as f:
+            json.dump({"mappings": mappings}, f, indent=2)
+        if verbose:
+            print(f"  Regenerated mapping: {len(mappings)} entries", file=sys.stderr)
+            for m in mappings:
+                print(f"    {m['label']}: {m['host_dir']} -> {m['container_dir']}", file=sys.stderr)
+
+    # Sync memory files
+    with open(map_path) as f:
+        data = json.load(f)
+
+    synced = 0
+    for m in data.get("mappings", []):
+        src = os.path.join(host_claude, "projects", m["host_dir"], "memory")
+        dst = os.path.join(claude_dir, "projects", m["container_dir"], "memory")
+        label = m.get("label", "")
+        if not os.path.isdir(src):
+            if verbose: print(f"  {label}: no host memory — skip", file=sys.stderr)
+            continue
+        md_files = [f for f in os.listdir(src) if f.endswith(".md")]
+        if not md_files:
+            continue
+        if dry_run:
+            print(f"  DRY-RUN: {label}: {len(md_files)} file(s)", file=sys.stderr)
+            continue
+        os.makedirs(dst, exist_ok=True)
+        copied = 0
+        for fname in md_files:
+            s, d = os.path.join(src, fname), os.path.join(dst, fname)
+            if not os.path.exists(d) or os.path.getmtime(s) > os.path.getmtime(d):
+                shutil.copy2(s, d)
+                copied += 1
+        if verbose and copied:
+            print(f"  {label}: synced {copied}/{len(md_files)} file(s)", file=sys.stderr)
+        synced += copied
+
+    if verbose:
+        print(f"Memory sync complete: {synced} file(s) updated.", file=sys.stderr)
+    PYEOF
+    SYNCEOF
+    sed -i "s|%%PATHMAP%%|${param_pathmap}|g" ~/.claude/bin/memory-sync.sh
+    chmod +x ~/.claude/bin/memory-sync.sh
+  - |
+    python3 << 'PYEOF'
+    import json, os
+
+    settings_path = os.path.expanduser("~/.claude/settings.json")
+    hook_command = "~/.claude/bin/memory-sync.sh"
+
+    settings = {}
+    if os.path.isfile(settings_path):
+        with open(settings_path) as f:
+            settings = json.load(f)
+
+    if "hooks" not in settings:
+        settings["hooks"] = {}
+
+    for event in ["SessionStart", "SessionEnd"]:
+        if event not in settings["hooks"]:
+            settings["hooks"][event] = []
+
+    already = any(
+        hook.get("command", "") == hook_command
+        for group in settings["hooks"]["SessionStart"]
+        for hook in group.get("hooks", [])
+    )
+    if not already:
+        settings["hooks"]["SessionStart"].append({
+            "hooks": [{"type": "command", "command": hook_command}]
+        })
+
+    with open(settings_path, "w") as f:
+        json.dump(settings, f, indent=2)
+
+    print("  SessionStart hook registered in ~/.claude/settings.json")
+    PYEOF
+  - |
+    if [ -d /mnt/host-claude ]; then
+      for f in CLAUDE.md engagement.md working-style.md document-boundaries.md design-implementation.md config-architecture.md; do
+        [ -f "/mnt/host-claude/$f" ] && cp "/mnt/host-claude/$f" ~/.claude/
+      done
+    fi
+  - PATHMAP="${param_pathmap}" ~/.claude/bin/memory-sync.sh --verbose || true
+
+verify: test -x /home/agentuser/.claude/bin/memory-sync.sh

--- a/src/main/resources/tools/claude-memory-sync.yaml
+++ b/src/main/resources/tools/claude-memory-sync.yaml
@@ -35,7 +35,7 @@ run_as_user:
         if verbose: print(f"  {msg}", file=sys.stderr)
 
     def encode_path(p):
-        return p.replace("/", "-")
+        return p.replace("/", "-").replace(".", "-")
 
     def discover_host_home():
         d = os.path.join(sync_repo, "projects")
@@ -122,6 +122,14 @@ run_as_user:
             synced += copied
         return synced
 
+    def sync_global_files():
+        for f in os.listdir(sync_repo):
+            if f.endswith(".md") and os.path.isfile(os.path.join(sync_repo, f)):
+                src = os.path.join(sync_repo, f)
+                dst = os.path.join(claude_dir, f)
+                if not os.path.exists(dst) or os.path.getmtime(src) > os.path.getmtime(dst):
+                    shutil.copy2(src, dst)
+
     ensure_mapping()
     if not os.path.isfile(map_path):
         sys.exit(0)
@@ -129,38 +137,33 @@ run_as_user:
         mappings = json.load(f).get("mappings", [])
 
     if push_mode:
+        subprocess.run(["git", "-C", sync_repo, "pull", "--rebase", "--quiet"],
+                       capture_output=True)
         synced = sync_files(claude_dir, sync_repo, mappings, "container_dir", "host_dir")
         if synced > 0 and not dry_run:
             subprocess.run(["git", "-C", sync_repo, "add", "--all"], capture_output=True)
             r = subprocess.run(["git", "-C", sync_repo, "diff", "--cached", "--quiet"],
                                capture_output=True)
             if r.returncode != 0:
-                hostname = subprocess.run(["hostname"], capture_output=True, text=True).stdout.strip()
+                import socket
                 subprocess.run(["git", "-C", sync_repo, "commit", "-m",
-                               f"memory sync from {hostname}"], capture_output=True)
-                log(f"Committed {synced} file(s) to sync repo.")
+                               f"memory sync from {socket.gethostname()}"], capture_output=True)
+                log(f"Committed {synced} file(s).")
                 r = subprocess.run(["git", "-C", sync_repo, "push"],
                                    capture_output=True, text=True)
                 if r.returncode == 0:
                     log("Pushed to remote.")
                 else:
-                    log("Committed locally (no remote or push failed — host can fetch via SSH).")
+                    log("Committed locally (host can fetch via SSH).")
         elif synced == 0:
             log("No changes to write back.")
     else:
         subprocess.run(["git", "-C", sync_repo, "pull", "--rebase", "--quiet"],
                        capture_output=True)
         synced = sync_files(sync_repo, claude_dir, mappings, "host_dir", "container_dir")
-        global_files = ["CLAUDE.md", "engagement.md", "working-style.md",
-                        "document-boundaries.md", "design-implementation.md",
-                        "config-architecture.md"]
-        for gf in global_files:
-            src = os.path.join(sync_repo, gf)
-            dst = os.path.join(claude_dir, gf)
-            if os.path.isfile(src):
-                if not os.path.exists(dst) or os.path.getmtime(src) > os.path.getmtime(dst):
-                    shutil.copy2(src, dst)
-        log(f"Sync complete: {synced} file(s) pulled from host.")
+        if not dry_run:
+            sync_global_files()
+        log(f"Sync complete: {synced} memory file(s) pulled from host.")
     PYEOF
     SYNCEOF
     sed -i "s|%%PATHMAP%%|${param_pathmap}|g" ~/.claude/bin/memory-sync.sh
@@ -201,9 +204,14 @@ run_as_user:
     print("  SessionStart + SessionEnd hooks registered")
     PYEOF
   - |
+    if [ -d ~/.claude-sync/.git ]; then
+      git -C ~/.claude-sync config user.name "isx-memory-sync"
+      git -C ~/.claude-sync config user.email "memory-sync@incus-spawn"
+    fi
+  - |
     if [ -d ~/.claude-sync ]; then
-      for f in CLAUDE.md engagement.md working-style.md document-boundaries.md design-implementation.md config-architecture.md; do
-        [ -f "$HOME/.claude-sync/$f" ] && cp "$HOME/.claude-sync/$f" ~/.claude/
+      for f in ~/.claude-sync/*.md; do
+        [ -f "$f" ] && cp "$f" ~/.claude/
       done
     fi
   - PATHMAP="${param_pathmap}" ~/.claude/bin/memory-sync.sh --verbose || true

--- a/src/main/resources/tools/claude-memory-sync.yaml
+++ b/src/main/resources/tools/claude-memory-sync.yaml
@@ -16,23 +16,27 @@ run_as_user:
     cat > ~/.claude/bin/memory-sync.sh << 'SYNCEOF'
     #!/bin/bash
     set -euo pipefail
-    HOST_CLAUDE="/mnt/host-claude"
-    CLAUDE="$HOME/.claude"
-    MAP="$CLAUDE/memory-map.json"
-    PATHMAP="%%PATHMAP%%"
+    export HOST_CLAUDE="/mnt/host-claude"
+    export CLAUDE_DIR="$HOME/.claude"
+    export PATHMAP="%%PATHMAP%%"
 
     [ -d "$HOST_CLAUDE/projects" ] || exit 0
 
     python3 - "$@" << 'PYEOF'
-    import json, os, shutil, sys
+    import json, os, re, shutil, subprocess, sys
 
-    host_claude = "/mnt/host-claude"
-    claude_dir = os.path.expanduser("~/.claude")
+    host_claude = os.environ["HOST_CLAUDE"]
+    claude_dir = os.environ["CLAUDE_DIR"]
     home = os.path.expanduser("~")
     map_path = os.path.join(claude_dir, "memory-map.json")
     pathmap_raw = os.environ.get("PATHMAP", "")
+    sync_dir = os.path.join(home, ".claude-sync")
     verbose = "--verbose" in sys.argv or "--dry-run" in sys.argv
     dry_run = "--dry-run" in sys.argv
+    push_mode = "--push" in sys.argv
+
+    def log(msg):
+        if verbose: print(f"  {msg}", file=sys.stderr)
 
     def encode_path(p):
         return p.replace("/", "-")
@@ -84,55 +88,145 @@ run_as_user:
                     })
         return mappings
 
-    # Regenerate mapping if stale (only home mapping or missing repos)
-    need_regen = True
-    if os.path.isfile(map_path):
-        with open(map_path) as f:
-            existing = json.load(f)
-        if any(m.get("match_type") == "pathmap" for m in existing.get("mappings", [])):
-            need_regen = False
-
-    if need_regen:
-        mappings = build_mappings()
-        os.makedirs(claude_dir, exist_ok=True)
-        with open(map_path, "w") as f:
-            json.dump({"mappings": mappings}, f, indent=2)
-        if verbose:
-            print(f"  Regenerated mapping: {len(mappings)} entries", file=sys.stderr)
+    def ensure_mapping():
+        need_regen = True
+        if os.path.isfile(map_path):
+            with open(map_path) as f:
+                existing = json.load(f)
+            if any(m.get("match_type") == "pathmap" for m in existing.get("mappings", [])):
+                need_regen = False
+        if need_regen:
+            mappings = build_mappings()
+            os.makedirs(claude_dir, exist_ok=True)
+            with open(map_path, "w") as f:
+                json.dump({"mappings": mappings}, f, indent=2)
+            log(f"Regenerated mapping: {len(mappings)} entries")
             for m in mappings:
-                print(f"    {m['label']}: {m['host_dir']} -> {m['container_dir']}", file=sys.stderr)
+                log(f"  {m['label']}: {m['host_dir']} -> {m['container_dir']}")
 
-    # Sync memory files
-    with open(map_path) as f:
-        data = json.load(f)
+    def read_mappings():
+        if not os.path.isfile(map_path):
+            return []
+        with open(map_path) as f:
+            return json.load(f).get("mappings", [])
 
-    synced = 0
-    for m in data.get("mappings", []):
-        src = os.path.join(host_claude, "projects", m["host_dir"], "memory")
-        dst = os.path.join(claude_dir, "projects", m["container_dir"], "memory")
-        label = m.get("label", "")
-        if not os.path.isdir(src):
-            if verbose: print(f"  {label}: no host memory — skip", file=sys.stderr)
-            continue
-        md_files = [f for f in os.listdir(src) if f.endswith(".md")]
-        if not md_files:
-            continue
+    def copy_memory(src_base, dst_base, mappings, src_key, dst_key):
+        synced = 0
+        for m in mappings:
+            src = os.path.join(src_base, "projects", m[src_key], "memory")
+            dst = os.path.join(dst_base, "projects", m[dst_key], "memory")
+            label = m.get("label", "")
+            if not os.path.isdir(src):
+                log(f"{label}: no memory at {src_key} — skip")
+                continue
+            md_files = [f for f in os.listdir(src) if f.endswith(".md")]
+            if not md_files:
+                continue
+            if dry_run:
+                log(f"DRY-RUN: {label}: {len(md_files)} file(s)")
+                continue
+            os.makedirs(dst, exist_ok=True)
+            copied = 0
+            for fname in md_files:
+                s, d = os.path.join(src, fname), os.path.join(dst, fname)
+                if not os.path.exists(d) or os.path.getmtime(s) > os.path.getmtime(d):
+                    shutil.copy2(s, d)
+                    copied += 1
+            if verbose and copied:
+                log(f"{label}: synced {copied}/{len(md_files)} file(s)")
+            synced += copied
+        return synced
+
+    def run_cmd(args, check=False):
+        r = subprocess.run(args, capture_output=True, text=True)
+        if check and r.returncode != 0:
+            raise RuntimeError(f"{' '.join(args)} failed: {r.stderr}")
+        return r
+
+    def get_host_remote_url():
+        git_config = os.path.join(host_claude, ".git", "config")
+        if not os.path.isfile(git_config):
+            return None
+        in_remote = False
+        with open(git_config) as f:
+            for line in f:
+                line = line.strip()
+                if line == '[remote "origin"]':
+                    in_remote = True
+                elif line.startswith("["):
+                    in_remote = False
+                elif in_remote and line.startswith("url = "):
+                    return line.split("= ", 1)[1]
+        return None
+
+    def get_github_slug(url):
+        m = re.search(r'github\.com[:/]([^/]+/[^/]+?)(?:\.git)?$', url)
+        return m.group(1) if m else None
+
+    # ── SessionStart: pull host memory into container ────────────────
+    def sync_from_host():
+        ensure_mapping()
+        mappings = read_mappings()
+        synced = copy_memory(host_claude, claude_dir, mappings, "host_dir", "container_dir")
+        log(f"Memory sync complete: {synced} file(s) updated.")
+
+    # ── SessionEnd: push container memory back via git ───────────────
+    def push_to_remote():
+        remote_url = get_host_remote_url()
+        if not remote_url:
+            log("No git remote on host ~/.claude — writeback disabled")
+            return
+
+        slug = get_github_slug(remote_url)
+        if not slug:
+            log(f"Cannot parse GitHub slug from: {remote_url} — writeback disabled")
+            return
+
+        if not os.path.isdir(sync_dir):
+            log(f"Cloning {slug} for writeback...")
+            r = run_cmd(["gh", "repo", "clone", slug, sync_dir])
+            if r.returncode != 0:
+                log(f"Clone failed: {r.stderr.strip()} — writeback disabled")
+                return
+            run_cmd(["git", "-C", sync_dir, "config", "user.name", "isx-memory-sync"])
+            run_cmd(["git", "-C", sync_dir, "config", "user.email", "memory-sync@incus-spawn"])
+
+        run_cmd(["git", "-C", sync_dir, "pull", "--rebase", "--quiet"])
+
+        mappings = read_mappings()
+        synced = copy_memory(claude_dir, sync_dir, mappings, "container_dir", "host_dir")
+
+        if synced == 0:
+            log("No memory changes to push.")
+            return
+
         if dry_run:
-            print(f"  DRY-RUN: {label}: {len(md_files)} file(s)", file=sys.stderr)
-            continue
-        os.makedirs(dst, exist_ok=True)
-        copied = 0
-        for fname in md_files:
-            s, d = os.path.join(src, fname), os.path.join(dst, fname)
-            if not os.path.exists(d) or os.path.getmtime(s) > os.path.getmtime(d):
-                shutil.copy2(s, d)
-                copied += 1
-        if verbose and copied:
-            print(f"  {label}: synced {copied}/{len(md_files)} file(s)", file=sys.stderr)
-        synced += copied
+            log(f"DRY-RUN: would commit and push {synced} file(s)")
+            return
 
-    if verbose:
-        print(f"Memory sync complete: {synced} file(s) updated.", file=sys.stderr)
+        run_cmd(["git", "-C", sync_dir, "add", "--all"])
+
+        r = run_cmd(["git", "-C", sync_dir, "diff", "--cached", "--quiet"])
+        if r.returncode == 0:
+            log("No memory changes to push (git sees no diff).")
+            return
+
+        hostname = run_cmd(["hostname"]).stdout.strip()
+        run_cmd(["git", "-C", sync_dir, "commit", "-m",
+                 f"memory sync from container {hostname}"])
+
+        r = run_cmd(["git", "-C", sync_dir, "push"])
+        if r.returncode != 0:
+            log(f"Push failed: {r.stderr.strip()}")
+            return
+
+        log(f"Pushed memory changes to {slug}.")
+
+    # ── Dispatch ─────────────────────────────────────────────────────
+    if push_mode:
+        push_to_remote()
+    else:
+        sync_from_host()
     PYEOF
     SYNCEOF
     sed -i "s|%%PATHMAP%%|${param_pathmap}|g" ~/.claude/bin/memory-sync.sh
@@ -142,7 +236,8 @@ run_as_user:
     import json, os
 
     settings_path = os.path.expanduser("~/.claude/settings.json")
-    hook_command = "~/.claude/bin/memory-sync.sh"
+    sync_cmd = "~/.claude/bin/memory-sync.sh"
+    push_cmd = "~/.claude/bin/memory-sync.sh --push"
 
     settings = {}
     if os.path.isfile(settings_path):
@@ -152,24 +247,24 @@ run_as_user:
     if "hooks" not in settings:
         settings["hooks"] = {}
 
-    for event in ["SessionStart", "SessionEnd"]:
+    hook_entries = {"SessionStart": sync_cmd, "SessionEnd": push_cmd}
+    for event, command in hook_entries.items():
         if event not in settings["hooks"]:
             settings["hooks"][event] = []
-
-    already = any(
-        hook.get("command", "") == hook_command
-        for group in settings["hooks"]["SessionStart"]
-        for hook in group.get("hooks", [])
-    )
-    if not already:
-        settings["hooks"]["SessionStart"].append({
-            "hooks": [{"type": "command", "command": hook_command}]
-        })
+        already = any(
+            hook.get("command", "") == command
+            for group in settings["hooks"][event]
+            for hook in group.get("hooks", [])
+        )
+        if not already:
+            settings["hooks"][event].append({
+                "hooks": [{"type": "command", "command": command}]
+            })
 
     with open(settings_path, "w") as f:
         json.dump(settings, f, indent=2)
 
-    print("  SessionStart hook registered in ~/.claude/settings.json")
+    print("  SessionStart + SessionEnd hooks registered")
     PYEOF
   - |
     if [ -d /mnt/host-claude ]; then

--- a/src/main/resources/tools/claude-memory-sync.yaml
+++ b/src/main/resources/tools/claude-memory-sync.yaml
@@ -1,13 +1,11 @@
 name: claude-memory-sync
-description: Sync Claude Code project memory from host to container at session boundaries
+description: Sync Claude Code project memory between host and container at session boundaries
 
 parameters:
   pathmap:
     type: string
     description: >
       Comma-separated host_rel:container_rel path pairs relative to home.
-      Maps host project directories to their container equivalents so that
-      Claude Code memory can be copied between path-encoded directories.
       Example: "claude/casehub:casehub,.hortora:.hortora"
 
 run_as_user:
@@ -16,21 +14,19 @@ run_as_user:
     cat > ~/.claude/bin/memory-sync.sh << 'SYNCEOF'
     #!/bin/bash
     set -euo pipefail
-    export HOST_CLAUDE="/mnt/host-claude"
-    export CLAUDE_DIR="$HOME/.claude"
     export PATHMAP="%%PATHMAP%%"
+    export SYNC_REPO="$HOME/.claude-sync"
 
-    [ -d "$HOST_CLAUDE/projects" ] || exit 0
+    [ -d "$SYNC_REPO/.git" ] || exit 0
 
     python3 - "$@" << 'PYEOF'
-    import json, os, re, shutil, subprocess, sys
+    import json, os, shutil, subprocess, sys
 
-    host_claude = os.environ["HOST_CLAUDE"]
-    claude_dir = os.environ["CLAUDE_DIR"]
+    sync_repo = os.environ["SYNC_REPO"]
+    claude_dir = os.path.expanduser("~/.claude")
     home = os.path.expanduser("~")
     map_path = os.path.join(claude_dir, "memory-map.json")
     pathmap_raw = os.environ.get("PATHMAP", "")
-    sync_dir = os.path.join(home, ".claude-sync")
     verbose = "--verbose" in sys.argv or "--dry-run" in sys.argv
     dry_run = "--dry-run" in sys.argv
     push_mode = "--push" in sys.argv
@@ -42,14 +38,11 @@ run_as_user:
         return p.replace("/", "-")
 
     def discover_host_home():
-        d = os.path.join(host_claude, "projects")
+        d = os.path.join(sync_repo, "projects")
         if not os.path.isdir(d):
             return None
         dirs = [e for e in os.listdir(d) if os.path.isdir(os.path.join(d, e))]
-        if not dirs:
-            return None
-        shortest = min(dirs, key=len)
-        return "/" + shortest.lstrip("-").replace("-", "/")
+        return "/" + min(dirs, key=len).lstrip("-").replace("-", "/") if dirs else None
 
     def find_repos(base):
         if not os.path.isdir(base):
@@ -78,10 +71,9 @@ run_as_user:
             container_base = os.path.join(home, container_rel)
             for repo in find_repos(container_base):
                 name = os.path.basename(repo)
-                host_path = os.path.join(host_base, name)
-                h_enc = encode_path(host_path)
+                h_enc = encode_path(os.path.join(host_base, name))
                 c_enc = encode_path(repo)
-                if os.path.isdir(os.path.join(host_claude, "projects", h_enc, "memory")):
+                if os.path.isdir(os.path.join(sync_repo, "projects", h_enc, "memory")):
                     mappings.append({
                         "host_dir": h_enc, "container_dir": c_enc,
                         "label": os.path.relpath(repo, home), "match_type": "pathmap"
@@ -104,20 +96,13 @@ run_as_user:
             for m in mappings:
                 log(f"  {m['label']}: {m['host_dir']} -> {m['container_dir']}")
 
-    def read_mappings():
-        if not os.path.isfile(map_path):
-            return []
-        with open(map_path) as f:
-            return json.load(f).get("mappings", [])
-
-    def copy_memory(src_base, dst_base, mappings, src_key, dst_key):
+    def sync_files(src_base, dst_base, mappings, src_key, dst_key):
         synced = 0
         for m in mappings:
             src = os.path.join(src_base, "projects", m[src_key], "memory")
             dst = os.path.join(dst_base, "projects", m[dst_key], "memory")
             label = m.get("label", "")
             if not os.path.isdir(src):
-                log(f"{label}: no memory at {src_key} — skip")
                 continue
             md_files = [f for f in os.listdir(src) if f.endswith(".md")]
             if not md_files:
@@ -132,101 +117,50 @@ run_as_user:
                 if not os.path.exists(d) or os.path.getmtime(s) > os.path.getmtime(d):
                     shutil.copy2(s, d)
                     copied += 1
-            if verbose and copied:
+            if copied:
                 log(f"{label}: synced {copied}/{len(md_files)} file(s)")
             synced += copied
         return synced
 
-    def run_cmd(args, check=False):
-        r = subprocess.run(args, capture_output=True, text=True)
-        if check and r.returncode != 0:
-            raise RuntimeError(f"{' '.join(args)} failed: {r.stderr}")
-        return r
+    ensure_mapping()
+    if not os.path.isfile(map_path):
+        sys.exit(0)
+    with open(map_path) as f:
+        mappings = json.load(f).get("mappings", [])
 
-    def get_host_remote_url():
-        git_config = os.path.join(host_claude, ".git", "config")
-        if not os.path.isfile(git_config):
-            return None
-        in_remote = False
-        with open(git_config) as f:
-            for line in f:
-                line = line.strip()
-                if line == '[remote "origin"]':
-                    in_remote = True
-                elif line.startswith("["):
-                    in_remote = False
-                elif in_remote and line.startswith("url = "):
-                    return line.split("= ", 1)[1]
-        return None
-
-    def get_github_slug(url):
-        m = re.search(r'github\.com[:/]([^/]+/[^/]+?)(?:\.git)?$', url)
-        return m.group(1) if m else None
-
-    # ── SessionStart: pull host memory into container ────────────────
-    def sync_from_host():
-        ensure_mapping()
-        mappings = read_mappings()
-        synced = copy_memory(host_claude, claude_dir, mappings, "host_dir", "container_dir")
-        log(f"Memory sync complete: {synced} file(s) updated.")
-
-    # ── SessionEnd: push container memory back via git ───────────────
-    def push_to_remote():
-        remote_url = get_host_remote_url()
-        if not remote_url:
-            log("No git remote on host ~/.claude — writeback disabled")
-            return
-
-        slug = get_github_slug(remote_url)
-        if not slug:
-            log(f"Cannot parse GitHub slug from: {remote_url} — writeback disabled")
-            return
-
-        if not os.path.isdir(sync_dir):
-            log(f"Cloning {slug} for writeback...")
-            r = run_cmd(["gh", "repo", "clone", slug, sync_dir])
-            if r.returncode != 0:
-                log(f"Clone failed: {r.stderr.strip()} — writeback disabled")
-                return
-            run_cmd(["git", "-C", sync_dir, "config", "user.name", "isx-memory-sync"])
-            run_cmd(["git", "-C", sync_dir, "config", "user.email", "memory-sync@incus-spawn"])
-
-        run_cmd(["git", "-C", sync_dir, "pull", "--rebase", "--quiet"])
-
-        mappings = read_mappings()
-        synced = copy_memory(claude_dir, sync_dir, mappings, "container_dir", "host_dir")
-
-        if synced == 0:
-            log("No memory changes to push.")
-            return
-
-        if dry_run:
-            log(f"DRY-RUN: would commit and push {synced} file(s)")
-            return
-
-        run_cmd(["git", "-C", sync_dir, "add", "--all"])
-
-        r = run_cmd(["git", "-C", sync_dir, "diff", "--cached", "--quiet"])
-        if r.returncode == 0:
-            log("No memory changes to push (git sees no diff).")
-            return
-
-        hostname = run_cmd(["hostname"]).stdout.strip()
-        run_cmd(["git", "-C", sync_dir, "commit", "-m",
-                 f"memory sync from container {hostname}"])
-
-        r = run_cmd(["git", "-C", sync_dir, "push"])
-        if r.returncode != 0:
-            log(f"Push failed: {r.stderr.strip()}")
-            return
-
-        log(f"Pushed memory changes to {slug}.")
-
-    # ── Dispatch ─────────────────────────────────────────────────────
     if push_mode:
-        push_to_remote()
+        synced = sync_files(claude_dir, sync_repo, mappings, "container_dir", "host_dir")
+        if synced > 0 and not dry_run:
+            subprocess.run(["git", "-C", sync_repo, "add", "--all"], capture_output=True)
+            r = subprocess.run(["git", "-C", sync_repo, "diff", "--cached", "--quiet"],
+                               capture_output=True)
+            if r.returncode != 0:
+                hostname = subprocess.run(["hostname"], capture_output=True, text=True).stdout.strip()
+                subprocess.run(["git", "-C", sync_repo, "commit", "-m",
+                               f"memory sync from {hostname}"], capture_output=True)
+                log(f"Committed {synced} file(s) to sync repo.")
+                r = subprocess.run(["git", "-C", sync_repo, "push"],
+                                   capture_output=True, text=True)
+                if r.returncode == 0:
+                    log("Pushed to remote.")
+                else:
+                    log("Committed locally (no remote or push failed — host can fetch via SSH).")
+        elif synced == 0:
+            log("No changes to write back.")
     else:
-        sync_from_host()
+        subprocess.run(["git", "-C", sync_repo, "pull", "--rebase", "--quiet"],
+                       capture_output=True)
+        synced = sync_files(sync_repo, claude_dir, mappings, "host_dir", "container_dir")
+        global_files = ["CLAUDE.md", "engagement.md", "working-style.md",
+                        "document-boundaries.md", "design-implementation.md",
+                        "config-architecture.md"]
+        for gf in global_files:
+            src = os.path.join(sync_repo, gf)
+            dst = os.path.join(claude_dir, gf)
+            if os.path.isfile(src):
+                if not os.path.exists(dst) or os.path.getmtime(src) > os.path.getmtime(dst):
+                    shutil.copy2(src, dst)
+        log(f"Sync complete: {synced} file(s) pulled from host.")
     PYEOF
     SYNCEOF
     sed -i "s|%%PATHMAP%%|${param_pathmap}|g" ~/.claude/bin/memory-sync.sh
@@ -236,9 +170,6 @@ run_as_user:
     import json, os
 
     settings_path = os.path.expanduser("~/.claude/settings.json")
-    sync_cmd = "~/.claude/bin/memory-sync.sh"
-    push_cmd = "~/.claude/bin/memory-sync.sh --push"
-
     settings = {}
     if os.path.isfile(settings_path):
         with open(settings_path) as f:
@@ -247,7 +178,10 @@ run_as_user:
     if "hooks" not in settings:
         settings["hooks"] = {}
 
-    hook_entries = {"SessionStart": sync_cmd, "SessionEnd": push_cmd}
+    hook_entries = {
+        "SessionStart": "~/.claude/bin/memory-sync.sh",
+        "SessionEnd": "~/.claude/bin/memory-sync.sh --push"
+    }
     for event, command in hook_entries.items():
         if event not in settings["hooks"]:
             settings["hooks"][event] = []
@@ -267,9 +201,9 @@ run_as_user:
     print("  SessionStart + SessionEnd hooks registered")
     PYEOF
   - |
-    if [ -d /mnt/host-claude ]; then
+    if [ -d ~/.claude-sync ]; then
       for f in CLAUDE.md engagement.md working-style.md document-boundaries.md design-implementation.md config-architecture.md; do
-        [ -f "/mnt/host-claude/$f" ] && cp "/mnt/host-claude/$f" ~/.claude/
+        [ -f "$HOME/.claude-sync/$f" ] && cp "$HOME/.claude-sync/$f" ~/.claude/
       done
     fi
   - PATHMAP="${param_pathmap}" ~/.claude/bin/memory-sync.sh --verbose || true


### PR DESCRIPTION
## Context — the problem

Claude Code stores per-project memory at `~/.claude/projects/<path-encoded>/memory/`. The encoding converts filesystem paths by replacing `/` with `-`:

```
Host:      /Users/mdproctor/claude/casehub/parent  →  -Users-mdproctor-claude-casehub-parent
Container: /home/agentuser/casehub/parent          →  -home-agentuser-casehub-parent
```

Same project, different identity. Every container session starts with amnesia — no memory of prior work, feedback, or project context from the host.

## What this PR adds

A built-in tool (`claude-memory-sync`) that provides **bidirectional** memory sync using isx's existing repo-cloning infrastructure. No special mounts, no external services required.

### Architecture

The host's `~/.claude` directory (which is a git repo) is declared as a template repo, cloned into `~/.claude-sync` inside the container. The tool uses Claude Code's `SessionStart` and `SessionEnd` hooks to sync at session boundaries:

**SessionStart (pull):**
1. `git pull --rebase` in `~/.claude-sync` (picks up host changes)
2. Copy `.md` memory files from host-encoded dirs → container-encoded dirs
3. Refresh global instruction files (CLAUDE.md, engagement.md, etc.)

**SessionEnd (push):**
1. Copy container-encoded memory → host-encoded dirs in `~/.claude-sync`
2. `git commit` locally
3. `git push` if a remote is configured (optional — host can also fetch via SSH)

### Path mapping

The tool takes a `pathmap` parameter — explicit `host_rel:container_rel` pairs:

```yaml
tools:
  - claude-memory-sync:
      pathmap: "claude/casehub:casehub,.hortora:.hortora"
```

This says: host repos under `~/claude/casehub/` correspond to container repos under `~/casehub/`. The host home path is auto-discovered from the cloned repo's project directory structure.

### Usage

Template authors add the repo and the tool:

```yaml
repos:
  - url: https://github.com/user/claude-memory.git  # or any git remote
    path: ~/.claude-sync

tools:
  - claude-memory-sync:
      pathmap: "my/projects:projects"
```

The GitHub remote is **optional**. Without it, the container commits locally and the host can fetch via SSH whenever needed. With it, both sides push/pull automatically.

Host-side hooks (added to host `~/.claude/settings.json`):
- `SessionEnd`: auto-commits memory changes and pushes if remote configured
- `SessionStart`: pulls if remote configured

## Discussion point: auto-remote gap

isx creates auto-remotes for repos in the template's `repos:` section by matching against `host-paths` directories. However, `~/.claude` isn't under any `host-paths` directory, so no auto-remote is created on the host.

If `repo-paths` entries were also included in auto-remote matching, the host would get a remote pointing to the container's `~/.claude-sync` automatically. This would eliminate the GitHub intermediary entirely — the host would just `git -C ~/.claude fetch <container>` via the isx gateway.

Currently `repo-paths` only affects `isx://` URL resolution. Extending it to auto-remote matching would make the memory sync fully native to isx with zero external dependencies.

## Tested

Full bidirectional round-trip verified:
1. Container SessionStart: pulled host memory (2 project + 4 global files)
2. Created test memory file inside container
3. Container SessionEnd: committed to `~/.claude-sync`, pushed to GitHub
4. Host: pulled from GitHub, test file appeared at correct host-encoded path
5. Host SessionEnd: auto-committed, pushed
6. Container SessionStart: pulled fresh host changes

## Status

This PR is an RFC — sharing the approach for discussion. The tool works as a user-level tool today. Open questions:

1. Should this be built-in or stay user-level?
2. Could `repo-paths` entries participate in auto-remote matching? That would eliminate the GitHub dependency.
3. Is there a better way to handle the tool-install-before-repo-clone timing? Currently the mapping auto-regenerates at first session start.