### PR TITLE
Point JVMs at the system trust store via a profile.d script

### DIFF
--- a/src/main/java/dev/incusspawn/command/BuildCommand.java
+++ b/src/main/java/dev/incusspawn/command/BuildCommand.java
@@ -723,6 +723,7 @@ public class BuildCommand extends BaseCommand {
                 .assertSuccess("Failed to install MITM CA certificate");
         container.exec("update-ca-trust")
                 .assertSuccess("Failed to update CA trust");
+        CertificateAuthority.setJavaTrustStoreOverride(incus, buildName);
 
         // UID mapping for Wayland passthrough, nested containers, and no dropped
         // capabilities since the container itself is the security boundary.

--- a/src/main/java/dev/incusspawn/proxy/CertificateAuthority.java
+++ b/src/main/java/dev/incusspawn/proxy/CertificateAuthority.java
@@ -152,6 +152,29 @@ public class CertificateAuthority {
     }
 
     /**
+     * Point all JVMs in the container at the system trust store, which update-ca-trust
+     * keeps in sync with the MITM CA. Non-RPM JDKs (e.g. SDKMAN-installed) bundle their
+     * own cacerts keystore without the MITM CA, so HTTPS through the proxy fails with
+     * SSLHandshakeException.
+     *
+     * This must be a profile.d script, not /etc/environment: /etc/environment is only
+     * applied by pam_env on PAM logins, and the interactive shells isx spawns via the
+     * Incus exec API ('bash --login') never go through PAM. profile.d is sourced by
+     * both that path and 'su -'. The guard keeps re-sourcing (nested login shells)
+     * from stacking duplicates and leaves a user-set trustStore alone.
+     */
+    public static void setJavaTrustStoreOverride(IncusClient incus, String container) {
+        incus.shellExec(container, "sh", "-c",
+                "cat > /etc/profile.d/isx-java-truststore.sh << 'PROFEOF'\n" +
+                "case \"${JAVA_TOOL_OPTIONS:-}\" in\n" +
+                "  *-Djavax.net.ssl.trustStore=*) ;;\n" +
+                "  *) export JAVA_TOOL_OPTIONS=\"-Djavax.net.ssl.trustStore=/etc/pki/java/cacerts${JAVA_TOOL_OPTIONS:+ $JAVA_TOOL_OPTIONS}\" ;;\n" +
+                "esac\n" +
+                "PROFEOF")
+                .assertSuccess("Failed to write Java trust store override");
+    }
+
+    /**
      * Check whether a container's stored CA fingerprint matches the current CA.
      * If mismatched, push the current cert into the container and update metadata.
      * Returns true if a fix was applied, false if no action was needed.
@@ -168,6 +191,7 @@ public class CertificateAuthority {
                 ca.caCertPem() +
                 "CERTEOF");
         incus.shellExec(container, "update-ca-trust");
+        setJavaTrustStoreOverride(incus, container);
         incus.configSet(container, Metadata.CA_FINGERPRINT, ca.caFingerprint());
         return true;
     }


### PR DESCRIPTION
## Summary

Same goal as #346 (thanks @yrodiere-agent for the diagnosis and the `JAVA_TOOL_OPTIONS` approach!), but delivered through `/etc/profile.d/isx-java-truststore.sh` instead of `/etc/environment`, because the latter turns out not to reach the shells isx actually spawns:

- `/etc/environment` is applied by `pam_env`, i.e. only on PAM logins (`su -`, ssh). The interactive shells isx opens via the Incus exec API (`bash --login` in `IncusClient.interactiveShell`) never go through PAM, so a JVM started from `isx shell` — the exact scenario the fix targets — would not see the variable. Verified empirically in a live container: a marker in `/etc/environment` was visible under `su -` but empty under `bash --login` via the exec API.
- `/etc/profile.d/` is sourced by both paths (also verified empirically).

The script also improves on the raw env-var line:

- **Merges instead of clobbers**: a user-set `JAVA_TOOL_OPTIONS` is appended after the trustStore flag (`merged=[-Djavax.net.ssl.trustStore=... -Dfoo=bar]` in testing).
- **Idempotent under re-sourcing**: nested login shells don't stack duplicate flags, and a user who configures their own `trustStore` is left alone.

Applied in `buildFromScratch` (after `update-ca-trust`) and on CA rotation in `fixContainerCaIfNeeded`, same call sites as #346.

## Tradeoff

Unchanged from #346: every JVM prints `Picked up JAVA_TOOL_OPTIONS: ...` to stderr. Cosmetic and unsuppressible by JVM design, but note it can trip in-container tests that assert clean stderr.

## Testing (performed in a live `tpl-incus-spawn` container via the exec API)

- Wrote the exact generated script; `JAVA_TOOL_OPTIONS` is set in `bash --login` (isx shell path), under `su -`, survives re-sourcing without duplication, and merges with a pre-existing value
- End-to-end TLS: `java.net.http.HttpClient` request to `https://api.anthropic.com` through the MITM proxy completes the handshake with the override active — and since `javax.net.ssl.trustStore` *replaces* the JDK's default keystore lookup entirely, this proves the system store path works for any JDK regardless of install method
- Remaining manual step: rebuild an image and confirm `/etc/profile.d/isx-java-truststore.sh` lands via the build path

🤖 Generated with [Claude Code](https://claude.com/claude-code)