### PR TITLE
Set JAVA_TOOL_OPTIONS to use system trust store in containers

### DIFF
--- a/src/main/java/dev/incusspawn/command/BuildCommand.java
+++ b/src/main/java/dev/incusspawn/command/BuildCommand.java
@@ -723,6 +723,7 @@ public class BuildCommand extends BaseCommand {
                 .assertSuccess("Failed to install MITM CA certificate");
         container.exec("update-ca-trust")
                 .assertSuccess("Failed to update CA trust");
+        CertificateAuthority.setJavaTrustStoreOverride(incus, buildName);
 
         // UID mapping for Wayland passthrough, nested containers, and no dropped
         // capabilities since the container itself is the security boundary.

--- a/src/main/java/dev/incusspawn/proxy/CertificateAuthority.java
+++ b/src/main/java/dev/incusspawn/proxy/CertificateAuthority.java
@@ -152,6 +152,17 @@ public class CertificateAuthority {
     }
 
     /**
+     * Set JAVA_TOOL_OPTIONS in /etc/environment so all JVMs use the system trust store.
+     * Non-RPM JDKs (e.g. SDKMAN) bundle their own cacerts that won't include the MITM CA;
+     * this override makes them use the system-managed keystore instead.
+     */
+    public static void setJavaTrustStoreOverride(IncusClient incus, String container) {
+        incus.shellExec(container, "sh", "-c",
+                "grep -q 'javax.net.ssl.trustStore' /etc/environment 2>/dev/null || " +
+                "echo 'JAVA_TOOL_OPTIONS=\"-Djavax.net.ssl.trustStore=/etc/pki/java/cacerts\"' >> /etc/environment");
+    }
+
+    /**
      * Check whether a container's stored CA fingerprint matches the current CA.
      * If mismatched, push the current cert into the container and update metadata.
      * Returns true if a fix was applied, false if no action was needed.
@@ -168,6 +179,7 @@ public class CertificateAuthority {
                 ca.caCertPem() +
                 "CERTEOF");
         incus.shellExec(container, "update-ca-trust");
+        setJavaTrustStoreOverride(incus, container);
         incus.configSet(container, Metadata.CA_FINGERPRINT, ca.caFingerprint());
         return true;
     }


### PR DESCRIPTION
## Summary

- Adds `setJavaTrustStoreOverride()` to `CertificateAuthority` that writes `JAVA_TOOL_OPTIONS="-Djavax.net.ssl.trustStore=/etc/pki/java/cacerts"` to `/etc/environment`
- Called during image build (after `update-ca-trust`) and on CA rotation (`fixContainerCaIfNeeded`)
- Non-RPM JDKs (e.g. SDKMAN-installed) bundle their own `cacerts` keystore that doesn't include the MITM proxy CA cert, causing `SSLHandshakeException` for HTTPS connections through the proxy
- Pointing `javax.net.ssl.trustStore` to the system-managed keystore fixes this for all JVMs regardless of install method

## Tradeoff

Every JVM invocation will print `Picked up JAVA_TOOL_OPTIONS: ...` to stderr. This is cosmetic and cannot be suppressed (by design in the JVM spec).

## Test plan

- [ ] Build a container image with MITM proxy enabled
- [ ] Verify `/etc/environment` contains the `JAVA_TOOL_OPTIONS` line
- [ ] Install a JDK via SDKMAN and verify HTTPS works through the proxy
- [ ] Rotate the CA cert and verify `fixContainerCaIfNeeded` also sets the env var