### PR TITLE
fix: clean up stale storage volumes on instance destroy

### DIFF
--- a/src/main/java/dev/incusspawn/incus/IncusClient.java
+++ b/src/main/java/dev/incusspawn/incus/IncusClient.java
@@ -983,6 +983,26 @@ public class IncusClient {
         }
         var resp = http.requestAndWait("DELETE", "/1.0/instances/" + name, null);
         if (!resp.isSuccess()) throw new IncusException("Failed to delete " + name);
+        cleanupStaleVolumes(name);
+    }
+
+    private void cleanupStaleVolumes(String instanceName) {
+        try {
+            var pools = http().get("/1.0/storage-pools?recursion=1");
+            if (!pools.isSuccess()) return;
+            for (var pool : pools.body().path("metadata")) {
+                var poolName = pool.path("name").asText();
+                var volResp = http().get("/1.0/storage-pools/" + poolName
+                        + "/volumes/container/" + instanceName);
+                if (volResp.isSuccess()) {
+                    http().requestAndWait("DELETE",
+                            "/1.0/storage-pools/" + poolName
+                                    + "/volumes/container/" + instanceName, null);
+                }
+            }
+        } catch (Exception ignored) {
+            // Best-effort cleanup — don't fail the destroy if volume removal fails.
+        }
     }
 
     public void deleteIfExists(String name) {

--- a/src/main/java/dev/incusspawn/incus/IncusClient.java
+++ b/src/main/java/dev/incusspawn/incus/IncusClient.java
@@ -904,6 +904,7 @@ public class IncusClient {
      * Automatically selects the best CoW storage pool if available.
      */
     public void copy(String source, String target) {
+        cleanupStaleVolumes(target);
         var http = http();
         var cowPool = findCowPool();
         var body = new LinkedHashMap<String, Object>();


### PR DESCRIPTION
## Summary

After `isx destroy <instance>`, stale storage volumes can remain in the storage pool. Attempting to `isx branch` with the same name fails:

```
$ isx destroy test && isx branch test --from tpl-casehub
Error: Operation failed: Create instance from copy: Cannot create volume, already exists on target storage
```

## Fix

After the `DELETE /1.0/instances/<name>` API call succeeds, iterate all storage pools and remove any leftover container volumes matching the instance name. This is best-effort — cleanup failures don't fail the destroy.

## Testing

1. `isx branch test --from tpl-casehub`
2. `isx destroy test`
3. `isx branch test --from tpl-casehub` — previously failed, now succeeds

Closes #293