### PR TITLE
Proactively restart the wedged vsock forwarder instead of just waiting

### DIFF
--- a/src/main/java/dev/incusspawn/vm/VmManager.java
+++ b/src/main/java/dev/incusspawn/vm/VmManager.java
@@ -405,6 +405,39 @@ public final class VmManager {
         return false;
     }
 
+    // Recovery budget for a VM that is up but whose Incus tunnel is unreachable.
+    private static final int REACHABILITY_GRACE_SECONDS = 10;
+    private static final int FORWARDER_RECOVERY_WAIT_SECONDS = 15;
+    private static final int REACHABILITY_BACKSTOP_SECONDS = 30;
+
+    /**
+     * Recover reachability when the VM is running but the Incus tunnel is not answering.
+     *
+     * Almost always this means the vsock forwarder is wedged with leaked socat fork-children:
+     * the vfkit boundary does not reliably propagate connection close, so children pin host-side
+     * fds and degrade new-connection latency until the forwarder's own {@code socat -T 180}
+     * inactivity backstop reaps them. Rather than block a command for up to that 180 s, we give a
+     * brief transient a chance to clear, then proactively restart the forwarder via the control
+     * agent — an independent vsock port that answers even when the Incus tunnel is wedged, so
+     * recovery is ~1 s. Restarting only drops connections that are already stalled (nothing is
+     * getting through, or we would not be here), so it is safe to trigger for other isx processes.
+     */
+    private static boolean recoverReachability() {
+        // A momentary blip (e.g. the daemon finishing a burst of work) may clear on its own.
+        if (waitUntilReady(REACHABILITY_GRACE_SECONDS)) return true;
+
+        // Still unreachable after the grace window: restart the wedged forwarder in place.
+        if (VmAgentClient.restartForwarder()) {
+            System.err.println("Restarted the vsock forwarder; waiting for Incus...");
+            if (waitUntilReady(FORWARDER_RECOVERY_WAIT_SECONDS)) return true;
+        } else {
+            System.err.println("Could not reach the control agent to restart the forwarder.");
+        }
+
+        // Last resort: keep waiting in case the forwarder's own -T backstop is mid-reap.
+        return waitUntilReady(REACHABILITY_BACKSTOP_SECONDS);
+    }
+
     /**
      * Auto-start hook: ensure VM is running and Incus is reachable.
      * Prints progress to stderr so it doesn't interfere with command output.
@@ -413,7 +446,7 @@ public final class VmManager {
         if (isRunning()) {
             if (IncusClient.isReachable()) return true;
             System.err.println("VM is running but Incus is not reachable. Waiting...");
-            return waitUntilReady(30);
+            return recoverReachability();
         }
 
         if (!Files.exists(Environment.applianceKernel())

--- a/src/main/java/dev/incusspawn/vm/VmManager.java
+++ b/src/main/java/dev/incusspawn/vm/VmManager.java
@@ -20,6 +20,8 @@ import java.nio.file.StandardCopyOption;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.BooleanSupplier;
+import java.util.function.IntPredicate;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 
@@ -405,7 +407,12 @@ public final class VmManager {
         return false;
     }
 
-    // Recovery budget for a VM that is up but whose Incus tunnel is unreachable.
+    // Recovery budget for a VM that is up but whose Incus tunnel is not answering. The primary
+    // recovery is the agent-driven forwarder restart (~1 s); the grace and backstop are short
+    // bounded probes around it. This is deliberately NOT sized to outwait the forwarder's own
+    // `socat -T 180` self-heal: if the agent cannot restart the forwarder and it does not clear
+    // within the budget, we give up so the caller can surface an actionable error rather than
+    // blocking the command for minutes.
     private static final int REACHABILITY_GRACE_SECONDS = 10;
     private static final int FORWARDER_RECOVERY_WAIT_SECONDS = 15;
     private static final int REACHABILITY_BACKSTOP_SECONDS = 30;
@@ -413,29 +420,41 @@ public final class VmManager {
     /**
      * Recover reachability when the VM is running but the Incus tunnel is not answering.
      *
-     * Almost always this means the vsock forwarder is wedged with leaked socat fork-children:
-     * the vfkit boundary does not reliably propagate connection close, so children pin host-side
-     * fds and degrade new-connection latency until the forwarder's own {@code socat -T 180}
-     * inactivity backstop reaps them. Rather than block a command for up to that 180 s, we give a
-     * brief transient a chance to clear, then proactively restart the forwarder via the control
-     * agent — an independent vsock port that answers even when the Incus tunnel is wedged, so
-     * recovery is ~1 s. Restarting only drops connections that are already stalled (nothing is
-     * getting through, or we would not be here), so it is safe to trigger for other isx processes.
+     * Almost always this means the vsock forwarder is wedged with leaked connections: the vfkit
+     * boundary does not reliably propagate connection close, so stranded streams pin host-side fds
+     * and degrade new-connection latency until the forwarder's own {@code socat -T 180} inactivity
+     * backstop reaps them. Rather than block a command for that long, we give a brief transient a
+     * chance to clear, then proactively restart the forwarder via the control agent — an
+     * independent vsock port that answers even when the Incus tunnel is wedged, so recovery is
+     * ~1 s. Restarting only drops connections that are already stalled (nothing is getting through,
+     * or we would not be here), so it is safe to trigger even for other isx processes.
      */
     private static boolean recoverReachability() {
+        return recoverReachability(VmManager::waitUntilReady, VmAgentClient::restartForwarder);
+    }
+
+    /**
+     * Testable core of {@link #recoverReachability()}. {@code waitUntilReady} probes reachability
+     * for a given number of seconds; {@code restartForwarder} asks the control agent to restart the
+     * forwarder and returns whether it confirmed. Split out so the grace / restart / backstop
+     * orchestration can be unit-tested without a live VM.
+     */
+    static boolean recoverReachability(IntPredicate waitUntilReady, BooleanSupplier restartForwarder) {
         // A momentary blip (e.g. the daemon finishing a burst of work) may clear on its own.
-        if (waitUntilReady(REACHABILITY_GRACE_SECONDS)) return true;
+        if (waitUntilReady.test(REACHABILITY_GRACE_SECONDS)) return true;
 
         // Still unreachable after the grace window: restart the wedged forwarder in place.
-        if (VmAgentClient.restartForwarder()) {
+        if (restartForwarder.getAsBoolean()) {
             System.err.println("Restarted the vsock forwarder; waiting for Incus...");
-            if (waitUntilReady(FORWARDER_RECOVERY_WAIT_SECONDS)) return true;
+            if (waitUntilReady.test(FORWARDER_RECOVERY_WAIT_SECONDS)) return true;
         } else {
-            System.err.println("Could not reach the control agent to restart the forwarder.");
+            // False covers both an unreachable agent and an unexpected reply — we cannot tell which.
+            System.err.println("The control agent did not confirm a forwarder restart.");
         }
 
-        // Last resort: keep waiting in case the forwarder's own -T backstop is mid-reap.
-        return waitUntilReady(REACHABILITY_BACKSTOP_SECONDS);
+        // Bounded final probe; if this fails, ensureRunning() returns false and the caller surfaces
+        // an actionable connection error (rather than blocking for the forwarder's ~180 s self-heal).
+        return waitUntilReady.test(REACHABILITY_BACKSTOP_SECONDS);
     }
 
     /**
@@ -445,7 +464,7 @@ public final class VmManager {
     public static boolean ensureRunning() {
         if (isRunning()) {
             if (IncusClient.isReachable()) return true;
-            System.err.println("VM is running but Incus is not reachable. Waiting...");
+            System.err.println("VM is running but Incus is not reachable; attempting recovery...");
             return recoverReachability();
         }
 

--- a/src/test/java/dev/incusspawn/vm/VmManagerTest.java
+++ b/src/test/java/dev/incusspawn/vm/VmManagerTest.java
@@ -147,4 +147,44 @@ class VmManagerTest {
 
         assertEquals(modifiedFirst, modifiedSecond);
     }
+
+    // --- recoverReachability orchestration (grace -> forwarder restart -> backstop) ---
+
+    @Test
+    void recoverReachabilityReturnsEarlyWhenGraceClears() {
+        var restarts = new java.util.concurrent.atomic.AtomicInteger();
+        boolean ok = VmManager.recoverReachability(
+                secs -> true,                                       // reachable on the grace probe
+                () -> { restarts.incrementAndGet(); return true; });
+        assertTrue(ok);
+        assertEquals(0, restarts.get(), "must not restart the forwarder if the grace probe succeeds");
+    }
+
+    @Test
+    void recoverReachabilityRestartsForwarderThenRecovers() {
+        var probes = new java.util.ArrayDeque<>(java.util.List.of(false, true)); // grace fails, post-restart succeeds
+        var restarts = new java.util.concurrent.atomic.AtomicInteger();
+        boolean ok = VmManager.recoverReachability(
+                secs -> probes.poll(),
+                () -> { restarts.incrementAndGet(); return true; });
+        assertTrue(ok);
+        assertEquals(1, restarts.get());
+        assertTrue(probes.isEmpty(), "must not fall through to the backstop probe once recovery succeeds");
+    }
+
+    @Test
+    void recoverReachabilityFallsBackToBackstopWhenAgentDoesNotConfirm() {
+        var probes = new java.util.ArrayDeque<>(java.util.List.of(false, true)); // grace fails, backstop succeeds
+        boolean ok = VmManager.recoverReachability(
+                secs -> probes.poll(),
+                () -> false);                                       // agent unreachable or unconfirmed
+        assertTrue(ok);
+        assertTrue(probes.isEmpty(), "must probe the backstop after the restart cannot be confirmed");
+    }
+
+    @Test
+    void recoverReachabilityGivesUpWhenNothingRecovers() {
+        boolean ok = VmManager.recoverReachability(secs -> false, () -> false);
+        assertFalse(ok, "must return false so the caller can surface an actionable error");
+    }
 }


### PR DESCRIPTION
## Context

Follow-up to a real incident: right after a heavy template rebuild, `isx` reported **"VM is running but Incus is not reachable"** for a sustained ~30s and then aborted the command. Investigation showed the vsock forwarder (`socat -T 180 … fork …`, still the same PID throughout) was transiently wedged with leaked fork-children — the documented vfkit close-propagation gap (appliance/DESIGN.md:227): leaked children pin host-side fds and degrade new-connection latency until the forwarder's own `socat -T 180` inactivity backstop reaps them. It self-healed, but slowly.

## The gap

`VmManager.ensureRunning()` handled the VM-up-but-unreachable case by waiting only **30s** and then aborting:

```java
System.err.println("VM is running but Incus is not reachable. Waiting...");
return waitUntilReady(30);
```

But the underlying recovery — `-T 180` reaping idle leaked children — can take up to **3 minutes**. So a heavy exec burst can leave a degraded window longer than 30s, and `isx` gives up on a transient it was designed to survive. It also waited *passively*, when the control agent already exposes a `forwarder-restart` verb that recovers in ~1s (doctor uses it; appliance/test-boot.sh exercises it on every boot).

## The change

`recoverReachability()` replaces the flat `waitUntilReady(30)`:

1. **Grace window** (`waitUntilReady(10)`) — a momentary blip may clear on its own without touching the forwarder.
2. **Proactive restart** — if still unreachable, restart the forwarder via `VmAgentClient.restartForwarder()` (the agent listens on an independent vsock port that answers even when the Incus tunnel is wedged), then re-probe.
3. **Backstop** — if the agent is unreachable or the restart didn't help, keep waiting (covers the case where `-T` is mid-reap).

Restarting only drops connections that are **already stalled** — if anything were getting through we would not be in this path — so it is safe even for other `isx` processes sharing the forwarder.

## Testing

- [x] `./mvnw -o test` — 685 unit tests pass.
- [x] **Live (macOS):** drove the exact recovery action `recoverReachability` performs — `forwarder-restart` via the control agent — on the affected host. Agent replied `restarted` and **Incus was reachable again in 1.59s** (first probe), vs. the old 30s-then-abort / up-to-180s self-heal. `socat-count` returned to baseline (1).

Note: the private orchestration (grace → restart → backstop) wraps the `forwarder-restart` primitive verified above; it couldn't be driven through a *synthetic* wedge (hard to induce on demand), but every step reuses already-exercised code (`waitUntilReady`, `VmAgentClient.restartForwarder`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)