### PR TITLE
Workaround for macOS deadlock

### DIFF
--- a/src/main/java/dev/incusspawn/incus/IncusApi.java
+++ b/src/main/java/dev/incusspawn/incus/IncusApi.java
@@ -458,10 +458,7 @@ class IncusApi {
                                        Integer uid, Integer gid, String cwd,
                                        Map<String, String> env) {
         return retryOnNotRunning(() -> {
-            if (transport instanceof HttpsTransport) {
-                return execCaptureRecordOutput(instance, command, uid, gid, cwd, env);
-            }
-            return execCaptureWebSocket(instance, command, uid, gid, cwd, env);
+            return execCaptureRecordOutput(instance, command, uid, gid, cwd, env);
         });
     }
 


### PR DESCRIPTION
Not sure if this is a valid fix but at the very least is a workaround #286. The web socket logic here seems to deadlock on macOS. Capturing record output works:

```
$ isx build tpl-minimal --yes
incus-spawn.yaml:10: duplicate key 'tools' — merge into a single 'tools' section or remove the duplicate
────────────────────────────────────────────────────────────
Proxy version drift detected: Proxy is 0.0.0-SNAPSHOT (86c2c97), CLI is 0.0.0-SNAPSHOT (f7439b2).
Restart the proxy to use the current version:
  isx proxy stop && isx proxy start
────────────────────────────────────────────────────────────
Building image: tpl-minimal
Base image 'fedora-44-base' is up to date (fedora-44-20260621).
Launching fedora-44-base...
Installing MITM proxy CA certificate...
Restarting container with updated security config...
Waiting for network...
  Network ready.
Configuring DNS...
Verifying DNS resolution...
  DNS working.
Cleaning up caches...
Stopping image...
Image tpl-minimal built successfully.
```