### PR TITLE
feat: add post_repos hook for tools

### DIFF
--- a/src/main/java/dev/incusspawn/command/BuildCommand.java
+++ b/src/main/java/dev/incusspawn/command/BuildCommand.java
@@ -665,6 +665,7 @@ public class BuildCommand extends BaseCommand {
         maskServices(container, imageDef);
         installSkills(container, imageDef, defs);
         cloneRepos(container, imageDef);
+        runPostReposHooks(container, toolResolution.effective());
         updateClaudeJsonTrust(container, imageDef);
 
         HostResourceSetup.removeBuildDevices(incus, buildName, hostResources);
@@ -824,6 +825,7 @@ public class BuildCommand extends BaseCommand {
         writeEnvFile(container, imageDef, defs, tools, canonicalName);
         installSkills(container, imageDef, defs);
         cloneRepos(container, imageDef);
+        runPostReposHooks(container, tools);
         updateClaudeJsonTrust(container, imageDef);
 
         HostResourceSetup.removeBuildDevices(incus, buildName, hostResources);
@@ -1214,6 +1216,12 @@ public class BuildCommand extends BaseCommand {
 
         var script = resolver.resolve();
         container.writeFile("/etc/profile.d/isx-env.sh", script);
+    }
+
+    private void runPostReposHooks(Container container, List<ResolvedTool> tools) {
+        for (var resolved : tools) {
+            resolved.setup().postRepos(container, resolved.parameters());
+        }
     }
 
     private static ToolSetup findTool(String name, ToolDefLoader toolDefLoader, Iterable<ToolSetup> cdiTools) {

--- a/src/main/java/dev/incusspawn/tool/ToolDef.java
+++ b/src/main/java/dev/incusspawn/tool/ToolDef.java
@@ -57,6 +57,8 @@ public class ToolDef {
     @JsonProperty("package_repos")
     private List<ImageDef.PackageRepo> packageRepos = List.of();
     private Map<String, ParameterDef> parameters = Map.of();
+    @JsonProperty("post_repos")
+    private List<String> postRepos = List.of();
 
     private transient volatile String cachedFingerprint;
 
@@ -90,6 +92,8 @@ public class ToolDef {
     public void setParameters(Map<String, ParameterDef> parameters) {
         this.parameters = parameters != null ? parameters : Map.of();
     }
+    public List<String> getPostRepos() { return postRepos; }
+    public void setPostRepos(List<String> postRepos) { this.postRepos = postRepos; }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static class DownloadEntry {

--- a/src/main/java/dev/incusspawn/tool/ToolSetup.java
+++ b/src/main/java/dev/incusspawn/tool/ToolSetup.java
@@ -59,4 +59,10 @@ public interface ToolSetup {
     default void reconfigure(Container container, java.util.Map<String, String> resolvedParams) {
         install(container, resolvedParams);
     }
+
+    /**
+     * Run post-repos scripts after all template repos have been cloned.
+     * Called once after cloneRepos() completes. Default is a no-op.
+     */
+    default void postRepos(Container container, java.util.Map<String, String> resolvedParams) {}
 }

--- a/src/main/java/dev/incusspawn/tool/YamlToolSetup.java
+++ b/src/main/java/dev/incusspawn/tool/YamlToolSetup.java
@@ -116,6 +116,15 @@ public class YamlToolSetup implements ToolSetup {
         }
     }
 
+    @Override
+    public void postRepos(Container container, java.util.Map<String, String> resolvedParams) {
+        for (var script : def.getPostRepos()) {
+            var substituted = ParameterSubstitutor.substitute(script, resolvedParams);
+            container.runAsUser("agentuser", substituted,
+                    "Failed to run post-repos for " + def.getName());
+        }
+    }
+
     static String canonicalArch(String arch) {
         return switch (arch) {
             case "amd64", "x86_64" -> "x86_64";


### PR DESCRIPTION
## Summary

Adds a `post_repos` field to tool definitions — scripts that run as `agentuser` after all template repos have been cloned.

## Motivation

Tools install before repos clone (build order: `installTools → cloneRepos`). Tools that need to generate config based on cloned repo structure currently have no clean way to do so. The existing per-repo `prime` field handles repo-specific post-clone work, but there's no per-tool hook for cross-repo setup.

## YAML format

```yaml
name: my-tool
run_as_user:
  - echo "install-time setup"
post_repos:
  - echo "repos are now available"
  - ls ~/my-repo/.git
```

## Build order (updated)

```
installTools → maskServices → installSkills → cloneRepos → postReposHooks → updateClaudeJsonTrust
```

## Implementation

- `ToolDef.java`: new `post_repos` field (List<String>)
- `ToolSetup.java`: new `postRepos()` default method (no-op)
- `YamlToolSetup.java`: implements `postRepos()` — runs scripts with parameter substitution
- `BuildCommand.java`: calls `runPostReposHooks()` after `cloneRepos()` in both `buildFromParent()` and `buildFromScratch()`

## Use case: Claude Code memory sync

The `claude-memory-sync` tool generates a host↔container path mapping that depends on knowing which repos exist. Currently it works around the timing gap by auto-regenerating the mapping at first session start. With `post_repos`, it can generate the mapping at build time — no workaround needed.

## Related

- #277 — repo mapping file (complementary: isx writes a mapping, this hook lets tools consume it)
- #269 (closed) — Claude Code memory portability RFC