### PR TITLE
Propagate terminal resize to container PTY during isx shell

### DIFF
--- a/src/main/java/dev/incusspawn/incus/HttpsTransport.java
+++ b/src/main/java/dev/incusspawn/incus/HttpsTransport.java
@@ -334,6 +334,16 @@ class HttpsTransport implements IncusTransport {
         }
 
         @Override
+        public void sendText(String text) throws IOException {
+            try {
+                ws.sendText(text, true).join();
+            } catch (java.util.concurrent.CompletionException e) {
+                if (e.getCause() instanceof IOException io) throw io;
+                throw new IOException(e);
+            }
+        }
+
+        @Override
         public void sendPing() throws IOException {
             try {
                 ws.sendPing(ByteBuffer.allocate(0)).join();

--- a/src/main/java/dev/incusspawn/incus/IncusApi.java
+++ b/src/main/java/dev/incusspawn/incus/IncusApi.java
@@ -602,8 +602,21 @@ class IncusApi {
         // and we return immediately. We do NOT call waitForExecOp — that waits ~8s for Incus to
         // finalize the operation. For interactive logout, instant detach is the right behavior.
         var controlLostConnection = new java.util.concurrent.atomic.AtomicBoolean(false);
-        var controlThread = Thread.ofVirtual().start(() ->
-                wsDiscardTracked(opPath, fds.path("control").asText(), controlLostConnection));
+
+        // Open control WebSocket for both reading (close detection) and writing (resize).
+        IncusTransport.WsConnection controlWs;
+        try {
+            controlWs = transport.openWebSocket(opPath + "/websocket?secret=" + fds.path("control").asText());
+        } catch (IOException e) {
+            throw new IncusException("Failed to open control WebSocket", e);
+        }
+        var controlThread = Thread.ofVirtual().start(() -> {
+            try {
+                while (controlWs.readPayload() != null) {}
+            } catch (IOException e) {
+                controlLostConnection.set(true);
+            }
+        });
         assertAllFdsConnected(fds, Set.of("0", "control"));
 
         try (var ws = transport.openWebSocket(opPath + "/websocket?secret=" + fds.path("0").asText())) {
@@ -621,6 +634,25 @@ class IncusApi {
                         ws.sendPing();
                     }
                 } catch (IOException | InterruptedException ignored) {}
+            });
+
+            // Terminal resize: poll for size changes and send window-resize control messages.
+            var resizeThread = Thread.ofVirtual().start(() -> {
+                var lastWidth = width;
+                var lastHeight = height;
+                try {
+                    while (!Thread.currentThread().isInterrupted()) {
+                        Thread.sleep(500);
+                        var size = terminalSize();
+                        if (size[0] != lastWidth || size[1] != lastHeight) {
+                            lastWidth = size[0];
+                            lastHeight = size[1];
+                            try {
+                                controlWs.sendText("{\"command\":\"window-resize\",\"args\":{\"width\":" + lastWidth + ",\"height\":" + lastHeight + "}}");
+                            } catch (IOException ignored) { break; }
+                        }
+                    }
+                } catch (InterruptedException ignored) {}
             });
 
             setRawTerminal();
@@ -644,12 +676,14 @@ class IncusApi {
                 // Connection closed by watcher — normal PTY session end.
             } finally {
                 keepaliveThread.interrupt();
+                resizeThread.interrupt();
                 restoreTerminal();
             }
         } catch (IOException e) {
             throw new IncusException("PTY exec failed", e);
         }
         joinQuietly(controlThread);
+        controlWs.close();
 
         return controlLostConnection.get();
     }

--- a/src/main/java/dev/incusspawn/incus/IncusTransport.java
+++ b/src/main/java/dev/incusspawn/incus/IncusTransport.java
@@ -53,6 +53,11 @@ interface IncusTransport {
         byte[] readPayload() throws IOException;
         /** Send binary data to the server. */
         void sendData(byte[] data, int offset, int length) throws IOException;
+        /** Send a text frame to the server. */
+        default void sendText(String text) throws IOException {
+            var bytes = text.getBytes(java.nio.charset.StandardCharsets.UTF_8);
+            sendData(bytes, 0, bytes.length);
+        }
         /** Send a WebSocket ping frame (keepalive). */
         void sendPing() throws IOException;
         /** Send a WebSocket close frame. */

--- a/src/main/java/dev/incusspawn/incus/UnixSocketTransport.java
+++ b/src/main/java/dev/incusspawn/incus/UnixSocketTransport.java
@@ -350,6 +350,14 @@ class UnixSocketTransport implements IncusTransport {
         }
 
         @Override
+        public void sendText(String text) throws IOException {
+            var bytes = text.getBytes(java.nio.charset.StandardCharsets.UTF_8);
+            synchronized (writeLock) {
+                wsSendMasked(out, 0x1 /* WS_TEXT */, bytes, 0, bytes.length);
+            }
+        }
+
+        @Override
         public void sendPing() throws IOException {
             synchronized (writeLock) {
                 wsSendMasked(out, WS_PING, new byte[0], 0, 0);


### PR DESCRIPTION
## Summary

- Add `sendText(String)` to `WsConnection` interface for WebSocket text frame support
- Implement `sendText` in both `UnixSocketTransport` (WS_TEXT opcode 0x1 with masking) and `HttpsTransport` (Java HTTP WebSocket API)
- Open the control WebSocket as a writable `WsConnection` instead of discard-only, enabling both close detection and resize messages
- Poll terminal dimensions every 500ms; on change, send `{"command":"window-resize","args":{"width":N,"height":N}}` on the control channel

Fixes #305

## Test plan

- [ ] `isx shell <instance>` — resize terminal window, verify `stty size` reflects new dimensions
- [ ] Full-screen apps (vim, htop, less) re-render correctly after resize
- [ ] Shell exit still works cleanly (no hang from the resize thread)
- [ ] `mvn test` — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)