### PR TITLE
Fix default action not found on stopped instances

### DIFF
--- a/src/main/java/dev/incusspawn/command/ListCommand.java
+++ b/src/main/java/dev/incusspawn/command/ListCommand.java
@@ -688,7 +688,9 @@ public class ListCommand extends BaseCommand {
             return true;
         }
         if (key.isKey(KeyCode.F9)) {
-            var actions = getActionsForInstance(selected);
+            var actions = getActionsForInstance(selected).stream()
+                    .filter(a -> !a.requiresRunning() || isRunning(selected))
+                    .toList();
             if (actions.isEmpty()) {
                 statusMessage = "No actions available for " + selected.name;
                 return true;
@@ -2401,19 +2403,12 @@ public class ListCommand extends BaseCommand {
     }
 
     private boolean hasActionsForInstance(InstanceInfo instance) {
-        return !getActionsForInstance(instance).isEmpty();
+        return getActionsForInstance(instance).stream()
+                .anyMatch(a -> !a.requiresRunning() || isRunning(instance));
     }
 
     private java.util.List<ToolAction> getActionsForInstance(InstanceInfo instance) {
         return actionsCache.getOrDefault(instance.name, java.util.List.of());
-    }
-
-    private void addActionIfAllowed(java.util.List<ToolAction> actions,
-                                     ToolAction action,
-                                     InstanceInfo instance) {
-        if (!action.requiresRunning() || isRunning(instance)) {
-            actions.add(action);
-        }
     }
 
     private java.util.List<ToolAction> resolveActionsForInstance(InstanceInfo instance) {
@@ -2434,12 +2429,10 @@ public class ListCommand extends BaseCommand {
                     if (YamlToolAction.EXPAND_REPOS.equals(entry.getExpand())) {
                         if (repos == null) repos = collectRepos(instance);
                         for (var repo : repos) {
-                            addActionIfAllowed(actions,
-                                    new YamlToolAction(toolName, entry, repo), instance);
+                            actions.add(new YamlToolAction(toolName, entry, repo));
                         }
                     } else {
-                        addActionIfAllowed(actions,
-                                new YamlToolAction(toolName, entry), instance);
+                        actions.add(new YamlToolAction(toolName, entry));
                     }
                 }
             }
@@ -2453,12 +2446,10 @@ public class ListCommand extends BaseCommand {
                         if (YamlToolAction.EXPAND_REPOS.equals(entry.getExpand())) {
                             if (repos == null) repos = collectRepos(instance);
                             for (var repo : repos) {
-                                addActionIfAllowed(actions,
-                                        new YamlToolAction(cdiTool.name(), entry, repo), instance);
+                                actions.add(new YamlToolAction(cdiTool.name(), entry, repo));
                             }
                         } else {
-                            addActionIfAllowed(actions,
-                                    new YamlToolAction(cdiTool.name(), entry), instance);
+                            actions.add(new YamlToolAction(cdiTool.name(), entry));
                         }
                     }
                 }

--- a/src/main/java/dev/incusspawn/command/ListCommand.java
+++ b/src/main/java/dev/incusspawn/command/ListCommand.java
@@ -2544,12 +2544,7 @@ public class ListCommand extends BaseCommand {
         if (result.isEmpty()) {
             return false;
         }
-        var action = result.get();
-        if (action.requiresRunning() && !isRunning(selected)) {
-            statusMessage = "default-action '" + ref + "': instance not running";
-            return false;
-        }
-        return dispatchAction(action, buildActionContext(selected));
+        return dispatchAction(result.get(), buildActionContext(selected));
     }
 
     private boolean dispatchAction(ToolAction action, ActionContext context) {

--- a/src/main/java/dev/incusspawn/command/ListCommand.java
+++ b/src/main/java/dev/incusspawn/command/ListCommand.java
@@ -2544,7 +2544,12 @@ public class ListCommand extends BaseCommand {
         if (result.isEmpty()) {
             return false;
         }
-        return dispatchAction(result.get(), buildActionContext(selected));
+        var action = result.get();
+        if (action.requiresRunning() && !isRunning(selected)) {
+            statusMessage = "default-action '" + ref + "': instance not running";
+            return false;
+        }
+        return dispatchAction(action, buildActionContext(selected));
     }
 
     private boolean dispatchAction(ToolAction action, ActionContext context) {


### PR DESCRIPTION
## Summary
- The actions cache filtered out `requiresRunning` actions at population time, so `findDefaultAction` could never resolve the default action for a stopped instance, producing `default-action 'claude': tool not found`
- Moved the `requiresRunning` filter from cache population (`resolveActionsForInstance`) to the two display-layer consumption points: the F9 menu handler and the F9 button enablement check
- The cache now stores all actions regardless of `requiresRunning`, so default action resolution works for stopped instances

## Test plan
- [x] All 638 unit tests pass
- [ ] Press ENTER on a stopped instance that has a default action configured — should dispatch the action instead of showing "tool not found"
- [ ] Press F9 on a stopped instance — should still only show actions that don't require running
- [ ] F9 button in status bar should still be grayed out when all actions require a running instance