### PR TITLE
Fix macOS vsock exec hangs and forwarder leak; add isx doctor + in-VM recovery agent

### DIFF
--- a/appliance/root/usr/local/sbin/incus-spawn-vm-init
+++ b/appliance/root/usr/local/sbin/incus-spawn-vm-init
@@ -104,7 +104,16 @@ incus config set core.https_address :8443
 # socket instead of TCP to the VM subnet (bypasses VPN socket filters).
 VSOCK_INCUS_PORT=$(parse_cmdline "isx.vsock_incus")
 if [ -n "$VSOCK_INCUS_PORT" ]; then
-    socat -b 65536 VSOCK-LISTEN:"$VSOCK_INCUS_PORT",reuseaddr,fork \
+    # -T 180: total inactivity timeout. Each accepted connection forks a child, and a
+    # close that never propagates across the vsock boundary would otherwise leave that
+    # child (and the host-side vfkit fd it pins) alive forever — the leak that degrades
+    # new-connection latency. This reaps any connection idle for 180s as a backstop.
+    #
+    # The 180s floor is deliberate: the client keepalives every live exec fd every ~15s,
+    # but the Incus operation /wait long-poll is a plain HTTP request that legitimately
+    # carries no traffic for up to 120s (and the client request watchdog is 150s). -T must
+    # sit above that window or it would reap the long-poll that signals exec completion.
+    socat -b 65536 -T 180 VSOCK-LISTEN:"$VSOCK_INCUS_PORT",reuseaddr,fork \
         UNIX-CONNECT:/var/lib/incus/unix.socket &
     echo "incus-spawn-vm-init: vsock forwarder on port $VSOCK_INCUS_PORT"
 fi

--- a/appliance/root/usr/local/sbin/incus-spawn-vm-init
+++ b/appliance/root/usr/local/sbin/incus-spawn-vm-init
@@ -113,7 +113,9 @@ fi
 # fixed-verb isx-agent — not an arbitrary guest-exec channel.
 AGENT_VSOCK_PORT=$(parse_cmdline "isx.agent_vsock")
 if [ -n "$AGENT_VSOCK_PORT" ]; then
-    socat VSOCK-LISTEN:"$AGENT_VSOCK_PORT",reuseaddr,fork EXEC:/usr/local/sbin/isx-agent &
+    # -T 30: agent verbs are sub-second, so any connection idle for 30s is stuck; reap it.
+    # Bounds a hypothetical future blocking verb (the agent itself never lingers today).
+    socat -T 30 VSOCK-LISTEN:"$AGENT_VSOCK_PORT",reuseaddr,fork EXEC:/usr/local/sbin/isx-agent &
     echo "incus-spawn-vm-init: control agent on vsock port $AGENT_VSOCK_PORT"
 fi
 

--- a/appliance/root/usr/local/sbin/incus-spawn-vm-init
+++ b/appliance/root/usr/local/sbin/incus-spawn-vm-init
@@ -104,18 +104,17 @@ incus config set core.https_address :8443
 # socket instead of TCP to the VM subnet (bypasses VPN socket filters).
 VSOCK_INCUS_PORT=$(parse_cmdline "isx.vsock_incus")
 if [ -n "$VSOCK_INCUS_PORT" ]; then
-    # -T 180: total inactivity timeout. Each accepted connection forks a child, and a
-    # close that never propagates across the vsock boundary would otherwise leave that
-    # child (and the host-side vfkit fd it pins) alive forever — the leak that degrades
-    # new-connection latency. This reaps any connection idle for 180s as a backstop.
-    #
-    # The 180s floor is deliberate: the client keepalives every live exec fd every ~15s,
-    # but the Incus operation /wait long-poll is a plain HTTP request that legitimately
-    # carries no traffic for up to 120s (and the client request watchdog is 150s). -T must
-    # sit above that window or it would reap the long-poll that signals exec completion.
-    socat -b 65536 -T 180 VSOCK-LISTEN:"$VSOCK_INCUS_PORT",reuseaddr,fork \
-        UNIX-CONNECT:/var/lib/incus/unix.socket &
+    /usr/local/sbin/isx-start-vsock-forwarder "$VSOCK_INCUS_PORT" &
     echo "incus-spawn-vm-init: vsock forwarder on port $VSOCK_INCUS_PORT"
+fi
+
+# Allowlisted control agent on its own vsock port, so the host can introspect/recover the
+# forwarder independently of the (possibly wedged) Incus tunnel. Each connection runs the
+# fixed-verb isx-agent — not an arbitrary guest-exec channel.
+AGENT_VSOCK_PORT=$(parse_cmdline "isx.agent_vsock")
+if [ -n "$AGENT_VSOCK_PORT" ]; then
+    socat VSOCK-LISTEN:"$AGENT_VSOCK_PORT",reuseaddr,fork EXEC:/usr/local/sbin/isx-agent &
+    echo "incus-spawn-vm-init: control agent on vsock port $AGENT_VSOCK_PORT"
 fi
 
 # Trust the host's client certificate via the virtio-fs shared directory.

--- a/appliance/root/usr/local/sbin/isx-agent
+++ b/appliance/root/usr/local/sbin/isx-agent
@@ -1,0 +1,43 @@
+#!/bin/sh
+# Allowlisted control agent, reached from the macOS host over a dedicated vsock port
+# (one verb per connection, via `socat ... EXEC:`). This is intentionally NOT a general
+# guest-exec channel: it dispatches only the fixed verbs below, so the host can introspect
+# and recover the forwarder without granting arbitrary in-guest command execution.
+#
+# Protocol: read one verb line from stdin, write the result to stdout, exit.
+
+# The forwarder's distinctive cmdline fragment — matches the parent and every fork child,
+# and nothing else (the agent's own socat uses EXEC:, not UNIX-CONNECT).
+FORWARDER_MATCH='UNIX-CONNECT:/var/lib/incus/unix.socket'
+INCUS_VSOCK_PORT=8443
+
+read -r verb || exit 0
+
+case "$verb" in
+    ping)
+        echo ok
+        ;;
+    socat-count)
+        # In-guest count of forwarder socat processes (parent + per-connection children).
+        # Compared against the host-side vfkit fd count, this locates where streams leak:
+        # if this is low while the host count is high, vfkit is not reaping (link 2);
+        # if both are high, the forwarder is lingering children (link 3).
+        pgrep -f "$FORWARDER_MATCH" 2>/dev/null | wc -l | tr -d '[:space:]'
+        echo
+        ;;
+    sshd-status)
+        if pgrep -x sshd >/dev/null 2>&1; then echo running; else echo stopped; fi
+        ;;
+    forwarder-restart)
+        # Recover a leaked/wedged forwarder without rebooting the VM: drop every forwarder
+        # socat (parent + children, freeing the host fds vfkit pinned) and relaunch it.
+        # The agent's own listener is untouched (different cmdline).
+        pkill -f "$FORWARDER_MATCH" 2>/dev/null || true
+        sleep 1
+        /usr/local/sbin/isx-start-vsock-forwarder "$INCUS_VSOCK_PORT" &
+        echo restarted
+        ;;
+    *)
+        echo "error: unknown verb"
+        ;;
+esac

--- a/appliance/root/usr/local/sbin/isx-agent
+++ b/appliance/root/usr/local/sbin/isx-agent
@@ -32,9 +32,14 @@ case "$verb" in
         # Recover a leaked/wedged forwarder without rebooting the VM: drop every forwarder
         # socat (parent + children, freeing the host fds vfkit pinned) and relaunch it.
         # The agent's own listener is untouched (different cmdline).
+        #
+        # Detach the relaunch with setsid + std fds to /dev/null so the new forwarder neither
+        # inherits this connection's socket fds (which would leave a dangling dup) nor shares
+        # our process group (so socat tearing this connection down can't signal it). The agent
+        # connection then closes cleanly when this script exits — no lingering fd.
         pkill -f "$FORWARDER_MATCH" 2>/dev/null || true
         sleep 1
-        /usr/local/sbin/isx-start-vsock-forwarder "$INCUS_VSOCK_PORT" &
+        setsid /usr/local/sbin/isx-start-vsock-forwarder "$INCUS_VSOCK_PORT" </dev/null >/dev/null 2>&1 &
         echo restarted
         ;;
     *)

--- a/appliance/root/usr/local/sbin/isx-start-vsock-forwarder
+++ b/appliance/root/usr/local/sbin/isx-start-vsock-forwarder
@@ -1,0 +1,16 @@
+#!/bin/sh
+# Launch the Incus API vsock forwarder. Shared by incus-spawn-vm-init at boot and by
+# isx-agent when recovering a leaked/wedged forwarder, so the socat invocation lives in
+# exactly one place.
+#
+# -T 180: total inactivity timeout. Each accepted connection forks a child; a close that
+# never propagates across the vsock boundary would otherwise leave that child (and the
+# host-side vfkit fd it pins) alive forever. The 180s floor sits above the Incus /wait
+# long-poll (up to 120s of legitimate silence) and the client request watchdog (150s);
+# live exec fds are keepalived (~15s) so they are never reaped. See incus-spawn-vm-init.
+set -eu
+
+PORT="${1:?usage: isx-start-vsock-forwarder <vsock-port>}"
+
+exec socat -b 65536 -T 180 VSOCK-LISTEN:"$PORT",reuseaddr,fork \
+    UNIX-CONNECT:/var/lib/incus/unix.socket

--- a/appliance/test-boot.sh
+++ b/appliance/test-boot.sh
@@ -86,6 +86,29 @@ probe_vsock() {
         | grep -q 'incusbr0' && echo "ISX VSOCK BRIDGE OK" >> "$VSOCK_RESULT"
 }
 
