### PR TITLE
feat: add isx browse command — WebDAV mount + host-open

### DIFF
--- a/src/main/java/dev/incusspawn/IncusSpawn.java
+++ b/src/main/java/dev/incusspawn/IncusSpawn.java
@@ -41,7 +41,7 @@ public class IncusSpawn implements QuarkusApplication {
                 DestroyCommand.class, UpdateAllCommand.class, ProxyCommand.class,
                 CleanCommand.class, CompletionCommand.class, TemplatesCommand.class,
                 InstancesCommand.class, GitRemoteHelperCommand.class, SshProxyCommand.class,
-                VmCommand.class, UpdateBaseCommand.class, DoctorCommand.class
+                VmCommand.class, UpdateBaseCommand.class, DoctorCommand.class, BrowseCommand.class
             }, generateHelp = true)
     public static class IncusSpawnCommand extends BaseCommand {
         @Option(shortName = 'V', name = "version", hasValue = false, description = "Display version info")

--- a/src/main/java/dev/incusspawn/command/BrowseCommand.java
+++ b/src/main/java/dev/incusspawn/command/BrowseCommand.java
@@ -1,0 +1,246 @@
+package dev.incusspawn.command;
+
+import dev.incusspawn.Environment;
+import dev.incusspawn.RuntimeServices;
+import dev.incusspawn.config.SpawnConfig;
+import org.aesh.command.CommandDefinition;
+import org.aesh.command.CommandResult;
+import org.aesh.command.option.Argument;
+import org.aesh.command.option.Option;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.ServerSocket;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+@CommandDefinition(
+        name = "browse",
+        description = "Browse container files on the host via WebDAV mount",
+        generateHelp = true
+)
+public class BrowseCommand extends BaseCommand {
+
+    @Argument(description = "Name of the instance to browse", required = true)
+    String name;
+
+    @Option(name = "stop", hasValue = false, description = "Unmount and stop browsing")
+    boolean stop;
+
+    @Option(name = "port", description = "WebDAV port (default: 8888)",
+            defaultValue = {"8888"})
+    int port;
+
+    private static final int HOST_OPEN_PORT = 9999;
+    private static final String AGENTUSER_HOME = "/home/agentuser";
+
+    private Process sshTunnel;
+    private ServerSocket hostOpenServer;
+
+    @Override
+    protected CommandResult doExecute() throws Exception {
+        var incus = RuntimeServices.incus();
+
+        if (!incus.exists(name)) {
+            System.err.println("Error: no instance named '" + name + "' found.");
+            return CommandResult.valueOf(1);
+        }
+
+        var mountPath = mountPath();
+
+        if (stop) {
+            return doStop(mountPath);
+        }
+
+        if (!"Running".equalsIgnoreCase(incus.getInstanceStatus(name))) {
+            System.err.println("Error: instance '" + name + "' is not running.");
+            return CommandResult.valueOf(1);
+        }
+
+        var wsgidavCheck = incus.execInContainer(name, "agentuser", "test", "-x",
+                AGENTUSER_HOME + "/.local/bin/wsgidav");
+        if (!wsgidavCheck.success()) {
+            System.err.println("Error: wsgidav is not installed in '" + name + "'.");
+            System.err.println("Add the 'webdav' tool to your image definition, or install manually:");
+            System.err.println("  ssh " + name + " \"python3 -m pip install --user wsgidav cheroot\"");
+            return CommandResult.valueOf(1);
+        }
+
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> cleanup(mountPath)));
+
+        System.out.println("Starting WebDAV server on " + name + ":" + port + "...");
+        incus.execInContainer(name, "agentuser", "pkill", "-f", "wsgidav");
+        incus.execInContainer(name, "agentuser",
+                "sh", "-c", "nohup " + AGENTUSER_HOME + "/.local/bin/wsgidav"
+                        + " --host 0.0.0.0 --port " + port
+                        + " --root " + AGENTUSER_HOME
+                        + " --auth anonymous"
+                        + " > /tmp/wsgidav.log 2>&1 &");
+
+        Thread.sleep(2000);
+
+        System.out.println("Setting up SSH tunnel...");
+        sshTunnel = new ProcessBuilder(
+                "ssh", "-f", "-N",
+                "-L", port + ":localhost:" + port,
+                "-R", HOST_OPEN_PORT + ":localhost:" + HOST_OPEN_PORT,
+                name
+        ).start();
+        sshTunnel.waitFor();
+
+        Thread.sleep(1000);
+
+        Files.createDirectories(mountPath);
+
+        if (Environment.isMacOS()) {
+            System.out.println("Mounting at " + mountPath + "...");
+            var mount = new ProcessBuilder(
+                    "mount_webdav", "-s", "-v", name,
+                    "http://localhost:" + port + "/",
+                    mountPath.toString()
+            ).inheritIO().start();
+            int exitCode = mount.waitFor();
+            if (exitCode != 0) {
+                System.err.println("Error: mount_webdav failed (exit " + exitCode + ").");
+                return CommandResult.valueOf(1);
+            }
+        } else {
+            System.out.println("WebDAV available at http://localhost:" + port + "/");
+            System.out.println("Mount with: sudo mount -t davfs http://localhost:" + port + "/ " + mountPath);
+        }
+
+        var config = SpawnConfig.load();
+        var listenerThread = new Thread(() -> runHostOpenListener(config.getHostApps(), mountPath),
+                "host-open-listener");
+        listenerThread.setDaemon(true);
+        listenerThread.start();
+
+        System.out.println();
+        System.out.println("Browsing " + name + " at " + mountPath);
+        System.out.println("  host-open available inside container");
+        System.out.println("  Press Ctrl+C to unmount and stop.");
+
+        try {
+            Thread.sleep(Long.MAX_VALUE);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+
+        return CommandResult.SUCCESS;
+    }
+
+    private CommandResult doStop(Path mountPath) {
+        cleanup(mountPath);
+        System.out.println("Stopped.");
+        return CommandResult.SUCCESS;
+    }
+
+    private void cleanup(Path mountPath) {
+        try {
+            if (Environment.isMacOS()) {
+                new ProcessBuilder("umount", mountPath.toString())
+                        .inheritIO().start().waitFor();
+            }
+        } catch (Exception ignored) {}
+
+        try {
+            new ProcessBuilder("pkill", "-f",
+                    "ssh.*-L " + port + ":localhost:" + port + ".*" + name)
+                    .start().waitFor();
+        } catch (Exception ignored) {}
+
+        if (hostOpenServer != null) {
+            try {
+                hostOpenServer.close();
+            } catch (Exception ignored) {}
+        }
+
+        try {
+            var incus = RuntimeServices.incus();
+            if (incus.exists(name)) {
+                incus.execInContainer(name, "agentuser", "pkill", "-f", "wsgidav");
+            }
+        } catch (Exception ignored) {}
+    }
+
+    private void runHostOpenListener(Map<String, String> hostApps, Path mountPath) {
+        try {
+            hostOpenServer = new ServerSocket(HOST_OPEN_PORT);
+            while (!Thread.currentThread().isInterrupted()) {
+                try (var socket = hostOpenServer.accept();
+                     var reader = new BufferedReader(new InputStreamReader(socket.getInputStream()))) {
+                    var line = reader.readLine();
+                    if (line == null || line.isBlank()) continue;
+                    line = line.strip();
+
+                    String app = null;
+                    String filepath;
+                    if (line.contains("|")) {
+                        app = line.substring(0, line.indexOf('|'));
+                        filepath = line.substring(line.indexOf('|') + 1);
+                    } else {
+                        filepath = line;
+                    }
+
+                    // Strip container home prefix
+                    if (filepath.startsWith(AGENTUSER_HOME + "/")) {
+                        filepath = filepath.substring(AGENTUSER_HOME.length() + 1);
+                    } else if (filepath.startsWith("~/")) {
+                        filepath = filepath.substring(2);
+                    }
+
+                    var localPath = mountPath.resolve(filepath);
+                    if (!Files.exists(localPath)) {
+                        System.err.println("  host-open: not found: " + localPath);
+                        continue;
+                    }
+
+                    // Resolve app: explicit > config by extension > system default
+                    if (app == null || app.isBlank()) {
+                        var ext = extensionOf(filepath);
+                        app = hostApps.getOrDefault(ext, null);
+                    } else {
+                        app = hostApps.getOrDefault(app, app);
+                    }
+
+                    if (app != null && !app.isBlank()) {
+                        System.out.println("  Opening in " + app + ": " + localPath);
+                        if (Environment.isMacOS()) {
+                            new ProcessBuilder("open", "-a", app, localPath.toString()).start();
+                        } else {
+                            new ProcessBuilder(app, localPath.toString()).start();
+                        }
+                    } else {
+                        System.out.println("  Opening: " + localPath);
+                        if (Environment.isMacOS()) {
+                            new ProcessBuilder("open", localPath.toString()).start();
+                        } else {
+                            new ProcessBuilder("xdg-open", localPath.toString()).start();
+                        }
+                    }
+
+                } catch (IOException e) {
+                    if (!Thread.currentThread().isInterrupted()) {
+                        // Connection reset — client disconnected, normal for ncat
+                    }
+                }
+            }
+        } catch (IOException e) {
+            if (!Thread.currentThread().isInterrupted()) {
+                System.err.println("  host-open listener failed: " + e.getMessage());
+            }
+        }
+    }
+
+    private Path mountPath() {
+        return Path.of(System.getProperty("user.home"), "mnt", name);
+    }
+
+    private static String extensionOf(String path) {
+        int dot = path.lastIndexOf('.');
+        if (dot < 0 || dot == path.length() - 1) return "";
+        return path.substring(dot + 1).toLowerCase();
+    }
+}

