### PR TITLE
feat: add bidirectional isx sync command

### DIFF
--- a/src/main/java/dev/incusspawn/IncusSpawn.java
+++ b/src/main/java/dev/incusspawn/IncusSpawn.java
@@ -41,7 +41,7 @@ public class IncusSpawn implements QuarkusApplication {
                 DestroyCommand.class, UpdateAllCommand.class, ProxyCommand.class,
                 CleanCommand.class, CompletionCommand.class, TemplatesCommand.class,
                 InstancesCommand.class, GitRemoteHelperCommand.class, SshProxyCommand.class,
-                VmCommand.class, UpdateBaseCommand.class, DoctorCommand.class
+                VmCommand.class, UpdateBaseCommand.class, DoctorCommand.class, SyncCommand.class
             }, generateHelp = true)
     public static class IncusSpawnCommand extends BaseCommand {
         @Option(shortName = 'V', name = "version", hasValue = false, description = "Display version info")

--- a/src/main/java/dev/incusspawn/command/SyncCommand.java
+++ b/src/main/java/dev/incusspawn/command/SyncCommand.java
@@ -9,7 +9,6 @@ import org.aesh.command.option.Argument;
 import org.aesh.command.option.Option;
 
 import java.nio.file.Files;
-import java.nio.file.Path;
 
 @CommandDefinition(
         name = "sync",
@@ -51,6 +50,11 @@ public class SyncCommand extends BaseCommand {
         boolean doPull = !pushOnly;
         boolean doPush = !pullOnly;
 
+        if (doPush) {
+            incus.execInContainer(name, "agentuser",
+                    "git", "config", "--global", "receive.denyCurrentBranch", "updateInstead");
+        }
+
         int pulled = 0;
         int pushed = 0;
         int failed = 0;
@@ -88,7 +92,7 @@ public class SyncCommand extends BaseCommand {
 
             if (doPush) {
                 System.out.print("  Pushing  " + repoName + " (" + branch + ")... ");
-                var result = GitRemoteUtils.hostGitExec(hostPath, "push", name, branch);
+                var result = GitRemoteUtils.hostGitExec(hostPath, "push", "--no-verify", name, branch);
                 if (result != null) {
                     System.out.println("done");
                     pushed++;

--- a/src/main/java/dev/incusspawn/command/SyncCommand.java
+++ b/src/main/java/dev/incusspawn/command/SyncCommand.java
@@ -1,6 +1,8 @@
 package dev.incusspawn.command;
 
 import dev.incusspawn.RuntimeServices;
+import dev.incusspawn.config.HostResourceSetup;
+import dev.incusspawn.config.ImageDef;
 import dev.incusspawn.config.SpawnConfig;
 import dev.incusspawn.git.GitRemoteUtils;
 import dev.incusspawn.incus.IncusClient;
@@ -10,6 +12,10 @@ import org.aesh.command.option.Argument;
 import org.aesh.command.option.Option;
 
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
 
 @CommandDefinition(
         name = "sync",
@@ -21,10 +27,10 @@ public class SyncCommand extends BaseCommand {
     @Argument(description = "Name of the instance to sync", required = true)
     String name;
 
-    @Option(name = "push", hasValue = false, description = "Push only (host → container)")
+    @Option(name = "push", hasValue = false, description = "Push only (host to container)")
     boolean pushOnly;
 
-    @Option(name = "pull", hasValue = false, description = "Pull only (container → host)")
+    @Option(name = "pull", hasValue = false, description = "Pull only (container to host)")
     boolean pullOnly;
 
     @Override
@@ -42,7 +48,7 @@ public class SyncCommand extends BaseCommand {
         }
 
         var config = SpawnConfig.load();
-        var repos = GitRemoteUtils.collectReposForInstance(name, incus);
+        var repos = collectAllSyncTargets(incus, config);
         if (repos.isEmpty()) {
             System.out.println("No repos found for instance '" + name + "'.");
             return CommandResult.SUCCESS;
@@ -58,23 +64,26 @@ public class SyncCommand extends BaseCommand {
 
         int pulled = 0;
         int pushed = 0;
+        int skipped = 0;
         int failed = 0;
 
-        for (var repo : repos) {
-            var repoName = GitRemoteUtils.repoNameFromUrl(repo.getUrl());
-            if (repoName.isEmpty()) continue;
-
-            var hostPath = GitRemoteUtils.resolveHostRepoPath(repoName, config);
-            if (hostPath == null || !Files.isDirectory(hostPath) || !GitRemoteUtils.isGitRepo(hostPath)) continue;
+        for (var target : repos) {
+            var hostPath = target.hostPath;
+            var repoName = target.name;
 
             var remoteUrl = GitRemoteUtils.getHostRepoRemoteUrl(hostPath, name);
-            if (remoteUrl == null || !remoteUrl.startsWith("isx://")) continue;
+            if (remoteUrl == null || !remoteUrl.startsWith("isx://")) {
+                skipped++;
+                continue;
+            }
 
             var hostBranch = GitRemoteUtils.hostGitExec(hostPath, "rev-parse", "--abbrev-ref", "HEAD");
             if (hostBranch == null) hostBranch = "main";
 
             if (doPull) {
-                var containerBranch = getContainerBranch(incus, repo.getPath());
+                var containerPath = GitRemoteUtils.parseIsxUrl(remoteUrl);
+                var containerBranch = containerPath != null
+                        ? getContainerBranch(incus, containerPath.path()) : null;
                 if (containerBranch == null) containerBranch = hostBranch;
 
                 System.out.print("  Fetching " + repoName + " (" + containerBranch + ")... ");
@@ -112,15 +121,55 @@ public class SyncCommand extends BaseCommand {
             }
         }
 
-        var summary = new StringBuilder("Synced " + repos.size() + " repos with " + name + ":");
+        int synced = repos.size() - skipped;
+        var summary = new StringBuilder("Synced " + synced + " repos with " + name + ":");
         if (doPull) summary.append(" ").append(pulled).append(" pulled");
         if (doPull && doPush) summary.append(",");
         if (doPush) summary.append(" ").append(pushed).append(" pushed");
         if (failed > 0) summary.append(", ").append(failed).append(" failed");
+        if (skipped > 0) summary.append(", ").append(skipped).append(" skipped (no isx remote)");
         summary.append(".");
         System.out.println(summary);
 
         return failed > 0 ? CommandResult.valueOf(1) : CommandResult.SUCCESS;
+    }
+
+    record SyncTarget(String name, Path hostPath) {}
+
+    private List<SyncTarget> collectAllSyncTargets(IncusClient incus, SpawnConfig config) {
+        var targets = new ArrayList<SyncTarget>();
+        var seen = new HashSet<String>();
+
+        // Template-declared repos
+        var templateRepos = GitRemoteUtils.collectReposForInstance(name, incus);
+        for (var repo : templateRepos) {
+            var repoName = GitRemoteUtils.repoNameFromUrl(repo.getUrl());
+            if (repoName.isEmpty() || !seen.add(repoName)) continue;
+            var hostPath = GitRemoteUtils.resolveHostRepoPath(repoName, config);
+            if (hostPath != null && Files.isDirectory(hostPath) && GitRemoteUtils.isGitRepo(hostPath)) {
+                targets.add(new SyncTarget(repoName, hostPath));
+            }
+        }
+
+        // All repos under host-paths that have an isx:// remote for this instance
+        for (var hp : config.getHostPaths()) {
+            var basePath = Path.of(HostResourceSetup.expandHostTilde(hp));
+            if (!Files.isDirectory(basePath)) continue;
+            try (var stream = Files.list(basePath)) {
+                stream.filter(Files::isDirectory)
+                      .filter(GitRemoteUtils::isGitRepo)
+                      .forEach(repoPath -> {
+                          var repoName = repoPath.getFileName().toString();
+                          if (!seen.add(repoName)) return;
+                          var remoteUrl = GitRemoteUtils.getHostRepoRemoteUrl(repoPath, name);
+                          if (remoteUrl != null && remoteUrl.startsWith("isx://")) {
+                              targets.add(new SyncTarget(repoName, repoPath));
+                          }
+                      });
+            } catch (java.io.IOException ignored) {}
+        }
+
+        return targets;
     }
 
     private String getContainerBranch(IncusClient incus, String containerRepoPath) {

--- a/src/main/java/dev/incusspawn/command/SyncCommand.java
+++ b/src/main/java/dev/incusspawn/command/SyncCommand.java
@@ -1,0 +1,112 @@
+package dev.incusspawn.command;
+
+import dev.incusspawn.RuntimeServices;
+import dev.incusspawn.config.SpawnConfig;
+import dev.incusspawn.git.GitRemoteUtils;
+import org.aesh.command.CommandDefinition;
+import org.aesh.command.CommandResult;
+import org.aesh.command.option.Argument;
+import org.aesh.command.option.Option;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+@CommandDefinition(
+        name = "sync",
+        description = "Sync repos between host and a running instance via auto-remotes",
+        generateHelp = true
+)
+public class SyncCommand extends BaseCommand {
+
+    @Argument(description = "Name of the instance to sync", required = true)
+    String name;
+
+    @Option(name = "push", hasValue = false, description = "Push only (host → container)")
+    boolean pushOnly;
+
+    @Option(name = "pull", hasValue = false, description = "Pull only (container → host)")
+    boolean pullOnly;
+
+    @Override
+    protected CommandResult doExecute() throws Exception {
+        if (pushOnly && pullOnly) {
+            System.err.println("Error: --push and --pull are mutually exclusive. Omit both for bidirectional sync.");
+            return CommandResult.valueOf(1);
+        }
+
+        var incus = RuntimeServices.incus();
+
+        if (!incus.exists(name)) {
+            System.err.println("Error: no instance named '" + name + "' found.");
+            return CommandResult.valueOf(1);
+        }
+
+        var config = SpawnConfig.load();
+        var repos = GitRemoteUtils.collectReposForInstance(name, incus);
+        if (repos.isEmpty()) {
+            System.out.println("No repos found for instance '" + name + "'.");
+            return CommandResult.SUCCESS;
+        }
+
+        boolean doPull = !pushOnly;
+        boolean doPush = !pullOnly;
+
+        int pulled = 0;
+        int pushed = 0;
+        int failed = 0;
+
+        for (var repo : repos) {
+            var repoName = GitRemoteUtils.repoNameFromUrl(repo.getUrl());
+            if (repoName.isEmpty()) continue;
+
+            var hostPath = GitRemoteUtils.resolveHostRepoPath(repoName, config);
+            if (hostPath == null || !Files.isDirectory(hostPath) || !GitRemoteUtils.isGitRepo(hostPath)) continue;
+
+            var remoteUrl = GitRemoteUtils.getHostRepoRemoteUrl(hostPath, name);
+            if (remoteUrl == null || !remoteUrl.startsWith("isx://")) continue;
+
+            var branch = GitRemoteUtils.hostGitExec(hostPath, "rev-parse", "--abbrev-ref", "HEAD");
+            if (branch == null) branch = "main";
+
+            if (doPull) {
+                System.out.print("  Fetching " + repoName + " (" + branch + ")... ");
+                var fetchResult = GitRemoteUtils.hostGitExec(hostPath, "fetch", name, branch);
+                if (fetchResult != null) {
+                    var mergeResult = GitRemoteUtils.hostGitExec(hostPath, "merge", "--ff-only", "FETCH_HEAD");
+                    if (mergeResult != null) {
+                        System.out.println("done");
+                        pulled++;
+                    } else {
+                        System.out.println("fetched (can't fast-forward — diverged)");
+                        failed++;
+                    }
+                } else {
+                    System.out.println("failed");
+                    failed++;
+                }
+            }
+
+            if (doPush) {
+                System.out.print("  Pushing  " + repoName + " (" + branch + ")... ");
+                var result = GitRemoteUtils.hostGitExec(hostPath, "push", name, branch);
+                if (result != null) {
+                    System.out.println("done");
+                    pushed++;
+                } else {
+                    System.out.println("failed");
+                    failed++;
+                }
+            }
+        }
+
+        var summary = new StringBuilder("Synced " + repos.size() + " repos with " + name + ":");
+        if (doPull) summary.append(" ").append(pulled).append(" pulled");
+        if (doPull && doPush) summary.append(",");
+        if (doPush) summary.append(" ").append(pushed).append(" pushed");
+        if (failed > 0) summary.append(", ").append(failed).append(" failed");
+        summary.append(".");
+        System.out.println(summary);
+
+        return failed > 0 ? CommandResult.valueOf(1) : CommandResult.SUCCESS;
+    }
+}

--- a/src/main/java/dev/incusspawn/command/SyncCommand.java
+++ b/src/main/java/dev/incusspawn/command/SyncCommand.java
@@ -3,6 +3,7 @@ package dev.incusspawn.command;
 import dev.incusspawn.RuntimeServices;
 import dev.incusspawn.config.SpawnConfig;
 import dev.incusspawn.git.GitRemoteUtils;
+import dev.incusspawn.incus.IncusClient;
 import org.aesh.command.CommandDefinition;
 import org.aesh.command.CommandResult;
 import org.aesh.command.option.Argument;
@@ -69,20 +70,28 @@ public class SyncCommand extends BaseCommand {
             var remoteUrl = GitRemoteUtils.getHostRepoRemoteUrl(hostPath, name);
             if (remoteUrl == null || !remoteUrl.startsWith("isx://")) continue;
 
-            var branch = GitRemoteUtils.hostGitExec(hostPath, "rev-parse", "--abbrev-ref", "HEAD");
-            if (branch == null) branch = "main";
+            var hostBranch = GitRemoteUtils.hostGitExec(hostPath, "rev-parse", "--abbrev-ref", "HEAD");
+            if (hostBranch == null) hostBranch = "main";
 
             if (doPull) {
-                System.out.print("  Fetching " + repoName + " (" + branch + ")... ");
-                var fetchResult = GitRemoteUtils.hostGitExec(hostPath, "fetch", name, branch);
+                var containerBranch = getContainerBranch(incus, repo.getPath());
+                if (containerBranch == null) containerBranch = hostBranch;
+
+                System.out.print("  Fetching " + repoName + " (" + containerBranch + ")... ");
+                var fetchResult = GitRemoteUtils.hostGitExec(hostPath, "fetch", name, containerBranch);
                 if (fetchResult != null) {
-                    var mergeResult = GitRemoteUtils.hostGitExec(hostPath, "merge", "--ff-only", "FETCH_HEAD");
-                    if (mergeResult != null) {
-                        System.out.println("done");
-                        pulled++;
+                    if (containerBranch.equals(hostBranch)) {
+                        var mergeResult = GitRemoteUtils.hostGitExec(hostPath, "merge", "--ff-only", "FETCH_HEAD");
+                        if (mergeResult != null) {
+                            System.out.println("done");
+                            pulled++;
+                        } else {
+                            System.out.println("fetched (can't fast-forward — diverged)");
+                            failed++;
+                        }
                     } else {
-                        System.out.println("fetched (can't fast-forward — diverged)");
-                        failed++;
+                        System.out.println("fetched (container on " + containerBranch + ", host on " + hostBranch + ")");
+                        pulled++;
                     }
                 } else {
                     System.out.println("failed");
@@ -91,8 +100,8 @@ public class SyncCommand extends BaseCommand {
             }
 
             if (doPush) {
-                System.out.print("  Pushing  " + repoName + " (" + branch + ")... ");
-                var result = GitRemoteUtils.hostGitExec(hostPath, "push", "--no-verify", name, branch);
+                System.out.print("  Pushing  " + repoName + " (" + hostBranch + ")... ");
+                var result = GitRemoteUtils.hostGitExec(hostPath, "push", "--no-verify", name, hostBranch);
                 if (result != null) {
                     System.out.println("done");
                     pushed++;
@@ -112,5 +121,19 @@ public class SyncCommand extends BaseCommand {
         System.out.println(summary);
 
         return failed > 0 ? CommandResult.valueOf(1) : CommandResult.SUCCESS;
+    }
+
+    private String getContainerBranch(IncusClient incus, String containerRepoPath) {
+        try {
+            var path = containerRepoPath;
+            if (path.startsWith("~/")) path = "/home/agentuser/" + path.substring(2);
+            var result = incus.execInContainer(name, "agentuser",
+                    "git", "-C", path, "rev-parse", "--abbrev-ref", "HEAD");
+            if (result.success()) {
+                var branch = result.stdout().strip();
+                return branch.isEmpty() || "HEAD".equals(branch) ? null : branch;
+            }
+        } catch (Exception ignored) {}
+        return null;
     }
 }

--- a/src/main/java/dev/incusspawn/command/SyncCommand.java
+++ b/src/main/java/dev/incusspawn/command/SyncCommand.java
@@ -77,13 +77,31 @@ public class SyncCommand extends BaseCommand {
                 continue;
             }
 
+            // Verify container path exists; fix stale remote if repo was renamed
+            var parsed = GitRemoteUtils.parseIsxUrl(remoteUrl);
+            if (parsed != null) {
+                var check = incus.execInContainer(name, "agentuser", "test", "-d", parsed.path());
+                if (!check.success()) {
+                    var fixedUrl = findRepoInContainer(incus, repoName, parsed.instance(), hostPath);
+                    if (fixedUrl != null) {
+                        GitRemoteUtils.hostGitExec(hostPath, "remote", "set-url", name, fixedUrl);
+                        remoteUrl = fixedUrl;
+                        parsed = GitRemoteUtils.parseIsxUrl(fixedUrl);
+                        System.out.println("  Fixed stale remote for " + repoName + " -> " + fixedUrl);
+                    } else {
+                        System.out.println("  Skipping " + repoName + " (not found in container)");
+                        skipped++;
+                        continue;
+                    }
+                }
+            }
+
             var hostBranch = GitRemoteUtils.hostGitExec(hostPath, "rev-parse", "--abbrev-ref", "HEAD");
             if (hostBranch == null) hostBranch = "main";
 
             if (doPull) {
-                var containerPath = GitRemoteUtils.parseIsxUrl(remoteUrl);
-                var containerBranch = containerPath != null
-                        ? getContainerBranch(incus, containerPath.path()) : null;
+                var containerBranch = parsed != null
+                        ? getContainerBranch(incus, parsed.path()) : null;
                 if (containerBranch == null) containerBranch = hostBranch;
 
                 System.out.print("  Fetching " + repoName + " (" + containerBranch + ")... ");
@@ -127,11 +145,38 @@ public class SyncCommand extends BaseCommand {
         if (doPull && doPush) summary.append(",");
         if (doPush) summary.append(" ").append(pushed).append(" pushed");
         if (failed > 0) summary.append(", ").append(failed).append(" failed");
-        if (skipped > 0) summary.append(", ").append(skipped).append(" skipped (no isx remote)");
+        if (skipped > 0) summary.append(", ").append(skipped).append(" skipped");
         summary.append(".");
         System.out.println(summary);
 
         return failed > 0 ? CommandResult.valueOf(1) : CommandResult.SUCCESS;
+    }
+
+    private String findRepoInContainer(IncusClient incus, String repoName, String instanceName, Path hostPath) {
+        var hostHead = GitRemoteUtils.hostGitExec(hostPath, "rev-parse", "HEAD");
+        if (hostHead == null) return null;
+
+        var staleUrl = GitRemoteUtils.getHostRepoRemoteUrl(hostPath, instanceName);
+        if (staleUrl == null) return null;
+        var staleIsxUrl = GitRemoteUtils.parseIsxUrl(staleUrl);
+        if (staleIsxUrl == null) return null;
+        var parentDir = staleIsxUrl.path().substring(0, staleIsxUrl.path().lastIndexOf('/'));
+
+        var result = incus.execInContainer(name, "agentuser",
+                "find", parentDir, "-maxdepth", "2", "-mindepth", "1",
+                "-type", "d", "-name", ".git");
+        if (!result.success()) return null;
+
+        for (var line : result.stdout().strip().split("\n")) {
+            if (line.isBlank()) continue;
+            var repoDir = line.replace("/.git", "");
+            var catResult = incus.execInContainer(name, "agentuser",
+                    "git", "-C", repoDir, "cat-file", "-t", hostHead);
+            if (catResult.success() && "commit".equals(catResult.stdout().strip())) {
+                return "isx://" + instanceName + repoDir;
+            }
+        }
+        return null;
     }
 
     record SyncTarget(String name, Path hostPath) {}

--- a/src/main/java/dev/incusspawn/git/GitRemoteUtils.java
+++ b/src/main/java/dev/incusspawn/git/GitRemoteUtils.java
@@ -209,7 +209,7 @@ public final class GitRemoteUtils {
                 .anyMatch(url -> urlsMatch(url, cloneUrl));
     }
 
-    static String hostGitExec(Path repoDir, String... gitArgs) {
+    public static String hostGitExec(Path repoDir, String... gitArgs) {
         var command = new ArrayList<String>();
         command.add("git");
         command.add("-C");


### PR DESCRIPTION
## Summary

Adds `isx sync <instance>` — bidirectional repo sync between host and a running container via auto-remotes. After sync, both sides are mirrored.

## Motivation

When a container is long-lived and the host is actively developing, the container's repo clones become stale (they're snapshots from branch time). Currently, updating requires manually pushing each repo. With many repos (10+), this is tedious — and pulling container-side changes back to the host is equally manual.

## Usage

```bash
isx sync mem-test          # bidirectional: fetch then push (default)
isx sync --pull mem-test   # container → host only
isx sync --push mem-test   # host → container only
```

**Default (no flag):** fetch from container first (fast-forward merge), then push to container. Both sides end up with identical state.

**`--pull`:** fetch + fast-forward only. Useful when the container has commits you want on the host without pushing anything back.

**`--push`:** push only. Update the container from host.

`--push` and `--pull` are mutually exclusive. Omit both for bidirectional.

## Behavior

For each repo that has an auto-remote (`isx://` URL) pointing to the instance:
1. Find the host repo and its current branch
2. Fetch from container and fast-forward merge (if pulling)
3. Push current branch to container (if pushing)
4. Report what was synced, with failure counts

If the host branch has diverged and can't fast-forward, the fetch succeeds but the merge is skipped with a warning — no data loss.

## Implementation details

- New `SyncCommand` registered as a subcommand in `IncusSpawn`
- Uses existing `GitRemoteUtils` methods (`collectReposForInstance`, `resolveHostRepoPath`, `getHostRepoRemoteUrl`)
- `hostGitExec` visibility changed from package-private to public (needed from `command` package)
- Leverages the existing `isx://` git remote protocol for transport
- **`receive.denyCurrentBranch=updateInstead`** — set globally for `agentuser` before pushing, so git accepts pushes to checked-out branches and updates the worktree in place
- **`--no-verify`** on push — skips host pre-push hooks that aren't relevant for container sync (e.g. commit linting, scope checks)

## Tested

Smoke-tested against a `tpl-casehub` instance with 3 repos (parent, garden, claude-memory):

```
$ isx sync smoke-test
  Fetching parent (main)... done
  Pushing  parent (main)... done
  Fetching garden (main)... done
  Pushing  garden (main)... done
  Fetching claude-memory (main)... done
  Pushing  claude-memory (main)... done
Synced 3 repos with smoke-test: 3 pulled, 3 pushed.
```

## Related

Closes #279

- Auto-remotes are already created by `isx branch` for all template repos
- Memory sync (#280) solves this for Claude Code memory specifically; this is the general solution for all repos