### PR TITLE
Allocate a PTY for repo priming

### DIFF
--- a/src/main/java/dev/incusspawn/command/BuildCommand.java
+++ b/src/main/java/dev/incusspawn/command/BuildCommand.java
@@ -1825,7 +1825,7 @@ public class BuildCommand extends BaseCommand {
             if (repo.getPrime() != null && !repo.getPrime().isBlank()) {
                 System.out.println("Priming " + repo.getPath() + "...");
                 var expanded = expandHome(repo.getPath());
-                container.runAsUser("agentuser",
+                container.runAsUserPty("agentuser",
                         "cd " + shellQuote(expanded) + " && " + repo.getPrime(),
                         "Failed to prime " + repo.getPath());
             }

--- a/src/main/java/dev/incusspawn/incus/Container.java
+++ b/src/main/java/dev/incusspawn/incus/Container.java
@@ -50,6 +50,14 @@ public class Container {
         }
     }
 
+    /** Like {@link #runAsUser} but with a PTY so isatty() returns true inside the container. */
+    public void runAsUserPty(String user, String script, String failureMessage) {
+        int exitCode = incus.shellExecInteractivePtyAsUser(name, user, script);
+        if (exitCode != 0) {
+            throw new IncusException(failureMessage + " (exit code " + exitCode + ")");
+        }
+    }
+
     /** Install packages via dnf. */
     public void dnfInstall(String failureMessage, String... packages) {
         var command = new String[packages.length + 3];

--- a/src/main/java/dev/incusspawn/incus/IncusApi.java
+++ b/src/main/java/dev/incusspawn/incus/IncusApi.java
@@ -483,9 +483,54 @@ class IncusApi {
     int execStream(String instance, List<String> command,
                    Integer uid, Integer gid, String cwd, Map<String, String> env,
                    OutputStream stdout, OutputStream stderr) {
+        return execStream(instance, command, uid, gid, cwd, env, stdout, stderr, false, 0, 0);
+    }
+
+    /**
+     * Non-interactive exec with optional PTY. When {@code pty} is false, stdout and stderr
+     * are streamed separately. When true, a pseudo-terminal is allocated (so isatty() returns
+     * true inside the container) and output is muxed into {@code stdout}; {@code stderr} is
+     * ignored. The host terminal is not switched to raw mode and stdin is not forwarded.
+     */
+    int execStream(String instance, List<String> command,
+                   Integer uid, Integer gid, String cwd, Map<String, String> env,
+                   OutputStream stdout, OutputStream stderr,
+                   boolean pty, int width, int height) {
         return retryOnNotRunning(() -> {
-            var exec = postExec(instance, command, uid, gid, cwd, env, false, 0, 0);
-            return execWebSocket(exec, stdout, stderr, null);
+            var exec = postExec(instance, command, uid, gid, cwd, env, pty, width, height);
+            if (!pty) {
+                return execWebSocket(exec, stdout, stderr, null);
+            }
+            var outDst = stdout != null ? stdout : OutputStream.nullOutputStream();
+            try (var controlWs = transport.openWebSocket(wsUrl(exec, "control"));
+                 var dataWs    = transport.openWebSocket(wsUrl(exec, "0"))) {
+
+                var keepalive    = startKeepalive(controlWs);
+                var dataAlive    = startKeepalive(dataWs);
+                var controlDrain = Thread.ofVirtual().start(() -> drainQuietly(controlWs));
+
+                var lastData = new java.util.concurrent.atomic.AtomicLong(System.nanoTime());
+                var dataThread = Thread.ofVirtual().start(() -> wsWriteTo(dataWs, outDst, lastData));
+
+                assertAllFdsConnected(exec.fds, Set.of("0", "control"));
+
+                int exitCode = waitForExecOp(exec.opPath);
+
+                dataAlive.interrupt();
+                awaitDrain(lastData, dataThread);
+                if (dataThread.isAlive()) {
+                    dataWs.close();
+                    joinQuietly(dataThread);
+                }
+
+                keepalive.interrupt();
+                controlWs.close();
+                joinQuietly(controlDrain);
+
+                return exitCode;
+            } catch (IOException e) {
+                throw new IncusException("Failed to open exec WebSocket", e);
+            }
         });
     }
 
@@ -788,18 +833,18 @@ class IncusApi {
     }
 
     /**
-     * Drain the data reader threads, then force-close their sockets. Returns immediately when
-     * the readers finish on their own (close frames arrived — the healthy path). Otherwise it
-     * waits a short minimum for bytes still in flight, extends while output is still arriving
-     * (so trailing output isn't truncated), and force-closes once output has been idle for
-     * {@link #DRAIN_IDLE_MS} — bounded by {@link #DRAIN_MAX_MS}.
+     * Wait for reader threads to finish on their own, extending while output is still arriving.
+     * Returns immediately on the healthy path (close frames arrived). Otherwise waits at least
+     * {@link #DRAIN_MIN_MS} for bytes in flight, extends while output keeps arriving, and
+     * returns once idle for {@link #DRAIN_IDLE_MS} — bounded by {@link #DRAIN_MAX_MS}.
      */
-    private static void drainThenClose(java.util.concurrent.atomic.AtomicLong lastData,
-                                       Thread stdoutThread, Thread stderrThread,
-                                       IncusTransport.WsConnection stdoutWs,
-                                       IncusTransport.WsConnection stderrWs) {
+    private static void awaitDrain(java.util.concurrent.atomic.AtomicLong lastData,
+                                   Thread... threads) {
         long start = System.nanoTime();
-        while (stdoutThread.isAlive() || stderrThread.isAlive()) {
+        while (true) {
+            boolean anyAlive = false;
+            for (var t : threads) if (t.isAlive()) { anyAlive = true; break; }
+            if (!anyAlive) break;
             long now = System.nanoTime();
             long sinceStartMs = (now - start) / 1_000_000L;
             long sinceDataMs  = (now - lastData.get()) / 1_000_000L;
@@ -812,6 +857,13 @@ class IncusApi {
                 break;
             }
         }
+    }
+
+    private static void drainThenClose(java.util.concurrent.atomic.AtomicLong lastData,
+                                       Thread stdoutThread, Thread stderrThread,
+                                       IncusTransport.WsConnection stdoutWs,
+                                       IncusTransport.WsConnection stderrWs) {
+        awaitDrain(lastData, stdoutThread, stderrThread);
         if (stdoutThread.isAlive() || stderrThread.isAlive()) {
             stdoutWs.close();
             stderrWs.close();

--- a/src/main/java/dev/incusspawn/incus/IncusClient.java
+++ b/src/main/java/dev/incusspawn/incus/IncusClient.java
@@ -141,6 +141,7 @@ public class IncusClient {
                 0, 0, null, Map.of(), System.out, System.err);
     }
 
+    /** Like {@link #shellExecInteractiveAsUser} but with a PTY so isatty() returns true. */
     public int shellExecInteractivePtyAsUser(String container, String user, String script) {
         var size = IncusApi.terminalSize();
         return http().execStream(container,

--- a/src/main/java/dev/incusspawn/incus/IncusClient.java
+++ b/src/main/java/dev/incusspawn/incus/IncusClient.java
@@ -141,6 +141,13 @@ public class IncusClient {
                 0, 0, null, Map.of(), System.out, System.err);
     }
 
+    public int shellExecInteractivePtyAsUser(String container, String user, String script) {
+        var size = IncusApi.terminalSize();
+        return http().execStream(container,
+                List.of("su", "-", user, "-c", LOGIN_PATH_PREFIX + script),
+                0, 0, null, Map.of(), System.out, null, true, size[0], size[1]);
+    }
+
     /**
      * Execute a command inside a container as a given user.
      * Uses 'su - user -c "joined cmd"' to replicate the original CLI behaviour,

--- a/src/test/java/dev/incusspawn/command/BuildCommandTest.java
+++ b/src/test/java/dev/incusspawn/command/BuildCommandTest.java
@@ -192,6 +192,7 @@ class BuildCommandTest {
 
         // git clone succeeds
         when(incus.shellExecInteractiveAsUser(eq("test"), anyString(), anyString())).thenReturn(0);
+        when(incus.shellExecInteractivePtyAsUser(eq("test"), anyString(), anyString())).thenReturn(0);
 
         var repo = new ImageDef.RepoEntry();
         repo.setUrl("https://github.com/quarkusio/quarkus.git");
@@ -209,7 +210,7 @@ class BuildCommandTest {
                 "git clone --single-branch -- 'https://github.com/quarkusio/quarkus.git' '/home/agentuser/quarkus'");
         verify(incus).shellExecInteractiveAsUser("test", "agentuser",
                 "git -C '/home/agentuser/quarkus' remote set-branches origin '*'");
-        verify(incus).shellExecInteractiveAsUser("test", "agentuser",
+        verify(incus).shellExecInteractivePtyAsUser("test", "agentuser",
                 "cd '/home/agentuser/quarkus' && mvn -B dependency:go-offline");
     }
 


### PR DESCRIPTION
## Summary

- Add a PTY option to `execStream` so priming commands (`repos[].prime`) run with a pseudo-terminal allocated. Tools like `mvnd` detect `isatty()` and switch to their compact "refresh current lines" output instead of verbose line-by-line mode.
- Extract the drain-wait loop into `awaitDrain()` so both the two-fd (non-PTY) and single-fd (PTY) paths share it.
- Only priming is affected; all other build commands remain non-interactive.

## Test plan

- [x] `mvn test` — all 655 unit tests pass
- [x] Manual: built a template with a `prime:` command and confirmed interactive output formatting