--- a/src/main/java/dev/incusspawn/config/SpawnConfig.java
+++ b/src/main/java/dev/incusspawn/config/SpawnConfig.java
@@ -31,6 +31,8 @@ public class SpawnConfig {
     private java.util.List<String> hostPaths = java.util.List.of();
     @JsonProperty("repo-paths")
     private Map<String, String> repoPaths = Map.of();
+    @JsonProperty("host-apps")
+    private Map<String, String> hostApps = Map.of();
     @JsonProperty("incus-bridge-gateway")
     private String incusBridgeGateway = "";
 
@@ -97,6 +99,8 @@ public class SpawnConfig {
     public void setHostPaths(java.util.List<String> hostPaths) { this.hostPaths = hostPaths == null ? java.util.List.of() : hostPaths; }
     public Map<String, String> getRepoPaths() { return repoPaths; }
     public void setRepoPaths(Map<String, String> repoPaths) { this.repoPaths = repoPaths == null ? Map.of() : repoPaths; }
+    public Map<String, String> getHostApps() { return hostApps; }
+    public void setHostApps(Map<String, String> hostApps) { this.hostApps = hostApps == null ? Map.of() : hostApps; }
     public String getIncusBridgeGateway() { return incusBridgeGateway; }
     public void setIncusBridgeGateway(String incusBridgeGateway) { this.incusBridgeGateway = incusBridgeGateway == null ? "" : incusBridgeGateway; }
 

--- a/src/main/resources/tools/webdav.yaml
+++ b/src/main/resources/tools/webdav.yaml
@@ -1,0 +1,41 @@
+name: webdav
+description: WebDAV file server + host-open for browsing container files from the host
+
+packages:
+  - python3-pip
+  - nmap-ncat
+
+run:
+  - python3 -m pip install --user wsgidav cheroot
+  - |
+    cat > /usr/local/bin/webdav-start << 'SCRIPTEOF'
+    #!/bin/bash
+    PORT="${1:-8888}"
+    ROOT="${2:-$HOME}"
+    pkill -f wsgidav 2>/dev/null
+    nohup ~/.local/bin/wsgidav --host 0.0.0.0 --port "$PORT" --root "$ROOT" --auth anonymous > /tmp/wsgidav.log 2>&1 &
+    echo "WebDAV serving $ROOT on port $PORT"
+    SCRIPTEOF
+    chmod +x /usr/local/bin/webdav-start
+  - |
+    cat > /usr/local/bin/host-open << 'SCRIPTEOF'
+    #!/bin/bash
+    PORT=9999
+    if [ $# -eq 0 ]; then
+      echo "Usage: host-open [app] <file>"
+      echo "  host-open ~/path/to/file.md"
+      echo "  host-open Typora ~/path/to/file.md"
+      exit 0
+    fi
+    if [ $# -eq 1 ]; then
+      FILEPATH="$(realpath "$1" 2>/dev/null || echo "$1")"
+      printf '%s\n' "$FILEPATH" | ncat localhost $PORT 2>/dev/null
+    else
+      APP="$1"
+      FILEPATH="$(realpath "$2" 2>/dev/null || echo "$2")"
+      printf '%s\n' "$APP|$FILEPATH" | ncat localhost $PORT 2>/dev/null
+    fi
+    SCRIPTEOF
+    chmod +x /usr/local/bin/host-open
+
+verify: test -x /usr/local/bin/host-open


### PR DESCRIPTION
## Summary

Adds `isx browse <instance>` to mount container files on the host via WebDAV, with a reverse-tunnel listener that lets the container open files in host applications.

## Motivation

Developers need to browse container files with host tools (Typora for markdown, Finder for navigation, etc.). Currently requires manually installing scripts on the host. This command makes it work out of the box.

## Usage

```bash
isx browse hub          # mount at ~/mnt/hub/, listen for host-open
isx browse hub --stop   # unmount and stop
```

Inside the container:
```bash
host-open spec.md                # opens in configured app for .md files
host-open Typora spec.md         # opens in specific app
```

Config (`~/.config/incus-spawn/config.yaml`):
```yaml
host-apps:
  markdown: "Typora"    # or MacDown, Obsidian, etc.
  html: "Safari"
```

## How it works

1. Starts a WebDAV server (wsgidav) inside the container
2. SSH tunnel: forward port for WebDAV, reverse port for host-open
3. Mounts via `mount_webdav` on macOS (prints URL on Linux)
4. Host-open listener thread receives file paths from the container and opens them on the host using configured applications
5. Ctrl+C cleanly unmounts, kills tunnel, stops server

## Components

- **`BrowseCommand.java`** — main command, follows SyncCommand pattern
- **`SpawnConfig.java`** — adds `host-apps` map for file-type-to-app configuration
- **`webdav.yaml`** — bundled tool that installs wsgidav + `host-open` script in containers

## Prerequisites

Container must have the `webdav` tool installed (provides wsgidav + host-open script). Add to image definition:
```yaml
tools:
  - webdav
```

## Tested

- macOS mount via mount_webdav ✓
- host-open with explicit app (Typora) ✓
- host-open with auto-detect from config ✓
- Ctrl+C cleanup (unmount, kill tunnel, stop server) ✓
- `--stop` flag for stale cleanup ✓
- 638 existing tests pass ✓