### PR TITLE
site: point canonical and og:url at https://isx.run

### DIFF
--- a/site/docs.html
+++ b/site/docs.html
@@ -8,8 +8,8 @@
   <meta property="og:title" content="isx documentation">
   <meta property="og:description" content="Full documentation for isx — isolated Linux workstations with CoW branching and transparent credential isolation.">
   <meta property="og:type" content="website">
-  <meta property="og:url" content="https://sanne.github.io/incus-spawn/docs.html">
-  <link rel="canonical" href="https://sanne.github.io/incus-spawn/docs.html">
+  <meta property="og:url" content="https://isx.run/docs.html">
+  <link rel="canonical" href="https://isx.run/docs.html">
   <link rel="stylesheet" href="style.css">
 </head>
 <body>

--- a/site/index.html
+++ b/site/index.html
@@ -8,9 +8,9 @@
   <meta property="og:title" content="isx">
   <meta property="og:description" content="Give your AI coding agents their own machines — not your credentials. Isolated Linux workstations with CoW branching and transparent credential isolation.">
   <meta property="og:type" content="website">
-  <meta property="og:url" content="https://sanne.github.io/incus-spawn/">
+  <meta property="og:url" content="https://isx.run/">
   <meta name="twitter:card" content="summary_large_image">
-  <link rel="canonical" href="https://sanne.github.io/incus-spawn/">
+  <link rel="canonical" href="https://isx.run/">
   <link rel="stylesheet" href="style.css">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
Follow-up to #324: now that isx.run fronts the site, the canonical and og:url tags on the landing page and docs template should point there instead of sanne.github.io. GitHub Pages will redirect the old URLs once the custom domain is active.

🤖 Generated with [Claude Code](https://claude.com/claude-code)