+# Verify the in-guest control agent answers over its dedicated vsock port (the channel
+# isx doctor uses for introspection/recovery). One verb per connection: send "ping",
+# expect "ok"; then record the socat-count it reports.
+probe_agent() {
+    local sock="$1" deadline resp=""
+    deadline=$(( $(date +%s) + 30 ))
+    while [ "$(date +%s)" -lt "$deadline" ]; do
+        if [ -S "$sock" ]; then
+            resp=$(printf 'ping\n' | nc -U -w 5 "$sock" 2>/dev/null | tr -d '\r\n') || resp=""
+            [ "$resp" = "ok" ] && break
+        fi
+        sleep 1
+    done
+    if [ "$resp" = "ok" ]; then
+        echo "ISX AGENT OK" >> "$VSOCK_RESULT"
+        local count
+        count=$(printf 'socat-count\n' | nc -U -w 5 "$sock" 2>/dev/null | tr -d '\r\n') || count=""
+        echo "ISX AGENT SOCAT COUNT: $count" >> "$VSOCK_RESULT"
+    else
+        echo "ISX AGENT FAIL: no response from control agent" >> "$VSOCK_RESULT"
+    fi
+}
+
 boot_vfkit() {
     BACKEND="vfkit"
     echo "  backend: vfkit (Apple Virtualization.framework)"
@@ -102,15 +125,17 @@ boot_vfkit() {
     # that actually matters on macOS.
     VSOCK_DIR=$(mktemp -d)
     local vsock_sock="$VSOCK_DIR/incus.sock"
+    local agent_sock="$VSOCK_DIR/agent.sock"
     vfkit \
         --cpus 2 --memory 2048 \
         --kernel "$BUILD_DIR/vmlinuz" \
         --initrd "$dummy_initrd" \
-        --kernel-cmdline "root=/dev/vda rootfstype=btrfs rw rootflags=commit=300 console=hvc0 isx.vsock_incus=8443" \
+        --kernel-cmdline "root=/dev/vda rootfstype=btrfs rw rootflags=commit=300 console=hvc0 isx.vsock_incus=8443 isx.agent_vsock=1025" \
         --device virtio-blk,path="$BUILD_DIR/disk.img" \
         --device virtio-net,nat \
         --device virtio-serial,logFilePath="$LOGFILE" \
         --device "virtio-vsock,port=8443,socketURL=$vsock_sock,connect" \
+        --device "virtio-vsock,port=1025,socketURL=$agent_sock,connect" \
         --restful-uri "tcp://localhost:0" \
         > /dev/null 2>&1 &
     local pid=$!
@@ -127,6 +152,7 @@ boot_vfkit() {
     # Probe the forwarded socket regardless of ISX READY (the daemon is up well
     # before readiness; the probe polls on its own).
     probe_vsock "$vsock_sock"
+    probe_agent "$agent_sock"
     kill "$pid" 2>/dev/null || true; wait "$pid" 2>/dev/null || true
     rm -f "$dummy_initrd"
 }
@@ -253,6 +279,10 @@ if [ "$BACKEND" = "vfkit" ]; then
     check_result "ISX VSOCK API OK"            "Incus API reachable over forwarded host socket"
     check_result "ISX VSOCK STORAGE OK"        "cow storage pool visible via API"
     check_result "ISX VSOCK BRIDGE OK"         "incusbr0 bridge visible via API"
+    echo
+    echo "-- Control agent (isx.agent_vsock=1025) --"
+    check "control agent on vsock port 1025"   "in-guest control agent started"
+    check_result "ISX AGENT OK"                "control agent answered ping over vsock"
 else
     echo
     echo "-- Smoke test (isx.smoke_test=1) --"

--- a/appliance/test-boot.sh
+++ b/appliance/test-boot.sh
@@ -87,10 +87,12 @@ probe_vsock() {
 }
 
 # Verify the in-guest control agent answers over its dedicated vsock port (the channel
-# isx doctor uses for introspection/recovery). One verb per connection: send "ping",
-# expect "ok"; then record the socat-count it reports.
+# isx doctor uses for introspection/recovery), and that its no-reboot forwarder recovery
+# works: ping -> ok, record socat-count, then forwarder-restart and confirm the Incus API
+# is reachable again over the relaunched forwarder and the agent itself survived.
+# $1 = agent socket, $2 = incus vsock socket (to re-probe after recovery).
 probe_agent() {
-    local sock="$1" deadline resp=""
+    local sock="$1" incus_sock="$2" deadline resp=""
     deadline=$(( $(date +%s) + 30 ))
     while [ "$(date +%s)" -lt "$deadline" ]; do
         if [ -S "$sock" ]; then
@@ -99,13 +101,36 @@ probe_agent() {
         fi
         sleep 1
     done
-    if [ "$resp" = "ok" ]; then
-        echo "ISX AGENT OK" >> "$VSOCK_RESULT"
-        local count
-        count=$(printf 'socat-count\n' | nc -U -w 5 "$sock" 2>/dev/null | tr -d '\r\n') || count=""
-        echo "ISX AGENT SOCAT COUNT: $count" >> "$VSOCK_RESULT"
-    else
+    if [ "$resp" != "ok" ]; then
         echo "ISX AGENT FAIL: no response from control agent" >> "$VSOCK_RESULT"
+        return
+    fi
+    echo "ISX AGENT OK" >> "$VSOCK_RESULT"
+    local count
+    count=$(printf 'socat-count\n' | nc -U -w 5 "$sock" 2>/dev/null | tr -d '\r\n') || count=""
+    echo "ISX AGENT SOCAT COUNT: $count" >> "$VSOCK_RESULT"
+
+    # No-reboot recovery: restart the forwarder, then confirm the Incus API answers again
+    # over the relaunched forwarder, and that the agent listener is still up afterwards.
+    local recover
+    recover=$(printf 'forwarder-restart\n' | nc -U -w 8 "$sock" 2>/dev/null | tr -d '\r\n') || recover=""
+    if [ "$recover" = "restarted" ]; then
+        local rdeadline body=""
+        rdeadline=$(( $(date +%s) + 20 ))
+        while [ "$(date +%s)" -lt "$rdeadline" ]; do
+            body=$(curl -s --max-time 5 --unix-socket "$incus_sock" http://localhost/1.0 2>/dev/null) || body=""
+            echo "$body" | grep -q '"metadata"' && break
+            sleep 1
+        done
+        if echo "$body" | grep -q '"metadata"'; then
+            echo "ISX AGENT RECOVER OK" >> "$VSOCK_RESULT"
+        else
+            echo "ISX AGENT RECOVER FAIL: Incus not reachable after forwarder-restart" >> "$VSOCK_RESULT"
+        fi
+        [ "$(printf 'ping\n' | nc -U -w 5 "$sock" 2>/dev/null | tr -d '\r\n')" = "ok" ] \
+            && echo "ISX AGENT SURVIVED RECOVER OK" >> "$VSOCK_RESULT"
+    else
+        echo "ISX AGENT RECOVER FAIL: forwarder-restart not confirmed" >> "$VSOCK_RESULT"
     fi
 }
 
@@ -152,7 +177,7 @@ boot_vfkit() {
     # Probe the forwarded socket regardless of ISX READY (the daemon is up well
     # before readiness; the probe polls on its own).
     probe_vsock "$vsock_sock"
-    probe_agent "$agent_sock"
+    probe_agent "$agent_sock" "$vsock_sock"
     kill "$pid" 2>/dev/null || true; wait "$pid" 2>/dev/null || true
     rm -f "$dummy_initrd"
 }
@@ -283,6 +308,8 @@ if [ "$BACKEND" = "vfkit" ]; then
     echo "-- Control agent (isx.agent_vsock=1025) --"
     check "control agent on vsock port 1025"   "in-guest control agent started"
     check_result "ISX AGENT OK"                "control agent answered ping over vsock"
+    check_result "ISX AGENT RECOVER OK"        "no-reboot forwarder recovery restored the tunnel"
+    check_result "ISX AGENT SURVIVED RECOVER OK" "control agent still up after forwarder recovery"
 else
     echo
     echo "-- Smoke test (isx.smoke_test=1) --"

--- a/src/main/java/dev/incusspawn/Environment.java
+++ b/src/main/java/dev/incusspawn/Environment.java
@@ -133,6 +133,11 @@ public final class Environment {
         return vmStateDir().resolve("vm.incus.sock");
     }
 
+    /** Host-side Unix socket for the in-VM control agent (introspection/recovery). */
+    public static Path vmAgentSocket() {
+        return vmStateDir().resolve("vm.agent.sock");
+    }
+
     public static Path vmDiskImage() {
         return vmStateDir().resolve("disk.img");
     }

--- a/src/main/java/dev/incusspawn/IncusSpawn.java
+++ b/src/main/java/dev/incusspawn/IncusSpawn.java
@@ -41,7 +41,7 @@ public class IncusSpawn implements QuarkusApplication {
                 DestroyCommand.class, UpdateAllCommand.class, ProxyCommand.class,
                 CleanCommand.class, CompletionCommand.class, TemplatesCommand.class,
                 InstancesCommand.class, GitRemoteHelperCommand.class, SshProxyCommand.class,
-                VmCommand.class, UpdateBaseCommand.class
+                VmCommand.class, UpdateBaseCommand.class, DoctorCommand.class
             }, generateHelp = true)
     public static class IncusSpawnCommand extends BaseCommand {
         @Option(shortName = 'V', name = "version", hasValue = false, description = "Display version info")

--- a/src/main/java/dev/incusspawn/command/DoctorCommand.java
+++ b/src/main/java/dev/incusspawn/command/DoctorCommand.java
@@ -3,6 +3,7 @@ package dev.incusspawn.command;
 import dev.incusspawn.Environment;
 import dev.incusspawn.RuntimeServices;
 import dev.incusspawn.incus.IncusClient;
+import dev.incusspawn.vm.VmAgentClient;
 import dev.incusspawn.vm.VmManager;
 import org.aesh.command.CommandDefinition;
 import org.aesh.command.CommandResult;
@@ -135,7 +136,34 @@ public class DoctorCommand extends BaseCommand {
     }
 
     private Finding checkForwarderLeak() {
-        return forwarderFinding(VmManager.vsockForwarderConnectionCount());
+        var base = forwarderFinding(VmManager.vsockForwarderConnectionCount());
+
+        // If the in-VM control agent is present, enrich with the in-guest socat child count.
+        // Comparing it to the host-side count locates the leak: low in-guest + high host = vfkit
+        // not reaping (link 2); both high = forwarder lingering children (link 3).
+        var guest = VmAgentClient.socatCount();
+        var detail = base.detail();
+        if (guest.isPresent()) {
+            var sep = detail == null || detail.isBlank() ? "" : " ";
+            detail = (detail == null ? "" : detail) + sep + "(in-guest socat: " + guest.getAsInt() + ")";
+        }
+
+        if (base.status() == Status.OK) {
+            return new Finding(Status.OK, base.label(), detail, null);
+        }
+        // Leak: prefer no-reboot recovery via the agent; fall back to the VM restart otherwise.
+        if (VmAgentClient.ping()) {
+            return Finding.warn(base.label(), detail,
+                    new Remediation("Restart the forwarder in the VM (no reboot — running containers keep going)",
+                            false, DoctorCommand::restartForwarderViaAgent));
+        }
+        return new Finding(base.status(), base.label(), detail, base.remediation());
+    }
+
+    private static void restartForwarderViaAgent() {
+        if (!VmAgentClient.restartForwarder()) {
+            throw new RuntimeException("control agent did not confirm forwarder restart");
+        }
     }
 
     /** Pure decision from a forwarder connection count (-1 = unmeasurable). Package-private for testing. */

--- a/src/main/java/dev/incusspawn/command/DoctorCommand.java
+++ b/src/main/java/dev/incusspawn/command/DoctorCommand.java
@@ -136,28 +136,62 @@ public class DoctorCommand extends BaseCommand {
     }
 
     private Finding checkForwarderLeak() {
-        var base = forwarderFinding(VmManager.vsockForwarderConnectionCount());
+        int host = VmManager.vsockForwarderConnectionCount();
+        var base = forwarderFinding(host);
 
-        // If the in-VM control agent is present, enrich with the in-guest socat child count.
-        // Comparing it to the host-side count locates the leak: low in-guest + high host = vfkit
-        // not reaping (link 2); both high = forwarder lingering children (link 3).
+        // If the in-VM control agent is present, report the in-guest socat child count too.
         var guest = VmAgentClient.socatCount();
         var detail = base.detail();
         if (guest.isPresent()) {
-            var sep = detail == null || detail.isBlank() ? "" : " ";
-            detail = (detail == null ? "" : detail) + sep + "(in-guest socat: " + guest.getAsInt() + ")";
+            detail = append(detail, "(in-guest socat: " + guest.getAsInt() + ")");
         }
 
         if (base.status() == Status.OK) {
             return new Finding(Status.OK, base.label(), detail, null);
         }
-        // Leak: prefer no-reboot recovery via the agent; fall back to the VM restart otherwise.
+        // Leak: if we have both counts, localize which layer is leaking, and pick the matching
+        // remediation — link 3 (forwarder) clears with the no-reboot restart; link 2 (vfkit) needs
+        // a VM restart.
+        if (guest.isPresent()) {
+            var layer = leakLayer(host, guest.getAsInt());
+            detail = append(detail, "— " + layer.description);
+            if (layer == LeakLayer.FORWARDER && VmAgentClient.ping()) {
+                return Finding.warn(base.label(), detail,
+                        new Remediation("Restart the forwarder in the VM (no reboot — running containers keep going)",
+                                false, DoctorCommand::restartForwarderViaAgent));
+            }
+            return new Finding(base.status(), base.label(), detail, base.remediation());
+        }
+        // No in-guest count: try the non-destructive forwarder restart first if the agent answers.
         if (VmAgentClient.ping()) {
             return Finding.warn(base.label(), detail,
                     new Remediation("Restart the forwarder in the VM (no reboot — running containers keep going)",
                             false, DoctorCommand::restartForwarderViaAgent));
         }
         return new Finding(base.status(), base.label(), detail, base.remediation());
+    }
+
+    /** Where forwarder streams are leaking, inferred from host vs in-guest connection counts. */
+    enum LeakLayer {
+        FORWARDER("forwarder is lingering children (link 3) — the in-VM forwarder-restart clears it"),
+        VFKIT("vfkit is not reaping host fds (link 2) — a VM restart is required");
+        final String description;
+        LeakLayer(String description) { this.description = description; }
+    }
+
+    /**
+     * Localize a forwarder leak from the host-side connection count and the in-guest socat child
+     * count. Under a link-3 leak both climb together (each leaked stream is a socat child and a
+     * host fd); under link-2 the host count climbs while the in-guest children are reaped, so the
+     * guest count stays low. Package-private for testing.
+     */
+    static LeakLayer leakLayer(int hostCount, int guestCount) {
+        return guestCount * 2 <= hostCount ? LeakLayer.VFKIT : LeakLayer.FORWARDER;
+    }
+
+    private static String append(String detail, String extra) {
+        if (detail == null || detail.isBlank()) return extra;
+        return detail + " " + extra;
     }
 
     private static void restartForwarderViaAgent() {

--- a/src/main/java/dev/incusspawn/command/DoctorCommand.java
+++ b/src/main/java/dev/incusspawn/command/DoctorCommand.java
@@ -1,0 +1,170 @@
+package dev.incusspawn.command;
+
+import dev.incusspawn.Environment;
+import dev.incusspawn.RuntimeServices;
+import dev.incusspawn.incus.IncusClient;
+import dev.incusspawn.vm.VmManager;
+import org.aesh.command.CommandDefinition;
+import org.aesh.command.CommandResult;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Runs a battery of health checks across the host, VM, and vsock tunnel and reports a
+ * grouped pass/warn/fail summary. For problems that have a remediation, it offers to apply
+ * the fix interactively (when attached to a terminal) or prints the suggested action otherwise.
+ *
+ * Fine-grained diagnostics/recovery are intentionally not separate top-level commands — they
+ * live here as checks so there is a single, discoverable entry point.
+ */
+@CommandDefinition(
+        name = "doctor",
+        description = "Run health checks and offer to fix problems",
+        generateHelp = true
+)
+public class DoctorCommand extends BaseCommand {
+
+    enum Status {
+        OK("✓"), WARN("⚠"), FAIL("✗");
+        final String symbol;
+        Status(String symbol) { this.symbol = symbol; }
+    }
+
+    /** A remediation a check can offer. {@code destructive} drives the confirmation wording. */
+    interface Action { void run() throws Exception; }
+    record Remediation(String description, boolean destructive, Action action) {}
+
+    record Finding(Status status, String label, String detail, Remediation remediation) {
+        static Finding ok(String label, String detail) { return new Finding(Status.OK, label, detail, null); }
+        static Finding warn(String label, String detail, Remediation r) { return new Finding(Status.WARN, label, detail, r); }
+        static Finding fail(String label, String detail, Remediation r) { return new Finding(Status.FAIL, label, detail, r); }
+    }
+
+    @Override
+    protected CommandResult doExecute() throws Exception {
+        System.out.println("Running incus-spawn doctor...\n");
+
+        var findings = Environment.isLinux() ? runLinuxChecks() : runMacChecks();
+
+        for (var f : findings) {
+            var detail = f.detail() == null || f.detail().isBlank() ? "" : " " + f.detail();
+            System.out.println("  " + f.status().symbol + " " + f.label() + detail);
+        }
+
+        var actionable = findings.stream()
+                .filter(f -> f.status() != Status.OK && f.remediation() != null)
+                .toList();
+
+        if (actionable.isEmpty()) {
+            boolean anyProblem = findings.stream().anyMatch(f -> f.status() != Status.OK);
+            System.out.println("\n" + (anyProblem ? "Some checks reported issues with no automatic fix."
+                    : "All checks passed."));
+            return exitFor(findings);
+        }
+
+        System.out.println("\n" + actionable.size() + " issue(s) can be addressed:\n");
+        for (var f : actionable) {
+            System.out.println("  " + f.status().symbol + " " + f.label());
+            applyOrSuggest(f.remediation());
+        }
+        return exitFor(findings);
+    }
+
+    private CommandResult exitFor(List<Finding> findings) {
+        boolean anyFail = findings.stream().anyMatch(f -> f.status() == Status.FAIL);
+        return anyFail ? CommandResult.valueOf(1) : CommandResult.SUCCESS;
+    }
+
+    /** Prompt to apply a remediation (TTY), or print the suggestion when non-interactive. */
+    private void applyOrSuggest(Remediation r) {
+        var console = System.console();
+        if (console == null) {
+            System.out.println("     fix: " + r.description() + " (re-run in a terminal to apply)");
+            return;
+        }
+        var warn = r.destructive() ? " This is disruptive." : "";
+        System.out.print("     " + r.description() + "." + warn + " Apply now? (y/N): ");
+        var answer = console.readLine();
+        if (answer == null || !answer.strip().equalsIgnoreCase("y")) {
+            System.out.println("     skipped.");
+            return;
+        }
+        try {
+            r.action().run();
+            System.out.println("     done.");
+        } catch (Exception e) {
+            System.out.println("     failed: " + e.getMessage());
+        }
+    }
+
+    // ---- macOS checks (vfkit VM + vsock tunnel) ----
+
+    private List<Finding> runMacChecks() {
+        var findings = new ArrayList<Finding>();
+        boolean vmRunning = VmManager.isRunning();
+        findings.add(checkVmRunning(vmRunning));
+        if (vmRunning) {
+            findings.add(checkIncusReachable());
+            findings.add(checkForwarderLeak());
+        }
+        return findings;
+    }
+
+    private Finding checkVmRunning(boolean running) {
+        if (running) return Finding.ok("VM running", "");
+        return Finding.fail("VM not running", "",
+                new Remediation("Start the VM", false, VmManager::start));
+    }
+
+    private Finding checkIncusReachable() {
+        long t0 = System.nanoTime();
+        boolean reachable = IncusClient.isReachable();
+        double seconds = (System.nanoTime() - t0) / 1_000_000_000.0;
+        if (!reachable) {
+            var detail = RuntimeServices.incus().checkConnectivity();
+            return Finding.fail("Incus not reachable", detail == null ? "" : "(" + detail + ")",
+                    new Remediation("Restart the VM to restore the tunnel", true, DoctorCommand::restartVm));
+        }
+        if (seconds > 5.0) {
+            return Finding.warn("Incus reachable but slow",
+                    String.format("(%.1fs — possible forwarder pressure)", seconds),
+                    new Remediation("Restart the VM to clear the tunnel", true, DoctorCommand::restartVm));
+        }
+        return Finding.ok("Incus reachable", String.format("(%.1fs)", seconds));
+    }
+
+    private Finding checkForwarderLeak() {
+        return forwarderFinding(VmManager.vsockForwarderConnectionCount());
+    }
+
+    /** Pure decision from a forwarder connection count (-1 = unmeasurable). Package-private for testing. */
+    static Finding forwarderFinding(int conns) {
+        if (conns < 0) return Finding.ok("vsock forwarder", "(not measurable)");
+        if (conns > VmManager.VSOCK_CONN_WARN_THRESHOLD) {
+            return Finding.warn("vsock forwarder connections: " + conns,
+                    "(high — leaked streams degrade new-connection latency)",
+                    new Remediation("Restart the VM to clear leaked forwarder streams "
+                            + "(stops running containers)", true, DoctorCommand::restartVm));
+        }
+        return Finding.ok("vsock forwarder connections: " + conns, "");
+    }
+
+    private static void restartVm() {
+        VmManager.stop();
+        if (!VmManager.start()) throw new RuntimeException("VM failed to start");
+    }
+
+    // ---- Linux checks (native Incus) ----
+
+    private List<Finding> runLinuxChecks() {
+        var findings = new ArrayList<Finding>();
+        if (IncusClient.isReachable()) {
+            findings.add(Finding.ok("Incus reachable", ""));
+        } else {
+            var detail = RuntimeServices.incus().checkConnectivity();
+            findings.add(Finding.fail("Incus not reachable", detail == null ? "" : "(" + detail + ")", null));
+        }
+        return findings;
+    }
+}

--- a/src/main/java/dev/incusspawn/incus/IncusApi.java
+++ b/src/main/java/dev/incusspawn/incus/IncusApi.java
@@ -40,7 +40,9 @@ class IncusApi {
         this.transport = transport;
     }
 
-    private static final int PROBE_TIMEOUT_SECONDS = 5;
+    // Short enough that a stalled vsock fails fast (a healthy connect is sub-millisecond),
+    // so reachability polling stays responsive instead of blocking the full request watchdog.
+    private static final int PROBE_TIMEOUT_SECONDS = 3;
 
     /**
      * Try each candidate Unix socket path: Linux daemon sockets, then vsock (macOS).
@@ -468,14 +470,7 @@ class IncusApi {
         var exec = postExec(instance, command, uid, gid, cwd, env, false, 0, 0);
         var stdoutBuf = new ByteArrayOutputStream();
         var stderrBuf = new ByteArrayOutputStream();
-
-        var controlThread = Thread.ofVirtual().start(() ->
-                wsDiscardWithKeepalive(exec.opPath, exec.fds.path("control").asText()));
-        wsCloseOnly(exec.opPath, exec.fds.path("0").asText());
-        readOutputWithWatcher(exec, controlThread, stdoutBuf, stderrBuf);
-
-        int exitCode = waitForExecOp(exec.opPath);
-        joinQuietly(controlThread);
+        int exitCode = execWebSocket(exec, stdoutBuf, stderrBuf, null);
         return new IncusClient.ExecResult(exitCode,
                 stdoutBuf.toString(StandardCharsets.UTF_8),
                 stderrBuf.toString(StandardCharsets.UTF_8));
@@ -490,17 +485,7 @@ class IncusApi {
                    OutputStream stdout, OutputStream stderr) {
         return retryOnNotRunning(() -> {
             var exec = postExec(instance, command, uid, gid, cwd, env, false, 0, 0);
-
-            var controlThread = Thread.ofVirtual().start(() ->
-                    wsDiscardWithKeepalive(exec.opPath, exec.fds.path("control").asText()));
-            wsCloseOnly(exec.opPath, exec.fds.path("0").asText());
-            readOutputWithWatcher(exec, controlThread,
-                    stdout != null ? stdout : OutputStream.nullOutputStream(),
-                    stderr != null ? stderr : OutputStream.nullOutputStream());
-
-            int exitCode = waitForExecOp(exec.opPath);
-            joinQuietly(controlThread);
-            return exitCode;
+            return execWebSocket(exec, stdout, stderr, null);
         });
     }
 
@@ -650,28 +635,125 @@ class IncusApi {
     }
 
     /**
-     * Open stdout/stderr WebSockets with the watcher pattern: when controlThread
-     * finishes (process exited), force-close both connections. Reads data from each
-     * fd into the provided OutputStreams until done.
+     * Grace window after the operation completes during which the data sockets are
+     * allowed to drain any bytes still in flight over the tunnel before we force-close
+     * them. In the healthy case the server's own close frames arrive first and this is
+     * never reached; it only bounds the wait when close frames never arrive (macOS vsock).
      */
-    private void readOutputWithWatcher(ExecOp exec, Thread controlThread,
-                                       OutputStream stdout, OutputStream stderr) {
-        try (var stdoutWs = transport.openWebSocket(exec.opPath + "/websocket?secret=" + exec.fds.path("1").asText());
-             var stderrWs = transport.openWebSocket(exec.opPath + "/websocket?secret=" + exec.fds.path("2").asText())) {
+    private static final long DRAIN_GRACE_MS = 250;
 
-            Thread.ofVirtual().start(() -> {
-                joinQuietly(controlThread);
+    /**
+     * Unified non-interactive exec over WebSockets, used for capture, streaming and
+     * bidirectional (git) exec — the destination streams just differ.
+     *
+     * Streams stdout/stderr to the provided sinks in real time. Crucially, process
+     * completion is detected via the operation /wait endpoint (a normal HTTP request
+     * backed by the daemon's operation state machine) — NOT via WebSocket close frames,
+     * which the macOS vsock tunnel may never deliver. Once the operation completes we
+     * give the data sockets a brief grace window to drain, then force-close them so the
+     * reader threads always unblock. This makes the termination signal independent of
+     * the (unreliable) close-frame propagation that every prior iteration depended on.
+     *
+     * @param stdin null → stdin is closed immediately; non-null → forwarded to the container.
+     */
+    private int execWebSocket(ExecOp exec, OutputStream stdout, OutputStream stderr, InputStream stdin) {
+        var outDst = stdout != null ? stdout : OutputStream.nullOutputStream();
+        var errDst = stderr != null ? stderr : OutputStream.nullOutputStream();
+        try (var controlWs = transport.openWebSocket(wsUrl(exec, "control"));
+             var stdoutWs  = transport.openWebSocket(wsUrl(exec, "1"));
+             var stderrWs  = transport.openWebSocket(wsUrl(exec, "2"))) {
+
+            // Control fd is connected only to satisfy wait-for-websocket and kept alive
+            // with pings; it is no longer used as the termination signal.
+            // Keepalive pings on EVERY fd, not just control: each exec fd is a separate
+            // vsock connection (a separate forwarder child in the VM), so an inactivity
+            // reaper in the forwarder would otherwise collect the stdout/stderr connections
+            // of a long, quiet command and truncate it. Pings keep every live connection
+            // visibly alive so only genuinely-dead ones can be reaped.
+            var keepalive    = startKeepalive(controlWs);
+            var stdoutAlive  = startKeepalive(stdoutWs);
+            var stderrAlive  = startKeepalive(stderrWs);
+            var controlDrain = Thread.ofVirtual().start(() -> drainQuietly(controlWs));
+
+            var stdoutThread = Thread.ofVirtual().start(() -> wsWriteTo(stdoutWs, outDst));
+            var stderrThread = Thread.ofVirtual().start(() -> wsWriteTo(stderrWs, errDst));
+
+            Thread stdinThread = null;
+            if (stdin != null) {
+                stdinThread = Thread.ofVirtual().start(() ->
+                        wsForward(exec.opPath, exec.fds.path("0").asText(), stdin));
+            } else {
+                wsCloseOnly(exec.opPath, exec.fds.path("0").asText());
+            }
+            assertAllFdsConnected(exec.fds, Set.of("0", "1", "2", "control"));
+
+            // Authoritative completion + exit code (HTTP, reliable over vsock).
+            int exitCode = waitForExecOp(exec.opPath);
+
+            // Process has exited: stop pinging the data fds, let them drain, then
+            // force-close so the reader threads unblock even if no close frame arrives.
+            stdoutAlive.interrupt();
+            stderrAlive.interrupt();
+            if (!joinWithin(DRAIN_GRACE_MS, stdoutThread, stderrThread)) {
                 stdoutWs.close();
                 stderrWs.close();
-            });
+                joinQuietly(stdoutThread, stderrThread);
+            }
 
-            var stdoutThread = Thread.ofVirtual().start(() -> wsWriteTo(stdoutWs, stdout));
-            var stderrThread = Thread.ofVirtual().start(() -> wsWriteTo(stderrWs, stderr));
-            assertAllFdsConnected(exec.fds, Set.of("0", "1", "2", "control"));
-            joinQuietly(stdoutThread, stderrThread);
+            keepalive.interrupt();
+            controlWs.close();
+            joinQuietly(controlDrain);
+
+            if (stdinThread != null) {
+                // In the git pack protocol the caller closes stdin before we reach here;
+                // otherwise abandon the (uninterruptible) System.in read after 2 s.
+                try { stdinThread.join(2000); } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+            return exitCode;
         } catch (IOException e) {
             throw new IncusException("Failed to open exec WebSocket", e);
         }
+    }
+
+    private String wsUrl(ExecOp exec, String fd) {
+        return exec.opPath + "/websocket?secret=" + exec.fds.path(fd).asText();
+    }
+
+    /** Start a virtual thread that pings the socket until interrupted (idle-timeout guard). */
+    private Thread startKeepalive(IncusTransport.WsConnection ws) {
+        return Thread.ofVirtual().start(() -> {
+            try {
+                while (!Thread.currentThread().isInterrupted()) {
+                    Thread.sleep(WS_PING_INTERVAL_MS);
+                    ws.sendPing();
+                }
+            } catch (IOException | InterruptedException ignored) {}
+        });
+    }
+
+    /** Read and discard all frames until the socket closes. */
+    private static void drainQuietly(IncusTransport.WsConnection ws) {
+        try {
+            while (ws.readPayload() != null) {}
+        } catch (IOException ignored) {}
+    }
+
+    /** Join all threads within a total budget. Returns true iff all finished in time. */
+    private static boolean joinWithin(long millis, Thread... threads) {
+        long deadline = System.currentTimeMillis() + millis;
+        for (var t : threads) {
+            long remaining = deadline - System.currentTimeMillis();
+            try {
+                t.join(Math.max(1, remaining));
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return false;
+            }
+        }
+        for (var t : threads) if (t.isAlive()) return false;
+        return true;
     }
 
     private static void assertAllFdsConnected(JsonNode fds, Set<String> connected) {
@@ -687,30 +769,9 @@ class IncusApi {
     }
 
     /**
-     * Connect a WebSocket and read/discard all frames until the server closes it.
-     * Sends periodic keepalive pings to prevent vsock idle timeout.
-     */
-    private void wsDiscardWithKeepalive(String opPath, String secret) {
-        try (var ws = transport.openWebSocket(opPath + "/websocket?secret=" + secret)) {
-            var keepalive = Thread.ofVirtual().start(() -> {
-                try {
-                    while (!Thread.currentThread().isInterrupted()) {
-                        Thread.sleep(WS_PING_INTERVAL_MS);
-                        ws.sendPing();
-                    }
-                } catch (IOException | InterruptedException ignored) {}
-            });
-            try {
-                while (ws.readPayload() != null) {}
-            } finally {
-                keepalive.interrupt();
-            }
-        } catch (IOException ignored) {}
-    }
-
-    /**
-     * Like {@link #wsDiscardWithKeepalive}, but also sets connectionLost if the
-     * socket died due to an I/O error (used by execPty for reconnect logic).
+     * Connect a WebSocket, read/discard all frames with keepalive pings until it closes,
+     * and set connectionLost if the socket died due to an I/O error (used by execPty for
+     * reconnect logic).
      */
     private void wsDiscardTrackedWithKeepalive(String opPath, String secret,
                                                java.util.concurrent.atomic.AtomicBoolean connectionLost) {
@@ -753,17 +814,32 @@ class IncusApi {
         } catch (IOException ignored) {}
     }
 
-    /** GET /1.0/operations/{id}/wait and extract the exit code from metadata.metadata.return. */
+    /**
+     * Block until the exec operation finishes and return the command's exit code.
+     *
+     * The /wait long-poll returns after at most WAIT_TIMEOUT_SECONDS even if the command
+     * is still running, so we re-issue it until the operation leaves the Running/Pending
+     * state. This is the authoritative termination signal for {@link #execWebSocket} — it
+     * must report completion only when the process has actually exited, otherwise we would
+     * force-close the data sockets mid-stream and truncate output on long commands.
+     */
     private int waitForExecOp(String opPath) {
-        var waitResp = requestWithTimeout("GET",
-                opPath + "/wait?timeout=" + WAIT_TIMEOUT_SECONDS,
-                null, WAIT_TIMEOUT_SECONDS + 30);
-        if (!waitResp.isSuccess()) {
-            System.err.println("Warning: exec operation lost (HTTP " + waitResp.statusCode()
-                    + " on " + opPath + "/wait) — exit code unknown");
-            return -1;
+        while (true) {
+            var waitResp = requestWithTimeout("GET",
+                    opPath + "/wait?timeout=" + WAIT_TIMEOUT_SECONDS,
+                    null, WAIT_TIMEOUT_SECONDS + 30);
+            if (!waitResp.isSuccess()) {
+                System.err.println("Warning: exec operation lost (HTTP " + waitResp.statusCode()
+                        + " on " + opPath + "/wait) — exit code unknown");
+                return -1;
+            }
+            var meta = waitResp.body().path("metadata");
+            var status = meta.path("status").asText();
+            if ("Running".equals(status) || "Pending".equals(status)) {
+                continue; // long-poll window elapsed; command still running
+            }
+            return meta.path("metadata").path("return").asInt(0);
         }
-        return waitResp.body().path("metadata").path("metadata").path("return").asInt(0);
     }
 
     private static void joinQuietly(Thread... threads) {
@@ -802,48 +878,7 @@ class IncusApi {
                                     Integer uid, Integer gid, String cwd, Map<String, String> env,
                                     InputStream stdin, OutputStream stdout, OutputStream stderr) {
         var exec = postExec(instance, command, uid, gid, cwd, env, false, 0, 0);
-
-        var stdinSecret  = exec.fds.path("0").asText();
-        var outDst = stdout != null ? stdout : OutputStream.nullOutputStream();
-        var errDst = stderr != null ? stderr : OutputStream.nullOutputStream();
-
-        var controlThread = Thread.ofVirtual().start(() ->
-                wsDiscardWithKeepalive(exec.opPath, exec.fds.path("control").asText()));
-
-        try (var stdoutWs = transport.openWebSocket(exec.opPath + "/websocket?secret=" + exec.fds.path("1").asText());
-             var stderrWs = transport.openWebSocket(exec.opPath + "/websocket?secret=" + exec.fds.path("2").asText())) {
-
-            // Watcher: when control closes (process exited), force-close data fds.
-            // vsock may never deliver the WebSocket close frame.
-            Thread.ofVirtual().start(() -> {
-                joinQuietly(controlThread);
-                stdoutWs.close();
-                stderrWs.close();
-            });
-
-            // Forward stdin to the container
-            var stdinThread  = Thread.ofVirtual().start(() -> wsForward(exec.opPath, stdinSecret, stdin));
-            var stdoutThread = Thread.ofVirtual().start(() -> wsWriteTo(stdoutWs, outDst));
-            var stderrThread = Thread.ofVirtual().start(() -> wsWriteTo(stderrWs, errDst));
-            assertAllFdsConnected(exec.fds, Set.of("0", "1", "2", "control"));
-
-            // Join stdout/stderr first: they finish when the container process exits
-            // or when the watcher closes the WebSockets.
-            // After 2 s the stdin virtual thread is abandoned (System.in.read() cannot
-            // be interrupted; the thread dies when the JVM exits).
-            joinQuietly(stdoutThread, stderrThread);
-            try {
-                stdinThread.join(2000);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-            }
-        } catch (IOException e) {
-            throw new IncusException("Failed to open exec WebSocket", e);
-        }
-
-        int exitCode = waitForExecOp(exec.opPath);
-        joinQuietly(controlThread);
-        return exitCode;
+        return execWebSocket(exec, stdout, stderr, stdin);
     }
 
     /**

--- a/src/main/java/dev/incusspawn/incus/IncusApi.java
+++ b/src/main/java/dev/incusspawn/incus/IncusApi.java
@@ -637,10 +637,11 @@ class IncusApi {
     /**
      * Grace window after the operation completes during which the data sockets are
      * allowed to drain any bytes still in flight over the tunnel before we force-close
-     * them. In the healthy case the server's own close frames arrive first and this is
+     * them. 2 s is generous enough for a slow/loaded vsock tunnel to flush its buffers.
+     * In the healthy case the server's own close frames arrive first and this is
      * never reached; it only bounds the wait when close frames never arrive (macOS vsock).
      */
-    private static final long DRAIN_GRACE_MS = 250;
+    private static final long DRAIN_GRACE_MS = 2000;
 
     /**
      * Unified non-interactive exec over WebSockets, used for capture, streaming and
@@ -823,8 +824,13 @@ class IncusApi {
      * must report completion only when the process has actually exited, otherwise we would
      * force-close the data sockets mid-stream and truncate output on long commands.
      */
+    // Absolute ceiling so a zombie process or daemon bug cannot block the caller forever.
+    // Well above any real command (4 hours); the per-iteration budget is WAIT_TIMEOUT_SECONDS.
+    private static final long MAX_EXEC_WAIT_SECONDS = 4 * 3600L;
+
     private int waitForExecOp(String opPath) {
-        while (true) {
+        long deadline = System.nanoTime() + MAX_EXEC_WAIT_SECONDS * 1_000_000_000L;
+        while (System.nanoTime() < deadline) {
             var waitResp = requestWithTimeout("GET",
                     opPath + "/wait?timeout=" + WAIT_TIMEOUT_SECONDS,
                     null, WAIT_TIMEOUT_SECONDS + 30);
@@ -840,6 +846,9 @@ class IncusApi {
             }
             return meta.path("metadata").path("return").asInt(0);
         }
+        System.err.println("Warning: exec operation timed out after "
+                + MAX_EXEC_WAIT_SECONDS + "s on " + opPath + " — exit code unknown");
+        return -1;
     }
 
     private static void joinQuietly(Thread... threads) {

--- a/src/main/java/dev/incusspawn/incus/IncusApi.java
+++ b/src/main/java/dev/incusspawn/incus/IncusApi.java
@@ -634,14 +634,16 @@ class IncusApi {
                 opMeta.path("metadata").path("fds"));
     }
 
-    /**
-     * Grace window after the operation completes during which the data sockets are
-     * allowed to drain any bytes still in flight over the tunnel before we force-close
-     * them. 2 s is generous enough for a slow/loaded vsock tunnel to flush its buffers.
-     * In the healthy case the server's own close frames arrive first and this is
-     * never reached; it only bounds the wait when close frames never arrive (macOS vsock).
-     */
-    private static final long DRAIN_GRACE_MS = 2000;
+    // After the operation completes we drain the data sockets before force-closing them, so
+    // trailing output isn't truncated when close frames never arrive (macOS vsock). Rather than
+    // a blind fixed wait (too short risks truncation on a slow tunnel; too long adds that latency
+    // to *every* exec on machines where close frames don't arrive), the drain is adaptive: wait a
+    // short minimum for in-flight bytes, extend while output is still arriving, and close once it
+    // has been idle briefly — bounded by an absolute cap. On the healthy path the close frames
+    // arrive and the reader threads finish at once, so none of this is reached.
+    private static final long DRAIN_MIN_MS  = 200;   // always wait this for bytes in flight
+    private static final long DRAIN_IDLE_MS = 200;   // then close once output has been idle this long
+    private static final long DRAIN_MAX_MS  = 5000;  // absolute ceiling
 
     /**
      * Unified non-interactive exec over WebSockets, used for capture, streaming and
@@ -676,8 +678,10 @@ class IncusApi {
             var stderrAlive  = startKeepalive(stderrWs);
             var controlDrain = Thread.ofVirtual().start(() -> drainQuietly(controlWs));
 
-            var stdoutThread = Thread.ofVirtual().start(() -> wsWriteTo(stdoutWs, outDst));
-            var stderrThread = Thread.ofVirtual().start(() -> wsWriteTo(stderrWs, errDst));
+            // Timestamp of the last byte received on either data fd, for the adaptive drain.
+            var lastData = new java.util.concurrent.atomic.AtomicLong(System.nanoTime());
+            var stdoutThread = Thread.ofVirtual().start(() -> wsWriteTo(stdoutWs, outDst, lastData));
+            var stderrThread = Thread.ofVirtual().start(() -> wsWriteTo(stderrWs, errDst, lastData));
 
             Thread stdinThread = null;
             if (stdin != null) {
@@ -691,15 +695,11 @@ class IncusApi {
             // Authoritative completion + exit code (HTTP, reliable over vsock).
             int exitCode = waitForExecOp(exec.opPath);
 
-            // Process has exited: stop pinging the data fds, let them drain, then
-            // force-close so the reader threads unblock even if no close frame arrives.
+            // Process has exited: stop pinging the data fds, drain, then force-close so the
+            // reader threads unblock even if no close frame arrives.
             stdoutAlive.interrupt();
             stderrAlive.interrupt();
-            if (!joinWithin(DRAIN_GRACE_MS, stdoutThread, stderrThread)) {
-                stdoutWs.close();
-                stderrWs.close();
-                joinQuietly(stdoutThread, stderrThread);
-            }
+            drainThenClose(lastData, stdoutThread, stderrThread, stdoutWs, stderrWs);
 
             keepalive.interrupt();
             controlWs.close();
@@ -741,20 +741,36 @@ class IncusApi {
         } catch (IOException ignored) {}
     }
 
-    /** Join all threads within a total budget. Returns true iff all finished in time. */
-    private static boolean joinWithin(long millis, Thread... threads) {
-        long deadline = System.currentTimeMillis() + millis;
-        for (var t : threads) {
-            long remaining = deadline - System.currentTimeMillis();
+    /**
+     * Drain the data reader threads, then force-close their sockets. Returns immediately when
+     * the readers finish on their own (close frames arrived — the healthy path). Otherwise it
+     * waits a short minimum for bytes still in flight, extends while output is still arriving
+     * (so trailing output isn't truncated), and force-closes once output has been idle for
+     * {@link #DRAIN_IDLE_MS} — bounded by {@link #DRAIN_MAX_MS}.
+     */
+    private static void drainThenClose(java.util.concurrent.atomic.AtomicLong lastData,
+                                       Thread stdoutThread, Thread stderrThread,
+                                       IncusTransport.WsConnection stdoutWs,
+                                       IncusTransport.WsConnection stderrWs) {
+        long start = System.nanoTime();
+        while (stdoutThread.isAlive() || stderrThread.isAlive()) {
+            long now = System.nanoTime();
+            long sinceStartMs = (now - start) / 1_000_000L;
+            long sinceDataMs  = (now - lastData.get()) / 1_000_000L;
+            if (sinceStartMs >= DRAIN_MAX_MS) break;
+            if (sinceStartMs >= DRAIN_MIN_MS && sinceDataMs >= DRAIN_IDLE_MS) break;
             try {
-                t.join(Math.max(1, remaining));
+                Thread.sleep(20);
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
-                return false;
+                break;
             }
         }
-        for (var t : threads) if (t.isAlive()) return false;
-        return true;
+        if (stdoutThread.isAlive() || stderrThread.isAlive()) {
+            stdoutWs.close();
+            stderrWs.close();
+            joinQuietly(stdoutThread, stderrThread);
+        }
     }
 
     private static void assertAllFdsConnected(JsonNode fds, Set<String> connected) {
@@ -804,11 +820,17 @@ class IncusApi {
         }
     }
 
-    /** Read all data from an already-open WebSocket into dst until the connection closes. */
-    private static void wsWriteTo(IncusTransport.WsConnection ws, OutputStream dst) {
+    /**
+     * Read all data from an already-open WebSocket into dst until the connection closes,
+     * recording the arrival time of each payload so the adaptive drain knows when output has
+     * stopped flowing.
+     */
+    private static void wsWriteTo(IncusTransport.WsConnection ws, OutputStream dst,
+                                  java.util.concurrent.atomic.AtomicLong lastData) {
         try {
             byte[] payload;
             while ((payload = ws.readPayload()) != null) {
+                lastData.set(System.nanoTime());
                 dst.write(payload);
                 dst.flush();
             }

--- a/src/main/java/dev/incusspawn/incus/IncusClient.java
+++ b/src/main/java/dev/incusspawn/incus/IncusClient.java
@@ -165,22 +165,33 @@ public class IncusClient {
 
     /**
      * Poll a command inside a container until it succeeds or the timeout expires.
-     * @param timeoutSeconds maximum wait time in seconds; polls every 200ms for fast detection.
+     *
+     * Each probe is a full exec (~6 vsock connections), so a fixed 200ms cadence
+     * fires up to ~150 execs and creates hundreds of short-lived connections per
+     * wait — multiplied across every branch/shell/build and amplified by the
+     * forwarder leak. We instead start tight (100ms) for fast detection on quick
+     * starts and back off geometrically to a 1s ceiling, which keeps responsiveness
+     * but cuts the number of probes (and connections) several-fold for slow starts.
+     * The total wait budget is unchanged.
+     *
+     * @param timeoutSeconds maximum wait time in seconds.
      */
     public boolean pollUntilReady(String name, int timeoutSeconds, String... command) {
-        int maxAttempts = timeoutSeconds * 5;
-        for (int i = 0; i < maxAttempts; i++) {
+        long deadline = System.nanoTime() + timeoutSeconds * 1_000_000_000L;
+        long delayMs = 100;
+        while (System.nanoTime() < deadline) {
             try {
                 if (shellExec(name, command).success()) return true;
             } catch (Exception ignored) {
                 // Container may not be Running yet — treat any exec failure as not-ready and retry.
             }
             try {
-                Thread.sleep(200);
+                Thread.sleep(delayMs);
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 break;
             }
+            delayMs = Math.min(delayMs * 2, 1000);
         }
         return false;
     }

--- a/src/main/java/dev/incusspawn/incus/UnixSocketTransport.java
+++ b/src/main/java/dev/incusspawn/incus/UnixSocketTransport.java
@@ -41,6 +41,58 @@ class UnixSocketTransport implements IncusTransport {
     private final String socketPath;
     private final int timeoutSeconds;
 
+    // Diagnostics: track how many transport connections are open at once. Every
+    // request and every WebSocket opens a fresh connection (we intentionally do not
+    // pool), and on macOS each one is a vsock stream held by vfkit until the guest
+    // forwarder closes it. A climbing high-water mark is the signature of the socat
+    // forwarder leaking streams, so this is the cheapest way to see it accumulate.
+    private static final java.util.concurrent.atomic.AtomicInteger OPEN_CONNECTIONS =
+            new java.util.concurrent.atomic.AtomicInteger();
+    private static volatile int peakConnections = 0;
+
+    // Per-process safety valve: cap how many connections one isx invocation holds open
+    // at once, so a runaway fan-out can't pile streams onto the forwarder. This bounds a
+    // single process only — it cannot limit aggregate consumption across the many
+    // concurrent/short-lived isx processes a script spawns; that requires forwarder-side
+    // reaping. The cap is set well above any single operation's need (an exec holds ~5
+    // fds), so it never engages in normal use, and acquisition is fail-open after a
+    // timeout so it can never deadlock or wedge a legitimate burst.
+    private static final int MAX_CONCURRENT_CONNECTIONS = 48;
+    private static final long PERMIT_TIMEOUT_MS = 10_000;
+    private static final java.util.concurrent.Semaphore CONNECTION_PERMITS =
+            new java.util.concurrent.Semaphore(MAX_CONCURRENT_CONNECTIONS);
+
+    /** Number of transport connections currently open. */
+    static int openConnectionCount() { return OPEN_CONNECTIONS.get(); }
+
+    /** Highest number of simultaneously-open connections seen this process. */
+    static int peakConnectionCount() { return peakConnections; }
+
+    /**
+     * Record a newly-opened connection and try to claim a concurrency permit.
+     * @return true if a permit was acquired (must be passed to {@link #connectionClosed}).
+     *         A false return means we proceeded without throttling (fail-open).
+     */
+    private static boolean connectionOpened() {
+        boolean permit;
+        try {
+            permit = CONNECTION_PERMITS.tryAcquire(PERMIT_TIMEOUT_MS,
+                    java.util.concurrent.TimeUnit.MILLISECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            permit = false;
+        }
+        int now = OPEN_CONNECTIONS.incrementAndGet();
+        // Benign race on the compare/store — this is a diagnostic counter, not a lock.
+        if (now > peakConnections) peakConnections = now;
+        return permit;
+    }
+
+    private static void connectionClosed(boolean permit) {
+        OPEN_CONNECTIONS.decrementAndGet();
+        if (permit) CONNECTION_PERMITS.release();
+    }
+
     UnixSocketTransport(String socketPath) {
         this(socketPath, DEFAULT_TIMEOUT_SECONDS);
     }
@@ -64,8 +116,12 @@ class UnixSocketTransport implements IncusTransport {
         var addr = UnixDomainSocketAddress.of(socketPath);
         try (var channel = SocketChannel.open(StandardProtocolFamily.UNIX)) {
             var watchdog = startWatchdog(channel, requestTimeout);
+            boolean opened = false;
+            boolean permit = false;
             try {
                 channel.connect(addr);
+                opened = true;
+                permit = connectionOpened();
                 var out = Channels.newOutputStream(channel);
                 var in  = Channels.newInputStream(channel);
                 writeRequest(out, method, path, contentType, extraHeaders, bodyBytes);
@@ -77,6 +133,7 @@ class UnixSocketTransport implements IncusTransport {
                 throw timeoutException(path, requestTimeout);
             } finally {
                 watchdog.interrupt();
+                if (opened) connectionClosed(permit);
             }
         }
     }
@@ -88,8 +145,12 @@ class UnixSocketTransport implements IncusTransport {
         var addr = UnixDomainSocketAddress.of(socketPath);
         try (var channel = SocketChannel.open(StandardProtocolFamily.UNIX)) {
             var watchdog = startWatchdog(channel, timeoutSeconds);
+            boolean opened = false;
+            boolean permit = false;
             try {
                 channel.connect(addr);
+                opened = true;
+                permit = connectionOpened();
                 var out = Channels.newOutputStream(channel);
                 var in  = Channels.newInputStream(channel);
                 writeRequestFromFile(out, method, path, contentType, extraHeaders, bodyFile);
@@ -98,6 +159,7 @@ class UnixSocketTransport implements IncusTransport {
                 throw timeoutException(path, timeoutSeconds);
             } finally {
                 watchdog.interrupt();
+                if (opened) connectionClosed(permit);
             }
         }
     }
@@ -106,11 +168,17 @@ class UnixSocketTransport implements IncusTransport {
     public WsConnection openWebSocket(String wsPath) throws IOException {
         var addr = UnixDomainSocketAddress.of(socketPath);
         var channel = SocketChannel.open(StandardProtocolFamily.UNIX);
-        channel.connect(addr);
-        var out = Channels.newOutputStream(channel);
-        var in  = Channels.newInputStream(channel);
-        wsHandshake(out, in, wsPath);
-        return new UnixWsConnection(channel, out, in);
+        try {
+            channel.connect(addr);
+            var out = Channels.newOutputStream(channel);
+            var in  = Channels.newInputStream(channel);
+            wsHandshake(out, in, wsPath);
+            boolean permit = connectionOpened();
+            return new UnixWsConnection(channel, out, in, permit);
+        } catch (IOException e) {
+            try { channel.close(); } catch (IOException ignored) {}
+            throw e;
+        }
     }
 
     private void writeRequest(OutputStream out, String method, String path,
@@ -330,11 +398,15 @@ class UnixSocketTransport implements IncusTransport {
         private final OutputStream out;
         private final InputStream in;
         private final Object writeLock = new Object();
+        private final java.util.concurrent.atomic.AtomicBoolean closed =
+                new java.util.concurrent.atomic.AtomicBoolean(false);
+        private final boolean permit;
 
-        UnixWsConnection(SocketChannel channel, OutputStream out, InputStream in) {
+        UnixWsConnection(SocketChannel channel, OutputStream out, InputStream in, boolean permit) {
             this.channel = channel;
             this.out     = out;
             this.in      = in;
+            this.permit  = permit;
         }
 
         @Override
@@ -366,6 +438,11 @@ class UnixSocketTransport implements IncusTransport {
 
         @Override
         public void close() {
+            // close() is called more than once (try-with-resources + the watcher
+            // force-close in IncusApi), so only count the first.
+            if (closed.compareAndSet(false, true)) {
+                connectionClosed(permit);
+            }
             try { channel.close(); } catch (IOException ignored) {}
         }
     }

--- a/src/main/java/dev/incusspawn/vm/VmAgentClient.java
+++ b/src/main/java/dev/incusspawn/vm/VmAgentClient.java
@@ -1,0 +1,82 @@
+package dev.incusspawn.vm;
+
+import dev.incusspawn.Environment;
+
+import java.io.IOException;
+import java.net.StandardProtocolFamily;
+import java.net.UnixDomainSocketAddress;
+import java.nio.channels.Channels;
+import java.nio.channels.SocketChannel;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.OptionalInt;
+
+/**
+ * Talks to the in-VM control agent over its dedicated vsock port (exposed on the host as a
+ * Unix socket). The agent speaks one verb per connection: we write "{@code <verb>\n}", read
+ * the response until EOF, and the connection closes. Independent of the Incus tunnel, so it
+ * works even when the forwarder is wedged.
+ *
+ * The agent only honours a fixed allowlist of verbs (see appliance/.../isx-agent); this
+ * client exposes typed wrappers for them.
+ */
+public final class VmAgentClient {
+
+    private static final int TIMEOUT_SECONDS = 5;
+
+    private VmAgentClient() {}
+
+    /** Send a raw verb; returns the trimmed response, or empty if the agent is unreachable. */
+    public static Optional<String> send(String verb) {
+        return send(Environment.vmAgentSocket(), verb);
+    }
+
+    /** Package-private overload so tests can point at a fake agent socket. */
+    static Optional<String> send(Path socketPath, String verb) {
+        if (!Files.exists(socketPath)) return Optional.empty();
+        var addr = UnixDomainSocketAddress.of(socketPath.toString());
+        try (var ch = SocketChannel.open(StandardProtocolFamily.UNIX)) {
+            var watchdog = Thread.ofVirtual().start(() -> {
+                try {
+                    Thread.sleep(TIMEOUT_SECONDS * 1000L);
+                    ch.close();
+                } catch (InterruptedException | IOException ignored) {}
+            });
+            try {
+                ch.connect(addr);
+                var out = Channels.newOutputStream(ch);
+                out.write((verb + "\n").getBytes(StandardCharsets.US_ASCII));
+                out.flush();
+                var body = Channels.newInputStream(ch).readAllBytes();
+                return Optional.of(new String(body, StandardCharsets.UTF_8).strip());
+            } finally {
+                watchdog.interrupt();
+            }
+        } catch (IOException e) {
+            return Optional.empty();
+        }
+    }
+
+    /** In-guest count of forwarder socat processes, or empty if unavailable/unparseable. */
+    public static OptionalInt socatCount() {
+        var resp = send("socat-count");
+        if (resp.isEmpty()) return OptionalInt.empty();
+        try {
+            return OptionalInt.of(Integer.parseInt(resp.get().strip()));
+        } catch (NumberFormatException e) {
+            return OptionalInt.empty();
+        }
+    }
+
+    /** Restart the in-VM forwarder without rebooting the VM. Returns true on confirmed success. */
+    public static boolean restartForwarder() {
+        return send("forwarder-restart").map("restarted"::equals).orElse(false);
+    }
+
+    /** Whether the agent is reachable at all. */
+    public static boolean ping() {
+        return send("ping").map("ok"::equals).orElse(false);
+    }
+}

--- a/src/main/java/dev/incusspawn/vm/VmManager.java
+++ b/src/main/java/dev/incusspawn/vm/VmManager.java
@@ -340,17 +340,65 @@ public final class VmManager {
                 } catch (IOException ignored) {}
             }
             sb.append("\n  Log: ").append(Environment.vmLogFile());
+            int vsockConns = vsockForwarderConnectionCount();
+            if (vsockConns >= 0) {
+                sb.append("\n  vsock forwarder connections: ").append(vsockConns);
+                if (vsockConns > VSOCK_CONN_WARN_THRESHOLD) {
+                    sb.append("  ⚠ high — the in-VM forwarder may be leaking streams; 'isx vm restart' clears them");
+                }
+            }
             return sb.toString();
         }
         cleanupStaleFiles();
         return "VM not running";
     }
 
+    // Above this many held vsock connections, the appliance's socat forwarder is
+    // likely leaking streams (it does not reap connections whose close never
+    // propagates across the vsock boundary), which degrades new-connection latency.
+    private static final int VSOCK_CONN_WARN_THRESHOLD = 64;
+
+    /**
+     * Count the host-side connections currently open on the vsock Unix socket
+     * (macOS only). These are held by vfkit and are reclaimed when the in-VM
+     * forwarder closes its end; a steadily climbing count is the signature of the
+     * forwarder leak. Returns -1 if the count can't be determined (non-macOS, no
+     * socket, or lsof unavailable).
+     */
+    private static int vsockForwarderConnectionCount() {
+        var sock = Environment.vmVsockSocket();
+        if (!Environment.isMacOS() || !Files.exists(sock)) return -1;
+        try {
+            var pb = new ProcessBuilder("lsof", "-nP", "-U");
+            pb.redirectErrorStream(false);
+            var proc = pb.start();
+            int count;
+            try (var r = new java.io.BufferedReader(
+                    new java.io.InputStreamReader(proc.getInputStream()))) {
+                count = (int) r.lines().filter(l -> l.contains(sock.toString())).count();
+            }
+            if (!proc.waitFor(3, java.util.concurrent.TimeUnit.SECONDS)) {
+                proc.destroyForcibly();
+                return -1;
+            }
+            return count;
+        } catch (IOException | InterruptedException e) {
+            if (e instanceof InterruptedException) Thread.currentThread().interrupt();
+            return -1;
+        }
+    }
+
     /**
      * Wait for the Incus daemon inside the VM to become reachable.
+     *
+     * Bounded by a wall-clock deadline, not an iteration count: each isReachable()
+     * probe can take up to the connect watchdog (seconds) when the vsock is stalled,
+     * so a count-based loop would silently overrun its "maxWaitSeconds" budget several
+     * fold in exactly the degraded state we need to bound.
      */
     public static boolean waitUntilReady(int maxWaitSeconds) {
-        for (int i = 0; i < maxWaitSeconds; i++) {
+        long deadline = System.nanoTime() + maxWaitSeconds * 1_000_000_000L;
+        while (System.nanoTime() < deadline) {
             if (IncusClient.isReachable()) return true;
             try { Thread.sleep(1000); } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();

--- a/src/main/java/dev/incusspawn/vm/VmManager.java
+++ b/src/main/java/dev/incusspawn/vm/VmManager.java
@@ -38,6 +38,7 @@ public final class VmManager {
     private static final String DEFAULT_DISK_SIZE = "60G";
     private static final String DEFAULT_SWAP_SIZE = "12G";
     private static final int GA_VSOCK_PORT = 1024;
+    private static final int AGENT_VSOCK_PORT = 1025;
     private static final int INCUS_VSOCK_PORT = 8443;
 
     private static final String LATEST_KNOWN_RELEASE = "0.2.2";
@@ -582,6 +583,8 @@ public final class VmManager {
                 "--device", "virtio-fs,sharedDir=" + System.getProperty("user.home") + ",mountTag=hostfs",
                 "--device", "virtio-vsock,port=" + INCUS_VSOCK_PORT
                         + ",socketURL=" + Environment.vmVsockSocket() + ",connect",
+                "--device", "virtio-vsock,port=" + AGENT_VSOCK_PORT
+                        + ",socketURL=" + Environment.vmAgentSocket() + ",connect",
                 "--timesync", "vsockPort=" + GA_VSOCK_PORT,
                 "--restful-uri", "tcp://localhost:" + restPort
         ));
@@ -839,6 +842,7 @@ public final class VmManager {
                 + " isx.time=" + (System.currentTimeMillis() / 1000)
                 + " isx.ga_vsock=" + GA_VSOCK_PORT
                 + " isx.vsock_incus=" + INCUS_VSOCK_PORT
+                + " isx.agent_vsock=" + AGENT_VSOCK_PORT
                 + " isx.proxy=remote"
                 + " isx.shared=/host";
     }
@@ -900,6 +904,7 @@ public final class VmManager {
         try { Files.deleteIfExists(Environment.vmPidFile()); } catch (IOException ignored) {}
         try { Files.deleteIfExists(Environment.vmRestUriFile()); } catch (IOException ignored) {}
         try { Files.deleteIfExists(Environment.vmVsockSocket()); } catch (IOException ignored) {}
+        try { Files.deleteIfExists(Environment.vmAgentSocket()); } catch (IOException ignored) {}
     }
 
     private static String humanSize(long bytes) {

--- a/src/main/java/dev/incusspawn/vm/VmManager.java
+++ b/src/main/java/dev/incusspawn/vm/VmManager.java
@@ -356,7 +356,7 @@ public final class VmManager {
     // Above this many held vsock connections, the appliance's socat forwarder is
     // likely leaking streams (it does not reap connections whose close never
     // propagates across the vsock boundary), which degrades new-connection latency.
-    private static final int VSOCK_CONN_WARN_THRESHOLD = 64;
+    public static final int VSOCK_CONN_WARN_THRESHOLD = 64;
 
     /**
      * Count the host-side connections currently open on the vsock Unix socket
@@ -365,7 +365,7 @@ public final class VmManager {
      * forwarder leak. Returns -1 if the count can't be determined (non-macOS, no
      * socket, or lsof unavailable).
      */
-    private static int vsockForwarderConnectionCount() {
+    public static int vsockForwarderConnectionCount() {
         var sock = Environment.vmVsockSocket();
         if (!Environment.isMacOS() || !Files.exists(sock)) return -1;
         try {

--- a/src/main/java/dev/incusspawn/vm/VmManager.java
+++ b/src/main/java/dev/incusspawn/vm/VmManager.java
@@ -371,19 +371,21 @@ public final class VmManager {
         if (!Environment.isMacOS() || !Files.exists(sock)) return -1;
         try {
             var pb = new ProcessBuilder("lsof", "-nP", "-U");
-            pb.redirectErrorStream(false);
+            pb.redirectErrorStream(true);
             var proc = pb.start();
-            int count;
-            try (var r = new java.io.BufferedReader(
-                    new java.io.InputStreamReader(proc.getInputStream()))) {
-                count = (int) r.lines().filter(l -> l.contains(sock.toString())).count();
-            }
-            if (!proc.waitFor(3, java.util.concurrent.TimeUnit.SECONDS)) {
+            var future = java.util.concurrent.CompletableFuture.supplyAsync(() -> {
+                try (var r = new java.io.BufferedReader(
+                        new java.io.InputStreamReader(proc.getInputStream()))) {
+                    return (int) r.lines().filter(l -> l.contains(sock.toString())).count();
+                } catch (IOException e) { return -1; }
+            });
+            if (!proc.waitFor(5, java.util.concurrent.TimeUnit.SECONDS)) {
                 proc.destroyForcibly();
                 return -1;
             }
-            return count;
-        } catch (IOException | InterruptedException e) {
+            return future.get(1, java.util.concurrent.TimeUnit.SECONDS);
+        } catch (IOException | InterruptedException | java.util.concurrent.ExecutionException
+                 | java.util.concurrent.TimeoutException e) {
             if (e instanceof InterruptedException) Thread.currentThread().interrupt();
             return -1;
         }

--- a/src/test/java/dev/incusspawn/command/DoctorCommandTest.java
+++ b/src/test/java/dev/incusspawn/command/DoctorCommandTest.java
@@ -31,4 +31,18 @@ class DoctorCommandTest {
         assertTrue(f.label().contains(String.valueOf(VmManager.VSOCK_CONN_WARN_THRESHOLD + 1)),
                 "label should report the actual count");
     }
+
+    @Test
+    void leakLayerLocatesVfkitWhenGuestCountStaysLow() {
+        // Host fds high but few in-guest socat children → vfkit isn't reaping (link 2).
+        assertEquals(DoctorCommand.LeakLayer.VFKIT, DoctorCommand.leakLayer(300, 5));
+        assertEquals(DoctorCommand.LeakLayer.VFKIT, DoctorCommand.leakLayer(100, 50), "boundary: guest*2 == host");
+    }
+
+    @Test
+    void leakLayerLocatesForwarderWhenBothCountsClimb() {
+        // Host and in-guest counts climb together → forwarder lingering children (link 3).
+        assertEquals(DoctorCommand.LeakLayer.FORWARDER, DoctorCommand.leakLayer(300, 280));
+        assertEquals(DoctorCommand.LeakLayer.FORWARDER, DoctorCommand.leakLayer(100, 51));
+    }
 }

--- a/src/test/java/dev/incusspawn/command/DoctorCommandTest.java
+++ b/src/test/java/dev/incusspawn/command/DoctorCommandTest.java
@@ -1,0 +1,34 @@
+package dev.incusspawn.command;
+
+import dev.incusspawn.vm.VmManager;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class DoctorCommandTest {
+
+    @Test
+    void unmeasurableCountIsOkAndOffersNoFix() {
+        var f = DoctorCommand.forwarderFinding(-1);
+        assertEquals(DoctorCommand.Status.OK, f.status());
+        assertNull(f.remediation());
+    }
+
+    @Test
+    void countAtOrBelowThresholdIsOk() {
+        assertEquals(DoctorCommand.Status.OK, DoctorCommand.forwarderFinding(1).status());
+        assertEquals(DoctorCommand.Status.OK,
+                DoctorCommand.forwarderFinding(VmManager.VSOCK_CONN_WARN_THRESHOLD).status(),
+                "exactly at threshold must not warn");
+    }
+
+    @Test
+    void countAboveThresholdWarnsWithDestructiveRemediation() {
+        var f = DoctorCommand.forwarderFinding(VmManager.VSOCK_CONN_WARN_THRESHOLD + 1);
+        assertEquals(DoctorCommand.Status.WARN, f.status());
+        assertNotNull(f.remediation(), "a leak must offer a remediation");
+        assertTrue(f.remediation().destructive(), "VM restart is disruptive and must be flagged");
+        assertTrue(f.label().contains(String.valueOf(VmManager.VSOCK_CONN_WARN_THRESHOLD + 1)),
+                "label should report the actual count");
+    }
+}

--- a/src/test/java/dev/incusspawn/incus/ExecStreamLiveTest.java
+++ b/src/test/java/dev/incusspawn/incus/ExecStreamLiveTest.java
@@ -33,32 +33,24 @@ class ExecStreamLiveTest {
 
     @BeforeAll
     static void connect() {
+        // Opt-in only: requires an explicitly-named throwaway container. We deliberately do
+        // NOT auto-discover a running container — a plain `mvn test` must never exec into a
+        // user's real instance (or add a 90s idle test to every CI run).
+        container = System.getProperty("isx.test.container");
+        if (container == null || container.isBlank()) {
+            System.out.println("Skipping exec stream live tests: set -Disx.test.container=<throwaway> to run.");
+            return;
+        }
         http = IncusApi.tryConnect();
         if (http == null) {
             System.out.println("Skipping exec stream live tests: Incus not reachable.");
             return;
-        }
-        container = System.getProperty("isx.test.container");
-        if (container == null || container.isBlank()) {
-            container = firstRunningContainer();
         }
         System.out.println("ExecStreamLiveTest target container: " + container);
     }
 
     private static boolean skip() {
         return http == null || container == null;
-    }
-
-    private static String firstRunningContainer() {
-        var resp = http.get("/1.0/instances?recursion=2");
-        if (!resp.isSuccess()) return null;
-        for (var inst : resp.body().path("metadata")) {
-            if ("Running".equalsIgnoreCase(inst.path("status").asText())
-                    && "container".equalsIgnoreCase(inst.path("type").asText())) {
-                return inst.path("name").asText();
-            }
-        }
-        return null;
     }
 
     @Test

--- a/src/test/java/dev/incusspawn/incus/ExecStreamLiveTest.java
+++ b/src/test/java/dev/incusspawn/incus/ExecStreamLiveTest.java
@@ -1,0 +1,147 @@
+package dev.incusspawn.incus;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Live validation of the unified /wait-driven exec ({@link IncusApi#execWebSocket}) against
+ * a real container over the macOS vsock tunnel. Exercises the streaming paths the unit tests
+ * can't: high-throughput output, a long idle stream (keepalive must hold the data fds open),
+ * and bidirectional stdin/stdout.
+ *
+ * Skipped automatically when Incus is unreachable. Target a specific container with
+ *   -Disx.test.container=isx-validate-exec
+ * otherwise the first Running container is used.
+ *
+ *   mvn test -Dtest=ExecStreamLiveTest -Disx.test.container=isx-validate-exec
+ */
+class ExecStreamLiveTest {
+
+    private static IncusApi http;
+    private static String container;
+
+    @BeforeAll
+    static void connect() {
+        http = IncusApi.tryConnect();
+        if (http == null) {
+            System.out.println("Skipping exec stream live tests: Incus not reachable.");
+            return;
+        }
+        container = System.getProperty("isx.test.container");
+        if (container == null || container.isBlank()) {
+            container = firstRunningContainer();
+        }
+        System.out.println("ExecStreamLiveTest target container: " + container);
+    }
+
+    private static boolean skip() {
+        return http == null || container == null;
+    }
+
+    private static String firstRunningContainer() {
+        var resp = http.get("/1.0/instances?recursion=2");
+        if (!resp.isSuccess()) return null;
+        for (var inst : resp.body().path("metadata")) {
+            if ("Running".equalsIgnoreCase(inst.path("status").asText())
+                    && "container".equalsIgnoreCase(inst.path("type").asText())) {
+                return inst.path("name").asText();
+            }
+        }
+        return null;
+    }
+
+    @Test
+    @Timeout(30)
+    void captureReturnsOutputAndExitCode() {
+        if (skip()) return;
+        var r = http.execCapture(container, List.of("sh", "-c", "echo hello-capture; exit 0"),
+                0, 0, null, Map.of());
+        assertEquals(0, r.exitCode());
+        assertTrue(r.stdout().contains("hello-capture"), "stdout was: " + r.stdout());
+
+        var fail = http.execCapture(container, List.of("sh", "-c", "exit 7"), 0, 0, null, Map.of());
+        assertEquals(7, fail.exitCode(), "exit code must propagate through /wait");
+    }
+
+    /** High-activity stream: many lines must all arrive, in order, with no truncation. */
+    @Test
+    @Timeout(120)
+    void streamHighActivityIsCompleteAndOrdered() {
+        if (skip()) return;
+        int n = 200_000;
+        var counter = new CountingStream();
+        int exit = http.execStream(container,
+                List.of("sh", "-c", "i=0; while [ $i -lt " + n + " ]; do echo line$i; i=$((i+1)); done"),
+                0, 0, null, Map.of(), counter, OutputStream.nullOutputStream());
+        assertEquals(0, exit);
+        assertEquals(n, counter.lines.get(),
+                "expected " + n + " lines, got " + counter.lines.get() + " (truncation?)");
+        // Spot-check ordering/integrity: first and last lines present and correctly framed.
+        assertTrue(counter.text().startsWith("line0\n"), "first line wrong");
+        assertTrue(counter.text().endsWith("line" + (n - 1) + "\n"), "last line wrong/truncated");
+    }
+
+    /**
+     * Long idle stream: the command produces nothing for well over the keepalive interval,
+     * then emits a marker. The data fd must stay open (keepalive) and the final output must
+     * not be lost or the exit code misread.
+     */
+    @Test
+    @Timeout(150)
+    void streamLongIdleThenOutputSurvives() {
+        if (skip()) return;
+        var out = new ByteArrayOutputStream();
+        long t0 = System.currentTimeMillis();
+        int exit = http.execStream(container,
+                List.of("sh", "-c", "sleep 90; echo AFTER_IDLE_MARKER"),
+                0, 0, null, Map.of(), out, OutputStream.nullOutputStream());
+        long elapsed = (System.currentTimeMillis() - t0) / 1000;
+        assertEquals(0, exit, "exit code after long idle");
+        assertTrue(out.toString(StandardCharsets.UTF_8).contains("AFTER_IDLE_MARKER"),
+                "marker lost after " + elapsed + "s idle; got: " + out);
+        assertTrue(elapsed >= 88, "command returned too early (" + elapsed + "s) — premature close?");
+    }
+
+    /** Bidirectional: bytes written to stdin must echo back through stdout. */
+    @Test
+    @Timeout(30)
+    void bidirectionalEchoesStdin() {
+        if (skip()) return;
+        var stdin = new ByteArrayInputStream("ping-bidir\n".getBytes(StandardCharsets.UTF_8));
+        var out = new ByteArrayOutputStream();
+        int exit = http.execBidirectional(container, List.of("cat"),
+                0, 0, null, Map.of(), stdin, out, OutputStream.nullOutputStream());
+        assertEquals(0, exit);
+        assertTrue(out.toString(StandardCharsets.UTF_8).contains("ping-bidir"),
+                "stdin not echoed through bidirectional exec; got: " + out);
+    }
+
+    /** OutputStream that counts newlines and keeps the bytes for spot-checks. */
+    private static final class CountingStream extends OutputStream {
+        final AtomicLong lines = new AtomicLong();
+        private final ByteArrayOutputStream buf = new ByteArrayOutputStream();
+
+        @Override public void write(int b) {
+            if (b == '\n') lines.incrementAndGet();
+            buf.write(b);
+        }
+
+        @Override public void write(byte[] b, int off, int len) {
+            for (int i = off; i < off + len; i++) if (b[i] == '\n') lines.incrementAndGet();
+            buf.write(b, off, len);
+        }
+
+        String text() { return buf.toString(StandardCharsets.UTF_8); }
+    }
+}

--- a/src/test/java/dev/incusspawn/incus/ExecStreamLiveTest.java
+++ b/src/test/java/dev/incusspawn/incus/ExecStreamLiveTest.java
@@ -20,9 +20,8 @@ import static org.junit.jupiter.api.Assertions.*;
  * can't: high-throughput output, a long idle stream (keepalive must hold the data fds open),
  * and bidirectional stdin/stdout.
  *
- * Skipped automatically when Incus is unreachable. Target a specific container with
- *   -Disx.test.container=isx-validate-exec
- * otherwise the first Running container is used.
+ * Opt-in only: requires {@code -Disx.test.container=<name>} naming an explicitly
+ * chosen throwaway container. A plain {@code mvn test} never runs these tests.
  *
  *   mvn test -Dtest=ExecStreamLiveTest -Disx.test.container=isx-validate-exec
  */

--- a/src/test/java/dev/incusspawn/vm/VmAgentClientTest.java
+++ b/src/test/java/dev/incusspawn/vm/VmAgentClientTest.java
@@ -40,8 +40,9 @@ class VmAgentClientTest {
     }
 
     @AfterEach
-    void stop() throws IOException {
+    void stop() throws IOException, InterruptedException {
         try { server.close(); } catch (IOException ignored) {}
+        serverThread.join(2000);
         Files.deleteIfExists(sock);
         Files.deleteIfExists(dir);
     }

--- a/src/test/java/dev/incusspawn/vm/VmAgentClientTest.java
+++ b/src/test/java/dev/incusspawn/vm/VmAgentClientTest.java
@@ -1,0 +1,101 @@
+package dev.incusspawn.vm;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.StandardProtocolFamily;
+import java.net.UnixDomainSocketAddress;
+import java.nio.channels.Channels;
+import java.nio.channels.ServerSocketChannel;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Validates the VmAgentClient one-verb-per-connection protocol against a fake agent socket
+ * that mimics the in-VM isx-agent dispatch — no VM required.
+ */
+class VmAgentClientTest {
+
+    private Path dir;
+    private Path sock;
+    private ServerSocketChannel server;
+    private Thread serverThread;
+    private final AtomicReference<String> lastVerb = new AtomicReference<>();
+
+    @BeforeEach
+    void startFakeAgent() throws IOException {
+        dir = Files.createTempDirectory("isxagt");
+        sock = dir.resolve("a.sock"); // keep path short (macOS sun_path limit)
+        server = ServerSocketChannel.open(StandardProtocolFamily.UNIX);
+        server.bind(UnixDomainSocketAddress.of(sock.toString()));
+        serverThread = Thread.ofVirtual().start(this::serve);
+    }
+
+    @AfterEach
+    void stop() throws IOException {
+        try { server.close(); } catch (IOException ignored) {}
+        Files.deleteIfExists(sock);
+        Files.deleteIfExists(dir);
+    }
+
+    private void serve() {
+        while (server.isOpen()) {
+            try (var conn = server.accept()) {
+                var in = Channels.newInputStream(conn);
+                var verb = readLine(in);
+                lastVerb.set(verb);
+                var resp = switch (verb) {
+                    case "ping" -> "ok";
+                    case "socat-count" -> "5";
+                    case "forwarder-restart" -> "restarted";
+                    default -> "error: unknown verb";
+                };
+                conn.write(java.nio.ByteBuffer.wrap((resp + "\n").getBytes(StandardCharsets.UTF_8)));
+            } catch (IOException e) {
+                return; // server closed
+            }
+        }
+    }
+
+    private static String readLine(InputStream in) throws IOException {
+        var sb = new StringBuilder();
+        int c;
+        while ((c = in.read()) != -1 && c != '\n') sb.append((char) c);
+        return sb.toString();
+    }
+
+    @Test
+    @Timeout(10)
+    void pingRoundTrips() {
+        assertTrue(VmAgentClient.send(sock, "ping").isPresent());
+        assertTrue(VmAgentClient.send(sock, "ping").map("ok"::equals).orElse(false));
+        assertEquals("ping", lastVerb.get());
+    }
+
+    @Test
+    @Timeout(10)
+    void socatCountParsesNumber() {
+        var n = VmAgentClient.send(sock, "socat-count");
+        assertEquals("5", n.orElse(null));
+    }
+
+    @Test
+    @Timeout(10)
+    void unknownVerbGetsError() {
+        assertEquals("error: unknown verb", VmAgentClient.send(sock, "bogus").orElse(null));
+    }
+
+    @Test
+    @Timeout(10)
+    void missingSocketReturnsEmpty() {
+        assertTrue(VmAgentClient.send(dir.resolve("nope.sock"), "ping").isEmpty());
+    }
+}


### PR DESCRIPTION
## Summary

This started as an investigation into a macOS user's report that operations "hang quite often" (issue #286, superseding the record-output workaround in #301). Tracing it end to end pointed at a **single root cause** — **close/EOF does not propagate reliably across the vfkit vsock boundary** — which manifests in two directions:

- **Read side** → non-interactive exec hangs waiting for a WebSocket close frame that never arrives.
- **Teardown side** → the in-VM `socat` forwarder never reaps connections whose close didn't propagate, so they pile up in vfkit's fd table and degrade every new connection.

Both are fixed here, plus the tooling to observe and recover from the leak. All changes are macOS/vsock-focused and no-ops on Linux (native Unix socket).

## Root cause, concretely

On macOS the CLI reaches Incus over `host unix socket → vfkit virtio-vsock → in-guest socat → /var/lib/incus/unix.socket`. When a connection's close doesn't cross that boundary:

- Exec completion was being derived from the data-fd close frame, so `readPayload()` blocked forever. Prior fixes (control-fd watcher, #298) still keyed off a close frame on the *same* unreliable channel, so they didn't hold.
- On the live VM we measured **375 leaked connections held by vfkit**, with `list` latency degraded to **~31s**; a VM restart dropped it to **1 connection / 0.6s**. Clean HTTP requests reap fine — the leak is specifically the no-EOF / aborted-exec connections plus the post-sleep vfkit wedge.

## What changed

### 1. Exec independent of close-frame delivery (`32fb44f`)
Unified capture/stream/bidirectional exec through one `execWebSocket` that takes the **operation `/wait` endpoint** (daemon operation state, over HTTP) as the authoritative completion + exit-code signal, then drains and force-closes the data sockets so reader threads always unblock. `waitForExecOp` loops until the operation truly finishes so long commands aren't truncated. Keepalive pings now ride **every** exec fd (not just control), since each fd is a separate forwarder child that an inactivity reaper could otherwise collect mid-command.

### 2. Reduce & observe vsock connection consumption (`0c50009`)
- Per-process open/peak connection counters in `UnixSocketTransport`, plus a process-independent **`vsock forwarder connections: N`** line in `isx vm status` (counts what vfkit holds; warns past a threshold) — the gauge that surfaces a leak no single short-lived CLI can see in its own counter.
- `pollUntilReady` backs off `100ms → 1s` instead of a flat 200ms, cutting readiness-probe connections several-fold for the same wait budget.
- `waitUntilReady` is now wall-clock-deadline-bounded (a count-based loop silently overran ~6× when probes stalled), and the reachability probe timeout is tightened 5s → 3s.
- A fail-open, per-process semaphore caps a single runaway invocation (explicitly *not* an aggregate limit — that requires forwarder-side reaping).

### 3. Forwarder inactivity backstop (`fdb547d`)
`socat` gains `-T 180` so a connection whose close never propagates is reaped instead of pinning a vfkit fd forever. The 180s floor is deliberate: the `/wait` long-poll legitimately carries no traffic for up to 120s (client watchdog 150s), and live exec fds are keepalived (~15s), so `-T` sits safely above them.

### 4. `isx doctor` (`a4e5c74`)
A single top-level health command (checks: VM running, Incus reachable + latency, forwarder connection count) with a grouped pass/warn/fail report and interactive remediation (prompts on a TTY, prints the suggested fix otherwise). Fine-grained diagnostics/recovery live here as checks rather than as separate top-level commands.

### 5. In-VM control agent + no-reboot recovery (`a2c5ace`, `7005635`, `75edade`)
Because Incus has no native vsock API listener (verified: `core.https_address` is HTTPS-only), the forwarder stays — so we added a way to introspect and recover it. A small **allowlisted** agent (`isx-agent`) listens on a dedicated vsock port (a second vfkit `virtio-vsock` device, host-side `vm.agent.sock`), one verb per connection, fixed allowlist only — **no arbitrary guest-exec**: `ping`, `socat-count`, `sshd-status`, `forwarder-restart`.

- `forwarder-restart` drops the leaked forwarder children (freeing the vfkit-pinned host fds) and relaunches — recovering a wedged tunnel **without rebooting the VM or stopping containers**. It's hardened with `setsid` + fd-redirect so the relaunched forwarder can't inherit the connection's fds or process group, and the agent's own listener has `-T 30`.
- `doctor` now enriches the forwarder check with the **in-guest socat count**; comparing it to the host-side count locates whether streams leak at vfkit (link 2) or the forwarder (link 3), and prefers the no-reboot agent recovery, falling back to a VM restart when the agent is absent (older images degrade gracefully).
- `VmAgentClient` speaks the one-verb protocol (unit-tested against a fake socket).

### 6. Test-safety fix (`b4f72fb`)
`ExecStreamLiveTest` is now strictly opt-in (`-Disx.test.container`); it previously auto-discovered a running container, so a plain `mvn test` would exec into a real instance.

## Validation

- **Unit:** 649 tests pass. New: `DoctorCommandTest`, `VmAgentClientTest`.
- **Live (real vsock):** `ExecStreamLiveTest` — capture, high-activity streaming (200k lines, no truncation/reorder), long-idle streaming (90s silent then marker survives), bidirectional echo, forwarder gauge flat throughout.
- **Recovery, live:** rebuilt the appliance, deployed, and ran **5 back-to-back `forwarder-restart`s** — agent-socket fd count flat each time, tunnel healthy, VM **not** rebooted, running container untouched.
- **Boot test:** `test-boot.sh` extended from 15 → **19 checks**, now asserting the agent answers, the no-reboot recovery restores the tunnel, and the agent survives recovery.

## Follow-ups (filed)

- #308 doctor: proxy + DNS checks
- #309 doctor: shell completion
- #310 doctor: localize the leak (host vs in-guest count) instead of just reporting both
- #311 agent: evaluate a static binary vs the shell script

## Notes for the reviewer

- Everything is macOS/vsock-specific; the Linux native-socket path is unchanged.
- The exec fix's remaining external confirmation is the original reporter's M4 hardware, which we could not reproduce on our M2 — but the fix is architecturally independent of the close-frame delivery that fails there.
- Link-2-vs-3 couldn't be force-tested because clean requests reap on a healthy VM; the `doctor` diagnostic is in place for the next real (e.g. post-sleep) leak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes https://github.com/Sanne/incus-spawn/issues/286
