### PR TITLE
Fix interactive PTY exec hanging at end of repo priming

### DIFF
--- a/src/main/java/dev/incusspawn/incus/IncusApi.java
+++ b/src/main/java/dev/incusspawn/incus/IncusApi.java
@@ -505,28 +505,40 @@ class IncusApi {
             try (var controlWs = transport.openWebSocket(wsUrl(exec, "control"));
                  var dataWs    = transport.openWebSocket(wsUrl(exec, "0"))) {
 
-                var keepalive    = startKeepalive(controlWs);
-                var dataAlive    = startKeepalive(dataWs);
-                var controlDrain = Thread.ofVirtual().start(() -> drainQuietly(controlWs));
+                var keepalive = startKeepalive(controlWs);
+                var dataAlive = startKeepalive(dataWs);
 
                 var lastData = new java.util.concurrent.atomic.AtomicLong(System.nanoTime());
                 var dataThread = Thread.ofVirtual().start(() -> wsWriteTo(dataWs, outDst, lastData));
 
                 assertAllFdsConnected(exec.fds, Set.of("0", "control"));
 
-                int exitCode = waitForExecOp(exec.opPath);
-
-                dataAlive.interrupt();
-                awaitDrain(lastData, dataThread);
-                if (dataThread.isAlive()) {
-                    dataWs.close();
+                // Completion for an INTERACTIVE op cannot be taken from waitForExecOp the way the
+                // non-interactive execWebSocket does: the daemon does not finalize an interactive
+                // operation until the fd "0" websocket is torn down, and over the vfkit vsock the
+                // daemon's fd "0" close frame is not reliably delivered. Gating the teardown on
+                // op-finalization (as execWebSocket does) therefore deadlocks — the client waits
+                // for the op to finish while the daemon waits for the client to close fd "0".
+                //
+                // So a watcher thread detects process exit from the control fd closing (the daemon
+                // closes control when the process exits — the same signal execPty relies on), then
+                // drains and force-closes fd "0" locally so the daemon can finalize. The main
+                // thread meanwhile blocks in waitForExecOp, which returns the authoritative exit
+                // code once the daemon finalizes. Keeping waitForExecOp on the main thread
+                // preserves its MAX_EXEC_WAIT_SECONDS ceiling as a hard backstop: if the control
+                // close is itself lost, the watcher parks in drainQuietly but the main thread
+                // still gives up after the ceiling (returning -1 with a warning) rather than
+                // hanging forever.
+                var teardown = Thread.ofVirtual().start(() -> {
+                    drainQuietly(controlWs);          // blocks until the daemon closes control (process exited)
+                    dataAlive.interrupt();
+                    awaitDrain(lastData, dataThread);
+                    dataWs.close();                   // force-close fd "0" so the daemon can finalize the op
                     joinQuietly(dataThread);
-                }
+                });
 
+                int exitCode = waitForExecOp(exec.opPath);
                 keepalive.interrupt();
-                controlWs.close();
-                joinQuietly(controlDrain);
-
                 return exitCode;
             } catch (IOException e) {
                 throw new IncusException("Failed to open exec WebSocket", e);


### PR DESCRIPTION
## Symptom

Rebuilding a template hangs at the **end** of the repo-*prime* step. Observed live while priming the `incus-spawn` repo: the prime command

```
su - agentuser -c "... cd '/home/agentuser/incus-spawn' && mvn -B dependency:resolve"
```

had **already finished** â no `mvn`/`java`/`su` process was left alive in the container â yet the Incus exec operation was still `Running`, and the host `isx` main thread was blocked in `read()`, looping on `GET /1.0/operations/<id>/wait`. It would have stayed there up to `MAX_EXEC_WAIT_SECONDS` (4 hours).

## Root cause

[#328](https://github.com/Sanne/incus-spawn/pull/328) switched `repos[].prime` commands to **interactive PTY exec** (`execStream(â¦ pty=true)`) so tools like `mvnd` see `isatty()` and print compact output. That change is the trigger.

The two exec paths finalize differently on the daemon:

- **Non-interactive** (`execWebSocket`): Incus finalizes the operation on **process exit**, independent of the stdout/stderr sockets. So `/wait` is a reliable, authoritative completion signal, and the client force-closes the data sockets *afterwards*. A lost close frame can't hang it. This is the documented design.
- **Interactive** (PTY): the daemon does **not** finalize the operation until the fd `"0"` websocket is torn down. And over the vfkit vsock, the daemon's fd `"0"` close frame is exactly the kind of close/EOF that is **not reliably propagated** (the same weakness that drives `/wait`-based completion, the socat `-T` backstop, and `isx doctor`'s forwarder recovery).

The PTY branch of `execStream` reused the **non-interactive ordering** â `waitForExecOp(...)` first, then tear down fd `"0"`:

```java
int exitCode = waitForExecOp(exec.opPath);   // waits for op to finalizeâ¦
dataAlive.interrupt();
awaitDrain(...);
dataWs.close();                              // â¦only then closes fd "0"
```

That is a mutual wait:

- the **client** won't close fd `"0"` until the operation finalizes, and
- the **daemon** won't finalize the operation until fd `"0"` is closed.

â deadlock, until the 4h ceiling. Confirmed on a live host: killing the client did **not** immediately reap the operation (the close still didn't reach `incusd`); it cleared only once the forwarder inactivity backstop caught up.

Note the pre-existing interactive shell path, `execPty`, does **not** have this bug: it keys completion off the **control fd closing** (the daemon closes control when the process exits) and then force-closes fd `"0"` locally. It never calls `waitForExecOp`. The `execStream` PTY branch simply didn't follow that pattern.

## Fix

Make the PTY branch of `execStream` complete the way `execPty` does:

1. Detect process exit from the **control fd closing** (`drainQuietly(controlWs)` blocks until the daemon closes control).
2. Then interrupt keepalives, drain in-flight output, and **force-close fd `"0"`** locally â this is what lets the daemon finalize the operation, and it doesn't depend on the daemon's fd `"0"` close frame arriving.
3. **Only then** call `waitForExecOp` to read the exit code â which now returns promptly, and remains the authoritative exit-code source.

Output is not truncated: the existing adaptive `awaitDrain` still waits for bytes in flight after control closes (the daemon flushes remaining PTY output before/around closing control), extending while output keeps arriving.

Only the interactive (`pty=true`) branch changes; `execWebSocket` (all non-interactive exec) and `execPty` (interactive shells) are untouched.

## Testing

- [x] `./mvnw -o test` — 677 unit tests pass (this path can't be unit-tested: it needs a live daemon + PTY over the vsock).
- [x] **End-to-end (macOS, 2026-07-02):** rebuilt `tpl-incus-spawn` with a jar built from this branch. The prime step ran `mvn -B dependency:resolve` to `BUILD SUCCESS` and the build then proceeded past it (cloned templates/images repos, cleaned caches, stopped the image) to `Image tpl-incus-spawn built successfully.` — process exited cleanly, no stuck operation. This reproduces the exact scenario that previously hung indefinitely at the end of prime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)