### PR TITLE
Add true (manually tested) support for VMs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,17 +37,19 @@ mvn package -Dnative -Dquarkus.native.container-build=true  # GraalVM native bin
 
 ### Image Hierarchy and Build System
 
-Templates are YAML definitions (`src/main/resources/images/`) with optional parent inheritance forming a chain: `tpl-minimal` -> `tpl-dev` -> `tpl-java`. Building an image auto-builds missing parents.
+Templates are YAML definitions (`src/main/resources/images/`) with optional parent inheritance forming a chain: `tpl-minimal` -> `tpl-dev` -> `tpl-java`. Building an image auto-builds missing parents. Each definition can set `type` (`container`, `vm`, or `kvm`) which inherits through the parent chain via `inheritTypes()` at `ImageDef.loadAll()` time. VM definitions also support `vm_image_url` and `vm_image_sha256` for a pre-baked VM base image.
 
 `BuildCommand` has two build paths:
 - **`buildFromScratch`** (root image, no parent): launches base OS, configures security/DNS/user, installs packages and tools
 - **`buildFromParent`** (derived image): copies parent via CoW, applies only the delta (new packages/tools)
 
+For VMs, `buildFromScratch` applies the entire ancestor chain from YAML definitions — parent Incus instances are not needed. `buildChain` detects type changes (container→VM) and skips unnecessary parent rebuilds. Container-specific security config (raw.idmap, nesting, setxattr interception) is skipped for VMs. Tool downloads use a mount-and-copy strategy instead of file push (vsock can't handle large pushes). The `--type` CLI flag overrides the definition's type; `effectiveVm()` resolves the effective VM status considering both the flag and definition.
+
 Package deduplication: `BuildCommand` collects all ancestor packages and subtracts them from the install list so derived images only install what's new.
 
 ### Host Resources
 
-`HostResourceSetup` (`config/HostResourceSetup.java`) handles sharing host files/directories with containers. Three modes: `readonly` (Incus disk device), `overlay` (overlayfs with container-local writable upper layer), `copy` (baked into template). Applied before tools during build so caches are available. Devices are removed from stopped templates and re-attached at branch time from JSON metadata stored in `user.incus-spawn.host-resources`. Overlay mounts persist across reboots via a systemd service inside the container.
+`HostResourceSetup` (`config/HostResourceSetup.java`) handles sharing host files/directories with containers. Three modes: `readonly` (Incus disk device), `overlay` (overlayfs with container-local writable upper layer), `copy` (baked into template). Applied before tools during build so caches are available. Devices are removed from stopped templates and re-attached at branch time from JSON metadata stored in `user.incus-spawn.host-resources`. Overlay mounts persist across reboots via a systemd service inside the container. VM-specific: virtiofs disk devices are mounted asynchronously by the incus-agent, so overlay mounts poll `mountpoint -q` for up to 15s before overlaying. File-level resources (not directories) fall back to `copy` mode on VMs since disk devices only support directories.
 
 ### Tool System
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -60,6 +60,9 @@ Each image definition specifies:
 - `image_url` — download URL for the base image tarball (supports `{arch}` and `{tag}` placeholders)
 - `image_tag` — release tag identifying the base image version
 - `image_sha256` — per-architecture checksums for integrity verification
+- `type` — instance type: `container` (default), `vm`, or `kvm`. Inherits through the parent chain via `inheritTypes()` at load time
+- `vm_image_url` — download URL for the VM base image (qcow2 tarball, supports `{arch}` and `{tag}` placeholders)
+- `vm_image_sha256` — per-architecture checksums for the VM base image
 - `parent` — parent image name (omit for root images)
 - `packages` — dnf packages to install
 - `tools` — tool names to run (resolved from YAML or Java)
@@ -71,13 +74,15 @@ from [`Sanne/incus-spawn-images`](https://github.com/Sanne/incus-spawn-images)
 instead of linuxcontainers.org. This image is a pre-baked systemd rootfs with
 agentuser, systemd-networkd, a connectivity watchdog, container-specific service
 masking, and a tmpfiles override for device node permissions — all the static
-setup that `buildFromScratch` would otherwise perform on every build. The base image tag and SHA256 checksums
-are pinned in `src/main/resources/images/minimal.yaml`. `isx update-base` manages
-base image versions: it fetches the release list from the GitHub API, retrieves
-per-architecture SHA256 checksums, and writes a user-level override to
-`~/.config/incus-spawn/images/minimal.yaml` when pinning. `--latest` removes the
-override so the built-in definition (updated with each isx release) is used.
-See the [incus-spawn-images README](https://github.com/Sanne/incus-spawn-images#releasing-a-new-version)
+setup that `buildFromScratch` would otherwise perform on every build. A separate
+VM base image (`vm_image_url`) is also available — a stock Incus Fedora VM image
+customized with the same base configuration via `virt-customize`. The base image
+tag and SHA256 checksums are pinned in `src/main/resources/images/minimal.yaml`.
+`isx update-base` manages base image versions: it fetches the release list from
+the GitHub API, retrieves per-architecture SHA256 checksums, and writes a
+user-level override to `~/.config/incus-spawn/images/minimal.yaml` when pinning.
+`--latest` removes the override so the built-in definition (updated with each isx
+release) is used. See the [incus-spawn-images README](https://github.com/Sanne/incus-spawn-images#releasing-a-new-version)
 for the full release process.
 
 **Resolution order** (later overrides earlier): built-in YAML (classpath) → user-defined YAML (`~/.config/incus-spawn/images/`) → search paths (`searchPaths` in config.yaml) → project-local (`.incus-spawn/images/`). Definitions with the same name from a later source override earlier ones.
@@ -126,8 +131,8 @@ Execution order: packages → downloads → run → run_as_user → files → ve
 **`buildFromScratch` (root image, no parent):**
 1. Import and launch base image (pre-baked with agentuser, systemd-networkd, service masks)
 2. Install MITM proxy CA certificate
-3. Configure security (idmap, nesting, syscall interception, no capability dropping)
-4. Prepare container for package install (tmpfiles overrides, temporary DHCP network config, man dirs)
+3. Configure security (idmap, nesting, syscall interception, no capability dropping) — *skipped for VMs*
+4. Prepare container for package install (tmpfiles overrides, temporary DHCP network config, man dirs) — *skipped for VMs*
 5. Configure DNS (disable systemd-resolved, point at Incus bridge gateway)
 6. Upgrade system packages
 7. Install image-defined packages via dnf
@@ -137,6 +142,17 @@ Execution order: packages → downloads → run → run_as_user → files → ve
 11. Pre-trust cloned repo directories in `.claude.json` (if Claude Code is installed)
 12. Clean caches (dnf, /tmp)
 13. Tag metadata (version, SHA, definition fingerprint, CA fingerprint, build source), stop
+
+**VM-specific build behavior:**
+
+When `type` is `vm` or `kvm` (set in the definition or via `--type`), `buildFromScratch` applies the entire ancestor tool/package chain from YAML definitions alone — parent Incus instances are not needed, so container parent rebuilds are skipped when a type change is detected in `buildChain`. Additional differences:
+
+- **Base image**: uses `vm_image_url` (pre-baked VM qcow2) when available, falls back to a stock Incus VM image otherwise
+- **Disk expansion**: runs `growpart` + `resize2fs`/`xfs_growfs` before package install (both for pre-baked images that ship at 10G and the final build which defaults to 100G)
+- **Security config**: container-specific security settings (raw.idmap, nesting, setxattr interception) are skipped — VMs have their own kernel and don't need them
+- **No restart**: VMs don't need the container restart that applies security config changes
+- **Tool downloads**: large file pushes over vsock are slow, so `YamlToolSetup` uses a mount-and-copy strategy — the extracted archive is attached as a disk device and copied locally inside the VM
+- **KVM passthrough**: when `type: kvm`, `/dev/kvm` is passed through to the VM for nested virtualization
 
 **`buildFromParent` (derived image):**
 1. Copy parent image, start, wait for network
@@ -156,6 +172,8 @@ Execution order: packages → downloads → run → run_as_user → files → ve
 Like `git branch`, branching creates an instant copy-on-write clone of any template image. Each branch has its own independent filesystem -- changes in one branch cannot affect the template image or any other branch. The CoW storage backend (btrfs/zfs/lvm) deduplicates unchanged data transparently at the block level, so branches are instant to create and only consume disk space for their own modifications.
 
 **Static IP assignment**: Each branch receives a deterministic static IP on the bridge subnet at creation time. `StaticIpAllocator` scans all existing instances for claimed `ipv4.address` values on NIC devices and picks the lowest free host address (`.2`–`.254`). The IP is set on the Incus NIC device (so Incus is authoritative) and a `systemd-networkd` `.network` file is pushed into the stopped container before start, so the interface comes up statically at boot with no DHCP lease to expire. Templates do not have baked-in addresses — all CoW branches share the template filesystem, so a static address in the template would collide. The base image (from `Sanne/incus-spawn-images`) provides `systemd-networkd` and bakes in a connectivity watchdog (30s systemd timer) that detects IP loss after host sleep/wake and restarts `systemd-networkd` to recover; `isx` only supplies the per-branch address.
+
+**VM deferred file pushes**: File push to a stopped VM is not possible (it requires the running `incus-agent` inside the VM). For VMs, `BranchCommand` and `ListCommand` skip pre-start file pushes (network config, SSH keys, terminfo) and instead call `InstanceLifecycle.pushDeferredVmFiles()` after starting the VM and waiting for the agent to become ready. The network config (IP and gateway) is read from Incus metadata at push time.
 
 The TUI branch modal supports:
 - Custom name
@@ -357,6 +375,12 @@ The overlay directory structure mirrors the container path directly under `/var/
 ```
 
 Incus disk device names are derived from the container path for readability (e.g. `hr-home-agentuser--m2-repository`). They are removed from stopped templates to avoid host-path dependencies and re-attached at branch time.
+
+#### VM behavior
+
+VMs mount Incus disk devices asynchronously via virtiofs (managed by the `incus-agent`). For overlay mode, `applyOverlay` polls `mountpoint -q` for up to 15 seconds before running the overlay mount, since the lower directory may not be populated yet when the mount command runs. If the device doesn't appear in time, the overlay is skipped with a warning.
+
+File-level host resources (individual files rather than directories) automatically fall back to `copy` mode on VMs, since Incus disk devices only support directory mounts for virtual machines. The fallback is logged: "VM: falling back to copy mode for file ...".
 
 #### Missing sources
 

--- a/README.md
+++ b/README.md
@@ -206,6 +206,9 @@ Image schema fields (all optional except `name`):
 - `image_url` -- download URL for the base image tarball (supports `{arch}` and `{tag}` placeholders)
 - `image_tag` -- release tag identifying the base image version
 - `image_sha256` -- per-architecture SHA256 checksums for integrity verification
+- `type` -- instance type: `container` (default), `vm`, or `kvm`. VMs use a separate kernel for hardware-level isolation. `kvm` is a VM with `/dev/kvm` passthrough for nested virtualization. Inherits from parent -- a child without `type` inherits its parent's type
+- `vm_image_url` -- download URL for the VM base image (qcow2 tarball). Only used when `type` is `vm` or `kvm`. Supports `{arch}` and `{tag}` placeholders
+- `vm_image_sha256` -- per-architecture SHA256 checksums for the VM base image
 - `parent` -- parent image name (omit for root images)
 - `packages` -- dnf packages to install
 - `tools` -- tool names to run (resolved from YAML or Java, see [Custom Tools](#custom-tools))
@@ -220,6 +223,9 @@ Image schema fields (all optional except `name`):
 ```shell
 # Build a specific image (builds missing parents automatically)
 isx build tpl-java
+
+# Build as a VM instead of a container (overrides the definition's type)
+isx build tpl-java --type vm
 
 # Rebuild a template and all its parents from scratch
 isx build tpl-java --with-parents
@@ -389,6 +395,8 @@ Three modes are available:
 | `copy` | No | Copied into the container at build time. Becomes part of the template. Also supports URL sources. |
 
 If `path` is omitted, it defaults to the same relative path under `/home/agentuser/`. Missing host paths are skipped with a warning, so templates remain portable. Host resources compose across the parent chain, with child entries overriding parent entries matched by container path.
+
+**VM note:** VMs mount disk devices via virtiofs (asynchronously, after the incus-agent starts). For overlay mode, the build waits up to 15 seconds for the device to appear before mounting. File-level host resources (single files rather than directories) automatically fall back to `copy` mode on VMs, since Incus disk devices only support directory mounts for VMs.
 
 ## Custom Tools
 

--- a/src/main/java/dev/incusspawn/command/BranchCommand.java
+++ b/src/main/java/dev/incusspawn/command/BranchCommand.java
@@ -41,6 +41,9 @@ public class BranchCommand extends BaseCommand {
     @Option(name = "kvm", description = "Expose /dev/kvm for nested virtualization", hasValue = false)
     boolean kvm;
 
+    @Option(name = "no-kvm", description = "Disable KVM even if the template was built with type: kvm", hasValue = false)
+    boolean noKvm;
+
     @Option(name = "airgap", description = "Disable network access (complete isolation)", hasValue = false)
     boolean airgap;
 
@@ -112,7 +115,8 @@ public class BranchCommand extends BaseCommand {
             warnIfTemplateWantsGui(resolvedSource);
         }
 
-        if (kvm) {
+        var enableKvm = kvm || (!noKvm && "kvm".equals(incus.configGet(resolvedSource, Metadata.INSTANCE_MODE)));
+        if (enableKvm) {
             if (!KvmPassthrough.configureKvm(incus, name)) {
                 System.err.println("Continuing without KVM — VMs inside this branch will not work.");
             }
@@ -125,15 +129,28 @@ public class BranchCommand extends BaseCommand {
             return CommandResult.SUCCESS;
         }
 
-        // Pre-fetch config, inject SSH keys, and push terminfo while container
-        // is stopped — the Incus daemon blocks API calls after start
+        // Pre-fetch config while instance is stopped — the Incus daemon blocks
+        // API calls after start due to seccomp_notify lock contention.
         var prefetched = InstanceLifecycle.prefetchRuntimeConfig(incus, name);
-        System.out.println("Configuring SSH access...");
-        InstanceLifecycle.injectSshKeyIfAvailable(incus, name, prefetched.hasSshKeys());
-        InstanceLifecycle.pushTerminfoIfNeeded(incus, name, prefetched.terminfo());
+        boolean isVm = incus.isVm(name);
 
-        System.out.println("Starting container...");
+        // Push SSH keys and terminfo into stopped containers (direct filesystem
+        // access). VMs require the incus-agent, so these are deferred to after start.
+        if (!isVm) {
+            System.out.println("Configuring SSH access...");
+            InstanceLifecycle.injectSshKeyIfAvailable(incus, name, prefetched.hasSshKeys());
+            InstanceLifecycle.pushTerminfoIfNeeded(incus, name, prefetched.terminfo());
+        }
+
+        System.out.println(isVm ? "Starting VM..." : "Starting container...");
         incus.start(name);
+
+        if (isVm) {
+            System.out.println("Waiting for VM agent...");
+            incus.waitForReady(name);
+            InstanceLifecycle.pushDeferredVmFiles(incus, name, networkMode, prefetched);
+        }
+
         InstanceLifecycle.setupRuntime(incus, name, networkMode, inbox, prefetched);
 
         System.out.println("Branch '" + name + "' is ready.\n");

--- a/src/main/java/dev/incusspawn/command/BuildCommand.java
+++ b/src/main/java/dev/incusspawn/command/BuildCommand.java
@@ -698,11 +698,6 @@ public class BuildCommand extends BaseCommand {
         System.out.println("Image " + canonicalName + " built successfully.");
     }
 
-    /**
-     * Build an image from scratch using the base OS image.
-     * This is the full setup path: DNS, user, packages, tools.
-     * @param buildName the Incus container name to create (may be a temp name)
-     */
     private boolean effectiveVm(ImageDef imageDef) {
         if (type != null) return type == InstanceType.vm;
         return imageDef.isVm();

--- a/src/main/java/dev/incusspawn/command/BuildCommand.java
+++ b/src/main/java/dev/incusspawn/command/BuildCommand.java
@@ -19,6 +19,7 @@ import dev.incusspawn.incus.IncusClient;
 import static dev.incusspawn.incus.Container.shellQuote;
 import dev.incusspawn.incus.IncusException;
 import dev.incusspawn.incus.Metadata;
+import dev.incusspawn.incus.ResourceLimits;
 import dev.incusspawn.proxy.CertificateAuthority;
 import dev.incusspawn.proxy.MitmProxy;
 import dev.incusspawn.proxy.ProxyHealthCheck;
@@ -79,8 +80,8 @@ public class BuildCommand extends BaseCommand {
     @Option(name = "missing", hasValue = false, description = "Build only templates that don't exist yet")
     boolean missing;
 
-    @Option(name = "vm", hasValue = false, description = "Build as a VM instead of a container")
-    boolean vm;
+    @Option(name = "type", description = "Instance type: container, vm, or kvm (overrides image definition)")
+    InstanceType type;
 
     @Option(name = "yes", hasValue = false, description = "Skip interactive confirmations (for TUI integration)")
     boolean yes;
@@ -443,17 +444,24 @@ public class BuildCommand extends BaseCommand {
                 System.exit(1);
             }
 
-            boolean parentMissing = !incus.exists(parentName);
-            boolean needsRebuild = parentMissing || isImageOutdated(parentName, parentDef, incus, toolDefLoader, defs);
+            // When the target type differs from the parent's resolved type
+            // (e.g. building a VM from container parents), buildFromScratch
+            // applies the entire ancestor chain from definitions alone —
+            // parent Incus instances are not needed.
+            boolean typeChange = effectiveVm(imageDef) != effectiveVm(parentDef);
+            if (!typeChange) {
+                boolean parentMissing = !incus.exists(parentName);
+                boolean needsRebuild = parentMissing || isImageOutdated(parentName, parentDef, incus, toolDefLoader, defs);
 
-            if (needsRebuild) {
-                if (parentMissing) {
-                    System.out.println("Parent image '" + parentName + "' not found, building it first...\n");
-                } else {
-                    System.out.println("Parent image '" + parentName + "' is outdated, rebuilding it first...\n");
+                if (needsRebuild) {
+                    if (parentMissing) {
+                        System.out.println("Parent image '" + parentName + "' not found, building it first...\n");
+                    } else {
+                        System.out.println("Parent image '" + parentName + "' is outdated, rebuilding it first...\n");
+                    }
+                    buildChain(parentDef, defs);
+                    System.out.println();
                 }
-                buildChain(parentDef, defs);
-                System.out.println();
             }
         }
 
@@ -483,7 +491,9 @@ public class BuildCommand extends BaseCommand {
         activeBuild = new String[]{tempName, canonicalName};
 
         try {
-            if (imageDef.isRoot()) {
+            boolean typeChange = !imageDef.isRoot()
+                    && effectiveVm(imageDef) != incus.isVm(imageDef.getParent());
+            if (imageDef.isRoot() || typeChange) {
                 buildFromScratch(imageDef, defs, tempName);
             } else {
                 buildFromParent(imageDef, defs, tempName, imageDef.getParent());
@@ -492,6 +502,10 @@ public class BuildCommand extends BaseCommand {
             System.err.println("\n\033[33m" + "─".repeat(60) + "\033[0m");
             System.err.println("\033[1mBuild failed for " + canonicalName + ": " + e.getMessage() + "\033[0m");
             printBuildDiagnostics(tempName);
+            try {
+                var failedHostResources = HostResourceSetup.collectEffective(imageDef, defs);
+                HostResourceSetup.removeBuildDevices(incus, tempName, failedHostResources);
+            } catch (Exception ignored) {}
             promoteToFailedInstance(tempName, canonicalName);
             activeBuild = null;
             throw new BuildFailedException(canonicalName);
@@ -613,26 +627,31 @@ public class BuildCommand extends BaseCommand {
                                   String buildName, String parentSource) {
         var canonicalName = imageDef.getName();
         var parentCanonical = imageDef.getParent();
+        var effectiveVm = effectiveVm(imageDef);
 
         System.out.println("Deriving from parent image '" + parentCanonical + "'...");
         incus.copy(parentSource, buildName);
-        incus.configSet(buildName, "security.idmap.size", "165536");
-        incus.configSet(buildName, "security.nesting", "true");
-        if (Environment.isLinux()) {
-            incus.configSet(buildName, "security.syscalls.intercept.setxattr", "true");
+        if (!effectiveVm) {
+            incus.configSet(buildName, "security.idmap.size", "165536");
+            incus.configSet(buildName, "security.nesting", "true");
+            if (Environment.isLinux()) {
+                incus.configSet(buildName, "security.syscalls.intercept.setxattr", "true");
+            }
+            incus.configSet(buildName, "raw.lxc", "lxc.cap.drop =");
         }
-        incus.configSet(buildName, "raw.lxc", "lxc.cap.drop =");
         incus.start(buildName);
         incus.waitForReady(buildName);
 
         var container = new Container(incus, buildName);
-        // Write the DHCP .network file before waiting for systemd — otherwise
-        // networkd-wait-online blocks systemd from reaching "running".
-        prepareContainerForPackageInstall(container);
+        if (!effectiveVm) {
+            prepareContainerForPackageInstall(container);
+        }
 
         incus.waitForSystemd(buildName);
 
-        waitForIpv4(container);
+        if (!effectiveVm) {
+            waitForIpv4(container);
+        }
 
         var gatewayIp = MitmProxy.resolveGatewayIp(incus);
         container.sh(
@@ -643,12 +662,12 @@ public class BuildCommand extends BaseCommand {
 
         waitForNetwork(buildName);
 
-        mountDnfCache(buildName);
+        mountDnfCache(buildName, effectiveVm);
 
         var hostResources = HostResourceSetup.collectEffective(imageDef, defs);
         if (!hostResources.isEmpty()) {
             System.out.println("Applying host-resources...");
-            HostResourceSetup.applyForBuild(incus, container, hostResources);
+            HostResourceSetup.applyForBuild(incus, container, hostResources, effectiveVm);
         }
 
         removePackages(container, imageDef);
@@ -656,13 +675,14 @@ public class BuildCommand extends BaseCommand {
         var toolResolution = collectEffectiveTools(imageDef, defs);
         enablePackageRepos(container, imageDef, toolResolution.effective(), toolResolution.ancestors(), defs);
         installAllPackages(container, imageDef, toolResolution.effective(), toolResolution.ancestors(), defs);
+
         runToolSetup(container, toolResolution.effective());
         var allTools = new ArrayList<>(toolResolution.ancestors());
         allTools.addAll(toolResolution.effective());
         writeEnvFile(container, imageDef, defs, allTools, canonicalName);
         maskServices(container, imageDef);
         installSkills(container, imageDef, defs);
-        cloneRepos(container, imageDef);
+        cloneRepos(container, imageDef, effectiveVm);
         updateClaudeJsonTrust(container, imageDef);
 
         HostResourceSetup.removeBuildDevices(incus, buildName, hostResources);
@@ -683,17 +703,65 @@ public class BuildCommand extends BaseCommand {
      * This is the full setup path: DNS, user, packages, tools.
      * @param buildName the Incus container name to create (may be a temp name)
      */
+    private boolean effectiveVm(ImageDef imageDef) {
+        if (type != null) return type == InstanceType.vm;
+        return imageDef.isVm();
+    }
+
+    private String effectiveType(ImageDef imageDef) {
+        if (type != null) return type.name();
+        if (imageDef.getType() != null) return imageDef.getType();
+        return "container";
+    }
+
     private void buildFromScratch(ImageDef imageDef, Map<String, ImageDef> defs, String buildName) {
         var canonicalName = imageDef.getName();
-        var image = imageDef.getImage();
-        var prebaked = imageDef.getImageUrl() != null;
+        var ancestors = ImageDef.ancestors(imageDef, defs);
+        var rootDef = ancestors.isEmpty() ? imageDef : ancestors.get(ancestors.size() - 1);
+        var image = rootDef.getImage();
+        var effectiveVm = effectiveVm(imageDef);
+        var prebaked = false;
 
-        ensureBaseImage(imageDef);
+        if (effectiveVm && rootDef.getVmImageUrl() != null) {
+            // Prebaked VM disk image available — use it directly
+            var vmAlias = rootDef.getImage() + "-vm";
+            ensureBaseImage(imageDef);
+            downloadAndAliasImage(vmAlias, rootDef.getVmImageUrl(),
+                    rootDef.getVmImageSha256(), rootDef.getImageTag());
+            image = vmAlias;
+            prebaked = true;
+        } else {
+            ensureBaseImage(imageDef);
+            prebaked = imageDef.getImageUrl() != null;
 
-        // Launch base image
-        System.out.println("Launching " + image + "...");
+            // Prebaked images are container format (.tar.xz) — VMs need a disk image.
+            // Detect container-only images and fall back to the standard remote source.
+            if (effectiveVm && !image.contains(":")) {
+                var fingerprint = incus.imageAliasTarget(image);
+                if (fingerprint != null) {
+                    var imageType = incus.getImageType(fingerprint);
+                    if (!"virtual-machine".equals(imageType)) {
+                        var os = incus.getImageProperty(fingerprint, "os");
+                        var release = incus.getImageProperty(fingerprint, "release");
+                        if (os != null && release != null) {
+                            image = "images:" + os.toLowerCase() + "/" + release;
+                            prebaked = false;
+                            System.out.println("Base image is container-only, using " + image + " for VM build.");
+                        } else {
+                            throw new RuntimeException(
+                                    "Cannot build VM from container image '" + rootDef.getImage() + "'. "
+                                    + "The image lacks OS/release metadata to derive a VM image source.");
+                        }
+                    }
+                }
+            }
+        }
+
+        // Create instance — for VMs, expand the disk before first boot so
+        // cloud-init's growpart module handles partition + filesystem resize.
+        System.out.println("Launching " + image + (effectiveVm ? " (VM)..." : "..."));
         try {
-            incus.launch(image, buildName, vm);
+            incus.create(image, buildName, effectiveVm);
         } catch (IncusException e) {
             if (incus.exists(buildName)) {
                 var log = incus.getLog(buildName);
@@ -707,7 +775,11 @@ public class BuildCommand extends BaseCommand {
             }
             throw e;
         }
-
+        if (effectiveVm) {
+            incus.deviceConfigSet(buildName, "root", "size", ResourceLimits.defaultDiskLimit());
+            incus.configSet(buildName, "limits.memory", ResourceLimits.adaptiveMemoryLimit());
+        }
+        incus.start(buildName);
         waitForReady(buildName);
 
         var container = new Container(incus, buildName);
@@ -724,31 +796,24 @@ public class BuildCommand extends BaseCommand {
         container.exec("update-ca-trust")
                 .assertSuccess("Failed to update CA trust");
 
-        // UID mapping for Wayland passthrough, nested containers, and no dropped
-        // capabilities since the container itself is the security boundary.
-        // mknod intercept is NOT enabled: the seccomp_notify handler causes
-        // per-container lock contention during startup, adding 5+ seconds to
-        // every exec call while systemd-tmpfiles processes device nodes.
-        // Podman uses fuse-overlayfs instead of native mknod-based whiteouts.
-        incus.configSet(buildName, "raw.idmap", "both 1000 1000");
-        // Map 165536 UIDs (0-165535) so subordinate UIDs 100000-165535
-        // are available for rootless podman inside the container.
-        incus.configSet(buildName, "security.idmap.size", "165536");
-        incus.configSet(buildName, "security.nesting", "true");
-        if (Environment.isLinux()) {
-            incus.configSet(buildName, "security.syscalls.intercept.setxattr", "true");
+        // Container-only security tweaks: UID mapping, nesting, capability
+        // retention, and setxattr interception. VMs run a full kernel and
+        // don't need any of these. Restart activates the new config.
+        if (!effectiveVm) {
+            incus.configSet(buildName, "raw.idmap", "both 1000 1000");
+            incus.configSet(buildName, "security.idmap.size", "165536");
+            incus.configSet(buildName, "security.nesting", "true");
+            if (Environment.isLinux()) {
+                incus.configSet(buildName, "security.syscalls.intercept.setxattr", "true");
+            }
+            incus.configSet(buildName, "raw.lxc", "lxc.cap.drop =");
+            prepareContainerForPackageInstall(container);
+
+            System.out.println("Restarting container with updated security config...");
+            incus.restart(buildName);
+            incus.waitForSystemd(buildName);
+            waitForIpv4(container);
         }
-        incus.configSet(buildName, "raw.lxc", "lxc.cap.drop =");
-        // Write network config before restart so systemd-networkd finds the
-        // DHCP .network file on boot — otherwise networkd-wait-online blocks
-        // systemd from reaching "running" for its full timeout.
-        prepareContainerForPackageInstall(container);
-
-        System.out.println("Restarting container with updated security config...");
-        incus.restart(buildName);
-        incus.waitForSystemd(buildName);
-
-        waitForIpv4(container);
 
         System.out.println("Configuring DNS...");
         var gatewayIp = MitmProxy.resolveGatewayIp(incus);
@@ -760,7 +825,16 @@ public class BuildCommand extends BaseCommand {
 
         waitForNetwork(buildName);
 
-        mountDnfCache(buildName);
+        mountDnfCache(buildName, effectiveVm);
+
+        if (effectiveVm) {
+            System.out.println("Expanding VM root filesystem...");
+            container.runInteractive("Failed to expand VM root filesystem",
+                    "sh", "-c",
+                    "dnf install -y -q cloud-utils-growpart e2fsprogs xfsprogs && " +
+                    "growpart /dev/sda 2 && " +
+                    "if findmnt -n -o FSTYPE / | grep -q xfs; then xfs_growfs /; else resize2fs /dev/sda2; fi");
+        }
 
         if (!prebaked) {
             removePackages(container, imageDef);
@@ -768,6 +842,12 @@ public class BuildCommand extends BaseCommand {
             System.out.println("Updating system packages...");
             runDnf(container, "Failed to update system packages",
                     "dnf", "-y", "--setopt=keepcache=true", "--setopt=metadata_expire=3600", "--setopt=tsflags=nodocs", "upgrade");
+
+            if (effectiveVm) {
+                System.out.println("Regenerating initramfs for VM...");
+                container.runInteractive("Failed to regenerate initramfs",
+                        "dracut", "--force", "--regenerate-all");
+            }
 
             // Disable systemd-resolved AFTER dnf upgrade — the upgrade can re-enable
             // it. Masking prevents package scripts from restarting it. Also remove
@@ -819,24 +899,44 @@ public class BuildCommand extends BaseCommand {
         var hostResources = HostResourceSetup.collectEffective(imageDef, defs);
         if (!hostResources.isEmpty()) {
             System.out.println("Applying host-resources...");
-            HostResourceSetup.applyForBuild(incus, container, hostResources);
+            HostResourceSetup.applyForBuild(incus, container, hostResources, effectiveVm);
         }
 
-        var tools = resolveTools(imageDef);
-        enablePackageRepos(container, imageDef, tools, List.of(), defs);
-        installAllPackages(container, imageDef, tools, List.of(), defs);
-        runToolSetup(container, tools);
-        writeEnvFile(container, imageDef, defs, tools, canonicalName);
-        installSkills(container, imageDef, defs);
-        cloneRepos(container, imageDef);
-        updateClaudeJsonTrust(container, imageDef);
+        // Build the full ancestor chain (root first) so that each layer's
+        // packages, tools, repos, and skills are applied in order. For root
+        // images this list contains only imageDef itself.
+        var chain = new ArrayList<ImageDef>();
+        for (int i = ancestors.size() - 1; i >= 0; i--) {
+            chain.add(ancestors.get(i));
+        }
+        chain.add(imageDef);
+
+        var allTools = new ArrayList<ResolvedTool>();
+        for (var layer : chain) {
+            if (chain.size() > 1) {
+                System.out.println("\nApplying layer: " + layer.getName());
+            }
+            removePackages(container, layer);
+            var toolResolution = collectEffectiveTools(layer, defs);
+            enablePackageRepos(container, layer, toolResolution.effective(), toolResolution.ancestors(), defs);
+            installAllPackages(container, layer, toolResolution.effective(), toolResolution.ancestors(), defs);
+
+            runToolSetup(container, toolResolution.effective());
+            allTools.addAll(toolResolution.effective());
+            maskServices(container, layer);
+            installSkills(container, layer, defs);
+            cloneRepos(container, layer, effectiveVm);
+            updateClaudeJsonTrust(container, layer);
+        }
+        writeEnvFile(container, imageDef, defs, allTools, canonicalName);
 
         HostResourceSetup.removeBuildDevices(incus, buildName, hostResources);
         unmountDnfCache(buildName);
 
         cleanCaches(buildName);
 
-        tagTemplateMetadata(buildName, canonicalName, imageDef, null, hostResources, defs);
+        var parentCanonical = imageDef.isRoot() ? null : imageDef.getParent();
+        tagTemplateMetadata(buildName, canonicalName, imageDef, parentCanonical, hostResources, defs);
 
         System.out.println("Stopping image...");
         incus.stop(buildName);
@@ -859,21 +959,21 @@ public class BuildCommand extends BaseCommand {
 
     private void ensureBaseImage(ImageDef imageDef) {
         checkPinnedWarning(imageDef);
+        downloadAndAliasImage(imageDef.getImage(), imageDef.getImageUrl(),
+                imageDef.getImageSha256(), imageDef.getImageTag());
+    }
 
-        var imageUrl = imageDef.getImageUrl();
+    private void downloadAndAliasImage(String localAlias, String imageUrl,
+            Map<String, String> sha256Map, String tag) {
         if (imageUrl == null || imageUrl.isBlank()) return;
-
-        var localAlias = imageDef.getImage();
         if (localAlias.contains(":")) return;
 
         var arch = normalizeHostArch();
         String expectedSha256 = null;
-        var sha256Map = imageDef.getImageSha256();
         if (sha256Map != null) {
             expectedSha256 = sha256Map.get(arch);
         }
 
-        var tag = imageDef.getImageTag();
         var existingFingerprint = incus.imageAliasTarget(localAlias);
         if (existingFingerprint != null) {
             var installedTag = incus.getImageProperty(existingFingerprint, "incus-spawn.tag");
@@ -928,6 +1028,7 @@ public class BuildCommand extends BaseCommand {
                 "mkdir -p /etc/systemd/network; " +
                 "printf '[Match]\\nName=eth0\\n\\n[Network]\\nDHCP=ipv4\\n\\n[DHCPv4]\\nUseDNS=no\\n' " +
                 "> /etc/systemd/network/10-eth0.network; " +
+                "systemctl enable systemd-networkd 2>/dev/null; " +
                 "systemctl restart systemd-networkd 2>/dev/null; " +
                 // Legacy: also configure dhcpcd if present (old base images)
                 "if [ -f /etc/dhcpcd.conf ]; then " +
@@ -1243,11 +1344,9 @@ public class BuildCommand extends BaseCommand {
     }
 
     private void cleanCaches(String container) {
-        // DNF cache volume is unmounted before this call — only clean the
-        // container-local mount point and temp files to minimize image size.
         System.out.println("Cleaning up caches...");
         incus.shellExec(container, "sh", "-c",
-                "rm -rf /var/cache/libdnf5 /tmp/* /var/tmp/*");
+                "dnf clean all; rm -rf /var/cache/libdnf5 /tmp/* /var/tmp/*; true");
     }
 
     private void waitForIpv4(Container container) {
@@ -1400,6 +1499,7 @@ public class BuildCommand extends BaseCommand {
                                     Map<String, ImageDef> defs) {
         incus.configSet(buildName, Metadata.TYPE, Metadata.TYPE_BASE);
         incus.configSet(buildName, Metadata.PROFILE, canonicalName);
+        incus.configSet(buildName, Metadata.INSTANCE_MODE, effectiveType(imageDef));
         if (parentCanonicalName != null) {
             incus.configSet(buildName, Metadata.PARENT, parentCanonicalName);
         }
@@ -1477,6 +1577,12 @@ public class BuildCommand extends BaseCommand {
         return null;
     }
 
+    enum InstanceType {
+        container,
+        vm,
+        kvm
+    }
+
     static class BuildFailedException extends RuntimeException {
         final String containerName;
 
@@ -1497,7 +1603,8 @@ public class BuildCommand extends BaseCommand {
      */
     static final String DNF_CACHE_VOLUME = "dnf-cache";
 
-    private void mountDnfCache(String container) {
+    private void mountDnfCache(String container, boolean isVm) {
+        if (isVm) return;
         try {
             var pool = incus.findCowPool();
             if (pool == null) return;
@@ -1786,7 +1893,7 @@ public class BuildCommand extends BaseCommand {
      * alternates removal makes the clone self-contained while the reference device
      * is still mounted.
      */
-    void cloneRepos(Container container, ImageDef imageDef) {
+    void cloneRepos(Container container, ImageDef imageDef, boolean isVm) {
         var config = SpawnConfig.load();
 
         for (var repo : imageDef.getRepos()) {
@@ -1796,7 +1903,7 @@ public class BuildCommand extends BaseCommand {
             RepoReference ref = null;
 
             try {
-                ref = tryMountReference(container, repo.getUrl(), config);
+                ref = tryMountReference(container, repo.getUrl(), config, isVm);
                 if (ref != null) {
                     System.out.println("  \033[1;32mUsing local host reference to speed up clone...\033[0m");
                     try {
@@ -1868,7 +1975,7 @@ public class BuildCommand extends BaseCommand {
         return cmd.toString();
     }
 
-    RepoReference tryMountReference(Container container, String cloneUrl, SpawnConfig config) {
+    RepoReference tryMountReference(Container container, String cloneUrl, SpawnConfig config, boolean isVm) {
         try {
             var repoName = GitRemoteUtils.repoNameFromUrl(cloneUrl);
             if (repoName.isEmpty()) return null;
@@ -1896,7 +2003,7 @@ public class BuildCommand extends BaseCommand {
                     "source=" + HostResourceSetup.translateForVm(hostPath.toString()),
                     "path=" + containerPath,
                     "readonly=true"));
-            HostResourceSetup.addShiftIfSupported(refArgs);
+            HostResourceSetup.addShiftIfSupported(refArgs, isVm);
             incus.deviceAdd(container.name(), deviceName, "disk", refArgs.toArray(String[]::new));
 
             return new RepoReference(deviceName, containerPath);

--- a/src/main/java/dev/incusspawn/command/BuildCommand.java
+++ b/src/main/java/dev/incusspawn/command/BuildCommand.java
@@ -606,7 +606,9 @@ public class BuildCommand extends BaseCommand {
         try {
             incus.deleteIfExists(promotedName);
             try { unmountDnfCache(buildName); } catch (Exception ignored) {}
-            incus.forceStop(buildName);
+            if (!"Stopped".equalsIgnoreCase(incus.getInstanceStatus(buildName))) {
+                incus.forceStop(buildName);
+            }
             incus.rename(buildName, promotedName);
             incus.configSet(promotedName, Metadata.TYPE, Metadata.TYPE_FAILED_BUILD);
             incus.configSet(promotedName, Metadata.PARENT, canonicalName);

--- a/src/main/java/dev/incusspawn/command/InstancePrep.java
+++ b/src/main/java/dev/incusspawn/command/InstancePrep.java
@@ -52,10 +52,15 @@ public class InstancePrep {
             fixCaMismatch(incus, name);
         }
 
-        // Start if stopped
+        // Start if stopped, or restart VMs with unresponsive agent
         if ("Stopped".equalsIgnoreCase(incus.getInstanceStatus(name))) {
             System.out.println("Starting " + name + "...");
             HostResourceSetup.removeStaleDevices(incus, name);
+            incus.start(name);
+            incus.waitForReady(name);
+        } else if (incus.isVm(name) && !incus.shellExec(name, "echo", "ready").success()) {
+            System.out.println("VM agent not responding, restarting " + name + "...");
+            incus.forceStop(name);
             incus.start(name);
             incus.waitForReady(name);
         }

--- a/src/main/java/dev/incusspawn/command/ListCommand.java
+++ b/src/main/java/dev/incusspawn/command/ListCommand.java
@@ -3488,6 +3488,11 @@ public class ListCommand extends BaseCommand {
             HostResourceSetup.removeStaleDevices(incus, name);
             incus.start(name);
             incus.waitForReady(name);
+        } else if (incus.isVm(name) && !incus.shellExec(name, "echo", "ready").success()) {
+            System.out.println("VM agent not responding, restarting " + name + "...");
+            incus.forceStop(name);
+            incus.start(name);
+            incus.waitForReady(name);
         }
         ZmxSocketForward.ensureSymlink(name);
         checkGuiHealth(name);

--- a/src/main/java/dev/incusspawn/command/ListCommand.java
+++ b/src/main/java/dev/incusspawn/command/ListCommand.java
@@ -800,7 +800,8 @@ public class ListCommand extends BaseCommand {
         var def = imageDefs.get(sourceName);
         branchEnableGui = (def != null && def.isGui())
                 || "true".equals(incus.configGet(sourceName, Metadata.GUI_ENABLED));
-        branchEnableKvm = false;
+        branchEnableKvm = (def != null && def.isKvm())
+                || "kvm".equals(incus.configGet(sourceName, Metadata.INSTANCE_MODE));
         branchNetworkMode = NetworkMode.FULL;
         branchEnableInbox = false;
         branchInboxInput = new TextInputState("");
@@ -3345,9 +3346,16 @@ public class ListCommand extends BaseCommand {
         }
 
         var prefetched = InstanceLifecycle.prefetchRuntimeConfig(incus, name);
-        InstanceLifecycle.injectSshKeyIfAvailable(incus, name, prefetched.hasSshKeys());
-        InstanceLifecycle.pushTerminfoIfNeeded(incus, name, prefetched.terminfo());
+        boolean isVm = incus.isVm(name);
+        if (!isVm) {
+            InstanceLifecycle.injectSshKeyIfAvailable(incus, name, prefetched.hasSshKeys());
+            InstanceLifecycle.pushTerminfoIfNeeded(incus, name, prefetched.terminfo());
+        }
         incus.start(name);
+        if (isVm) {
+            incus.waitForReady(name);
+            InstanceLifecycle.pushDeferredVmFiles(incus, name, networkMode, prefetched);
+        }
 
         var inbox = (inboxPath != null && !inboxPath.isEmpty()) ? java.nio.file.Path.of(inboxPath) : null;
         InstanceLifecycle.setupRuntime(incus, name, networkMode, inbox, prefetched);

--- a/src/main/java/dev/incusspawn/config/HostResourceSetup.java
+++ b/src/main/java/dev/incusspawn/config/HostResourceSetup.java
@@ -34,6 +34,7 @@ public final class HostResourceSetup {
         if (resolved.startsWith("http://") || resolved.startsWith("https://")) {
             throw new IllegalArgumentException("'path' is required for URL sources: " + source);
         }
+        if (!resolved.startsWith("/")) return "/home/agentuser/" + resolved;
         return resolved;
     }
 
@@ -43,8 +44,8 @@ public final class HostResourceSetup {
         return source;
     }
 
-    public static void addShiftIfSupported(java.util.List<String> args) {
-        if (!Environment.isMacOS()) args.add("shift=true");
+    public static void addShiftIfSupported(java.util.List<String> args, boolean isVm) {
+        if (!isVm && !Environment.isMacOS()) args.add("shift=true");
     }
 
     public static String translateForVm(String hostPath) {
@@ -108,12 +109,13 @@ public final class HostResourceSetup {
         return new ArrayList<>(result.values());
     }
 
-    public static void applyForBuild(IncusClient incus, Container container, List<ImageDef.HostResource> resources) {
+    public static void applyForBuild(IncusClient incus, Container container, List<ImageDef.HostResource> resources,
+                                      boolean isVm) {
         var overlayEntries = new ArrayList<ImageDef.HostResource>();
         for (var hr : resources) {
-            switch (hr.getMode()) {
+            switch (effectiveMode(hr, isVm)) {
                 case "copy" -> applyCopy(container, hr);
-                case "readonly" -> applyReadonly(incus, container.name(), hr);
+                case "readonly" -> applyReadonly(incus, container.name(), hr, isVm);
                 case "overlay" -> {
                     if (Environment.isMacOS()) {
                         throw new IllegalStateException(
@@ -122,7 +124,7 @@ public final class HostResourceSetup {
                                 + "  or remove the host-resource entry to skip it entirely.\n"
                                 + "  Tracking: https://github.com/Sanne/incus-spawn/issues/157");
                     }
-                    applyOverlay(incus, container, hr);
+                    applyOverlay(incus, container, hr, isVm);
                     overlayEntries.add(hr);
                 }
                 default -> System.err.println("Warning: unknown host-resource mode '" + hr.getMode()
@@ -151,12 +153,13 @@ public final class HostResourceSetup {
         }
     }
 
-    public static void applyForInstance(IncusClient incus, String container, List<ImageDef.HostResource> resources) {
+    public static void applyForInstance(IncusClient incus, String container, List<ImageDef.HostResource> resources,
+                                        boolean isVm) {
         for (var hr : resources) {
-            switch (hr.getMode()) {
+            switch (effectiveMode(hr, isVm)) {
                 case "readonly" -> {
                     removeExistingDevice(incus, container, deviceNameForMode(hr));
-                    applyReadonly(incus, container, hr);
+                    applyReadonly(incus, container, hr, isVm);
                 }
                 case "overlay" -> {
                     if (Environment.isMacOS()) {
@@ -167,7 +170,7 @@ public final class HostResourceSetup {
                                 + "  Tracking: https://github.com/Sanne/incus-spawn/issues/157");
                     }
                     removeExistingDevice(incus, container, deviceNameForMode(hr));
-                    applyOverlayDevice(incus, container, hr);
+                    applyOverlayDevice(incus, container, hr, isVm);
                 }
                 case "copy" -> {} // already baked into the template
             }
@@ -211,6 +214,20 @@ public final class HostResourceSetup {
         }
     }
 
+    /**
+     * VMs cannot mount individual files as disk devices (only directories).
+     * Fall back to copy mode for file-level readonly/overlay host resources.
+     */
+    private static String effectiveMode(ImageDef.HostResource hr, boolean isVm) {
+        if (!isVm || "copy".equals(hr.getMode())) return hr.getMode();
+        var expandedSource = expandHostTilde(hr.getSource());
+        if (Files.exists(Path.of(expandedSource)) && !Files.isDirectory(Path.of(expandedSource))) {
+            System.out.println("  VM: falling back to copy mode for file " + hr.getSource());
+            return "copy";
+        }
+        return hr.getMode();
+    }
+
     // --- Private helpers ---
 
     private static void applyCopy(Container container, ImageDef.HostResource hr) {
@@ -248,7 +265,7 @@ public final class HostResourceSetup {
         }
     }
 
-    private static void applyReadonly(IncusClient incus, String container, ImageDef.HostResource hr) {
+    private static void applyReadonly(IncusClient incus, String container, ImageDef.HostResource hr, boolean isVm) {
         var expandedSource = expandHostTilde(hr.getSource());
         if (!Files.exists(Path.of(expandedSource))) {
             System.err.println("Warning: host-resource source not found: " + hr.getSource() + " (skipping)");
@@ -260,12 +277,12 @@ public final class HostResourceSetup {
                 "source=" + translateForVm(expandedSource),
                 "path=" + containerPath,
                 "readonly=true"));
-        addShiftIfSupported(args);
+        addShiftIfSupported(args, isVm);
         incus.deviceAdd(container, devName, "disk", args.toArray(String[]::new));
         System.out.println("  Mounted " + hr.getSource() + " -> " + containerPath + " (readonly)");
     }
 
-    private static void applyOverlay(IncusClient incus, Container container, ImageDef.HostResource hr) {
+    private static void applyOverlay(IncusClient incus, Container container, ImageDef.HostResource hr, boolean isVm) {
         var containerPath = resolveContainerPath(hr.getSource(), hr.getPath());
         var oDir = overlayDir(containerPath);
         var lowerDir = oDir + "/lower";
@@ -282,21 +299,39 @@ public final class HostResourceSetup {
                 "source=" + translateForVm(expandedSource),
                 "path=" + lowerDir,
                 "readonly=true"));
-        addShiftIfSupported(overlayArgs);
+        addShiftIfSupported(overlayArgs, isVm);
         incus.deviceAdd(container.name(), overlayDeviceName(containerPath), "disk",
                 overlayArgs.toArray(String[]::new));
 
         container.exec("mkdir", "-p", upperDir, workDir, containerPath);
         container.exec("chown", "agentuser:agentuser", upperDir);
         chownHomeParents(container, containerPath);
-        container.exec("mount", "-t", "overlay", "overlay",
+
+        if (isVm) {
+            // VM disk devices are mounted asynchronously by incus-agent;
+            // wait for the lower directory to be populated before overlaying.
+            if (!incus.pollUntilReady(container.name(), 15,
+                    "sh", "-c", "mountpoint -q " + lowerDir)) {
+                System.err.println("  Warning: VM device for " + hr.getSource()
+                        + " did not mount in time (skipping overlay)");
+                return;
+            }
+        }
+
+        var mountResult = container.exec("mount", "-t", "overlay", "overlay",
                 "-o", "lowerdir=" + lowerDir + ",upperdir=" + upperDir + ",workdir=" + workDir + ",metacopy=off",
                 containerPath);
+        if (!mountResult.success()) {
+            System.err.println("  Warning: overlay mount failed for " + hr.getSource()
+                    + ": " + mountResult.stderr());
+            return;
+        }
 
         System.out.println("  Mounted " + hr.getSource() + " -> " + containerPath + " (overlay)");
     }
 
-    private static void applyOverlayDevice(IncusClient incus, String container, ImageDef.HostResource hr) {
+    private static void applyOverlayDevice(IncusClient incus, String container, ImageDef.HostResource hr,
+                                            boolean isVm) {
         var containerPath = resolveContainerPath(hr.getSource(), hr.getPath());
         var lowerDir = overlayDir(containerPath) + "/lower";
 
@@ -310,7 +345,7 @@ public final class HostResourceSetup {
                 "source=" + translateForVm(expandedSource),
                 "path=" + lowerDir,
                 "readonly=true"));
-        addShiftIfSupported(devArgs);
+        addShiftIfSupported(devArgs, isVm);
         incus.deviceAdd(container, overlayDeviceName(containerPath), "disk",
                 devArgs.toArray(String[]::new));
     }

--- a/src/main/java/dev/incusspawn/config/ImageDef.java
+++ b/src/main/java/dev/incusspawn/config/ImageDef.java
@@ -90,6 +90,10 @@ public class ImageDef {
     private String imageTag;
     @JsonProperty("image_sha256")
     private Map<String, String> imageSha256;
+    @JsonProperty("vm_image_url")
+    private String vmImageUrl;
+    @JsonProperty("vm_image_sha256")
+    private Map<String, String> vmImageSha256;
     private String parent;
     private List<String> packages = List.of();
     @JsonProperty("remove_packages")
@@ -108,6 +112,7 @@ public class ImageDef {
     private List<String> maskServices = List.of();
     private boolean gui;
     private boolean pinned;
+    private String type;
     private String workdir;
     @JsonProperty("shell-command")
     private String shellCommand;
@@ -131,6 +136,10 @@ public class ImageDef {
     public void setImageTag(String imageTag) { this.imageTag = imageTag; }
     public Map<String, String> getImageSha256() { return imageSha256; }
     public void setImageSha256(Map<String, String> imageSha256) { this.imageSha256 = imageSha256; }
+    public String getVmImageUrl() { return vmImageUrl; }
+    public void setVmImageUrl(String vmImageUrl) { this.vmImageUrl = vmImageUrl; }
+    public Map<String, String> getVmImageSha256() { return vmImageSha256; }
+    public void setVmImageSha256(Map<String, String> vmImageSha256) { this.vmImageSha256 = vmImageSha256; }
     public String getParent() { return parent; }
     public void setParent(String parent) { this.parent = parent; }
     public List<String> getPackages() { return packages; }
@@ -153,6 +162,12 @@ public class ImageDef {
     public void setGui(boolean gui) { this.gui = gui; }
     public boolean isPinned() { return pinned; }
     public void setPinned(boolean pinned) { this.pinned = pinned; }
+    public String getType() { return type; }
+    public void setType(String type) { this.type = type; }
+    public boolean isVm() { return "vm".equals(type); }
+    public boolean isKvm() { return "kvm".equals(type); }
+    @Deprecated
+    public void setVm(boolean vm) { if (vm) this.type = "vm"; }
     public String getWorkdir() { return workdir; }
     public void setWorkdir(String workdir) { this.workdir = workdir; }
     public String getShellCommand() { return shellCommand; }
@@ -318,6 +333,12 @@ public class ImageDef {
                     .forEach(e -> sb.append("image_sha256.").append(e.getKey())
                             .append('=').append(e.getValue()).append('\n'));
         }
+        if (vmImageUrl != null) sb.append("vm_image_url=").append(vmImageUrl).append('\n');
+        if (vmImageSha256 != null) {
+            vmImageSha256.entrySet().stream().sorted(Map.Entry.comparingByKey())
+                    .forEach(e -> sb.append("vm_image_sha256.").append(e.getKey())
+                            .append('=').append(e.getValue()).append('\n'));
+        }
         sb.append("parent=").append(parent != null ? parent : "").append('\n');
         packages.stream().sorted().forEach(p -> sb.append("pkg=").append(p).append('\n'));
         for (var t : tools.stream().sorted(java.util.Comparator.comparing(ToolDef.ToolRef::getName)).toList()) {
@@ -352,6 +373,7 @@ public class ImageDef {
                 .sorted()
                 .forEach(e -> sb.append(e).append('\n'));
         if (gui) sb.append("gui=true\n");
+        if (type != null) sb.append("type=").append(type).append('\n');
         if (workdir != null && !workdir.isEmpty()) sb.append("workdir=").append(workdir).append('\n');
         if (shellCommand != null && !shellCommand.isEmpty()) sb.append("shell-command=").append(shellCommand).append('\n');
         return sha256hex(sb.toString());
@@ -382,6 +404,22 @@ public class ImageDef {
             parentName = parent.getParent();
         }
         return result;
+    }
+
+    /**
+     * Resolve the instance type by walking up the parent chain.
+     * Returns the first non-null {@code type} found, or null if none is set.
+     */
+    public static String resolveType(ImageDef start, Map<String, ImageDef> defs) {
+        if (start.getType() != null) return start.getType();
+        for (var ancestor : ancestors(start, defs)) {
+            if (ancestor.getType() != null) return ancestor.getType();
+        }
+        return null;
+    }
+
+    public static boolean resolveVm(ImageDef start, Map<String, ImageDef> defs) {
+        return "vm".equals(resolveType(start, defs));
     }
 
     /** Whether this image is built from scratch (no parent). */
@@ -422,7 +460,22 @@ public class ImageDef {
             loadFromDirectory(Path.of(expandedPath).resolve("images"), defs, warnings);
         }
         loadFromDirectory(PROJECT_IMAGES_DIR, defs, warnings);
+        inheritTypes(defs);
         return defs;
+    }
+
+    /**
+     * Propagate {@code type} from parent to child when the child doesn't set its own.
+     */
+    private static void inheritTypes(Map<String, ImageDef> defs) {
+        for (var def : defs.values()) {
+            if (def.type == null && !def.isRoot()) {
+                var resolved = resolveType(def, defs);
+                if (resolved != null) {
+                    def.type = resolved;
+                }
+            }
+        }
     }
 
     /**

--- a/src/main/java/dev/incusspawn/incus/Container.java
+++ b/src/main/java/dev/incusspawn/incus/Container.java
@@ -19,6 +19,30 @@ public class Container {
         return name;
     }
 
+    public boolean isVm() {
+        return incus.isVm(name);
+    }
+
+    public void waitForPath(String path) {
+        for (int i = 0; i < 30; i++) {
+            if (exec("test", "-e", path).success()) return;
+            try { Thread.sleep(500); } catch (InterruptedException e) { break; }
+        }
+        throw new IncusException("Timed out waiting for " + path + " in " + name);
+    }
+
+    public void addDiskDevice(String deviceName, String hostSource, String containerPath, boolean readonly) {
+        var args = new java.util.ArrayList<>(java.util.List.of(
+                "source=" + hostSource,
+                "path=" + containerPath));
+        if (readonly) args.add("readonly=true");
+        incus.deviceAdd(name, deviceName, "disk", args.toArray(String[]::new));
+    }
+
+    public void removeDiskDevice(String deviceName) {
+        incus.deviceRemove(name, deviceName);
+    }
+
     /** Run a command as root. Returns the result for inspection. */
     public IncusClient.ExecResult exec(String... command) {
         return incus.shellExec(name, command);

--- a/src/main/java/dev/incusspawn/incus/IncusClient.java
+++ b/src/main/java/dev/incusspawn/incus/IncusClient.java
@@ -381,8 +381,16 @@ public class IncusClient {
     private record UidGid(String uid, String gid) {}
 
     private UidGid getUserUidGid(String container, String username) {
-        var result = shellExec(container, "id", "-u", username);
-        if (!result.success()) {
+        ExecResult result = null;
+        for (int i = 0; i < 5; i++) {
+            result = shellExec(container, "id", "-u", username);
+            if (result.success()) break;
+            try { Thread.sleep(1000); } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                break;
+            }
+        }
+        if (result == null || !result.success()) {
             throw new IncusException("Failed to get UID for user " + username);
         }
         var uid = result.stdout().strip();
@@ -878,6 +886,16 @@ public class IncusClient {
      * server URL instead.
      */
     public void launch(String image, String name, boolean vm) {
+        create(image, name, vm);
+        start(name);
+    }
+
+    /**
+     * Create a new instance from an image without starting it.
+     * Use this when you need to configure the instance (e.g. disk size)
+     * before first boot.
+     */
+    public void create(String image, String name, boolean vm) {
         var http = http();
         var cowPool = findCowPool();
         var body = new LinkedHashMap<String, Object>();
@@ -886,10 +904,7 @@ public class IncusClient {
         body.put("source", resolveImageSource(image));
         if (cowPool != null) body.put("storage", cowPool);
         var resp = http.requestAndWait("POST", "/1.0/instances", body);
-        if (!resp.isSuccess()) throw new IncusException("Failed to launch " + name);
-        var startResp = http.requestAndWait("PUT", "/1.0/instances/" + name + "/state",
-                Map.of("action", "start", "timeout", 30, "force", false));
-        if (!startResp.isSuccess()) throw new IncusException("Failed to start " + name + " after launch");
+        if (!resp.isSuccess()) throw new IncusException("Failed to create " + name);
     }
 
     /**
@@ -1193,6 +1208,12 @@ public class IncusClient {
         return resp.body().path("metadata").path("status").asText("");
     }
 
+    public boolean isVm(String name) {
+        var resp = http().get("/1.0/instances/" + name);
+        if (!resp.isSuccess()) return false;
+        return "virtual-machine".equals(resp.body().path("metadata").path("type").asText(""));
+    }
+
     /**
      * Get a specific config value. Returns empty string if the key is not set.
      */
@@ -1390,5 +1411,11 @@ public class IncusClient {
         if (!resp.isSuccess()) return null;
         var val = resp.body().path("metadata").path("properties").path(key);
         return val.isMissingNode() ? null : val.asText(null);
+    }
+
+    public String getImageType(String fingerprint) {
+        var resp = http().get("/1.0/images/" + fingerprint);
+        if (!resp.isSuccess()) return null;
+        return resp.body().path("metadata").path("type").asText(null);
     }
 }

--- a/src/main/java/dev/incusspawn/incus/Metadata.java
+++ b/src/main/java/dev/incusspawn/incus/Metadata.java
@@ -25,6 +25,7 @@ public final class Metadata {
     public static final String DEFINITION_SHA = PREFIX + "definition-sha";
     public static final String BUILD_SOURCE = PREFIX + "build-source";
     public static final String GUI_ENABLED = PREFIX + "gui-enabled";
+    public static final String INSTANCE_MODE = PREFIX + "instance-mode";
     public static final String KVM_ENABLED = PREFIX + "kvm-enabled";
     public static final String WORKDIR = PREFIX + "workdir";
     public static final String SHELL_COMMAND = PREFIX + "shell-command";

--- a/src/main/java/dev/incusspawn/lifecycle/InstanceLifecycle.java
+++ b/src/main/java/dev/incusspawn/lifecycle/InstanceLifecycle.java
@@ -70,7 +70,9 @@ public final class InstanceLifecycle {
                 Metadata.STATIC_IP, ip,
                 Metadata.STATIC_GATEWAY, gateway));
 
-        pushStaticNetworkConfig(incus, name, ip, gateway, bridgePrefixLen(incus));
+        if (!incus.isVm(name)) {
+            pushStaticNetworkConfig(incus, name, ip, gateway, bridgePrefixLen(incus));
+        }
         return ip;
     }
 
@@ -104,6 +106,25 @@ public final class InstanceLifecycle {
         }
     }
 
+    /**
+     * Push files that can't be written to a stopped VM (file push requires the
+     * incus-agent). Call after {@code incus.start()} + {@code waitForReady()}.
+     */
+    public static void pushDeferredVmFiles(IncusClient incus, String name,
+                                           NetworkMode networkMode, RuntimeConfig prefetched) {
+        if (networkMode != NetworkMode.AIRGAP) {
+            var ip = incus.configGet(name, Metadata.STATIC_IP);
+            var gateway = incus.configGet(name, Metadata.STATIC_GATEWAY);
+            if (!ip.isEmpty() && !gateway.isEmpty()) {
+                pushStaticNetworkConfig(incus, name, ip, gateway, bridgePrefixLen(incus));
+            }
+        }
+        if (prefetched != null) {
+            injectSshKeyIfAvailable(incus, name, prefetched.hasSshKeys());
+            pushTerminfoIfNeeded(incus, name, prefetched.terminfo());
+        }
+    }
+
     public static void tagMetadata(IncusClient incus, String name, String type, String parent) {
         incus.configSetAll(name, Map.of(
                 Metadata.TYPE, type,
@@ -119,7 +140,7 @@ public final class InstanceLifecycle {
         var hostResources = HostResourceSetup.deserialize(hrJson);
         if (!hostResources.isEmpty()) {
             System.out.println("Applying host-resource devices...");
-            HostResourceSetup.applyForInstance(incus, name, hostResources);
+            HostResourceSetup.applyForInstance(incus, name, hostResources, incus.isVm(name));
         }
 
         if (instanceType == InstanceType.INSTANCE) {

--- a/src/main/java/dev/incusspawn/lifecycle/ZmxSocketForward.java
+++ b/src/main/java/dev/incusspawn/lifecycle/ZmxSocketForward.java
@@ -74,7 +74,7 @@ public final class ZmxSocketForward {
         var args = new java.util.ArrayList<>(java.util.List.of(
                 "source=" + containerDir.toAbsolutePath(),
                 "path=" + CONTAINER_ZMX_DIR));
-        HostResourceSetup.addShiftIfSupported(args);
+        HostResourceSetup.addShiftIfSupported(args, false);
         incus.deviceAdd(name, DEVICE_NAME, "disk", args.toArray(String[]::new));
 
         ensureSymlink(zmxDir, name);

--- a/src/main/java/dev/incusspawn/tool/YamlToolSetup.java
+++ b/src/main/java/dev/incusspawn/tool/YamlToolSetup.java
@@ -128,7 +128,12 @@ public class YamlToolSetup implements ToolSetup {
         try {
             var cached = downloadCache.download(dl.getUrl(), dl.getSha256());
 
-            if (dl.isExtractInContainer()) {
+            if (container.isVm()) {
+                // VMs use the incus-agent for file I/O (over vsock), which
+                // cannot handle pushing large files. Mount the host directory
+                // as a disk device and copy locally inside the VM instead.
+                extractOnHostAndMountCopy(dl, cached, container);
+            } else if (dl.isExtractInContainer()) {
                 extractInContainer(dl, cached, container);
             } else {
                 extractOnHostAndPush(dl, cached, container);
@@ -152,6 +157,35 @@ public class YamlToolSetup implements ToolSetup {
 
         for (var linkEntry : dl.getLinks().entrySet()) {
             container.exec("ln", "-sf", linkEntry.getKey(), linkEntry.getValue());
+        }
+    }
+
+    private void extractOnHostAndMountCopy(ToolDef.DownloadEntry dl, Path cached, Container container)
+            throws IOException {
+        var extractDir = Files.createTempDirectory("isx-extract-");
+        var deviceName = "dl-" + def.getName();
+        var mountPath = "/mnt/isx-download";
+        try {
+            extractOnHost(cached, extractDir);
+            ensureWorldReadable(extractDir);
+
+            // Remove stale mount point from a previous tool's download so
+            // waitForPath detects the new virtio-fs mount, not the leftover dir
+            container.exec("rm", "-rf", mountPath);
+            container.addDiskDevice(deviceName, extractDir.toString(), mountPath, true);
+            container.waitForPath(mountPath);
+            container.exec("mkdir", "-p", dl.getExtract());
+            container.runInteractive("Failed to copy download for " + def.getName(),
+                    "cp", "-a", mountPath + "/.", dl.getExtract());
+            container.exec("chmod", "-R", "a+rX", dl.getExtract());
+
+            for (var linkEntry : dl.getLinks().entrySet()) {
+                container.exec("ln", "-sf", linkEntry.getKey(), linkEntry.getValue());
+            }
+        } finally {
+            try { container.removeDiskDevice(deviceName); } catch (Exception ignored) {}
+            try { container.exec("rm", "-rf", mountPath); } catch (Exception ignored) {}
+            deleteRecursive(extractDir);
         }
     }
 

--- a/src/test/java/dev/incusspawn/command/BuildCommandTest.java
+++ b/src/test/java/dev/incusspawn/command/BuildCommandTest.java
@@ -204,7 +204,7 @@ class BuildCommandTest {
         imageDef.setRepos(List.of(repo));
 
         var cmd = new BuildCommand();
-        cmd.cloneRepos(container, imageDef);
+        cmd.cloneRepos(container, imageDef, false);
 
         verify(incus).shellExecInteractiveAsUser("test", "agentuser",
                 "git clone --single-branch -- 'https://github.com/quarkusio/quarkus.git' '/home/agentuser/quarkus'");
@@ -757,7 +757,7 @@ class BuildCommandTest {
         imageDef.setRepos(List.of(repo));
 
         var cmd = new BuildCommand();
-        cmd.cloneRepos(container, imageDef);
+        cmd.cloneRepos(container, imageDef, false);
 
         verify(incus).shellExecInteractiveAsUser("test", "agentuser",
                 "git clone --single-branch --branch 'feature/my branch' -- 'https://github.com/owner/repo.git' '/home/agentuser/repo'");
@@ -782,7 +782,7 @@ class BuildCommandTest {
         imageDef.setRepos(List.of(repo));
 
         var cmd = new BuildCommand();
-        cmd.cloneRepos(container, imageDef);
+        cmd.cloneRepos(container, imageDef, false);
 
         // Clone call + refspec restore, but no prime
         verify(incus, times(2)).shellExecInteractiveAsUser(eq("test"), anyString(), anyString());
@@ -805,9 +805,9 @@ class BuildCommandTest {
         var cmd = spy(new BuildCommand());
         cmd.incus = incus;
         var ref = new BuildCommand.RepoReference("ref-repo", "/mnt/ref/repo");
-        doReturn(ref).when(cmd).tryMountReference(eq(container), eq(repo.getUrl()), any());
+        doReturn(ref).when(cmd).tryMountReference(eq(container), eq(repo.getUrl()), any(), eq(false));
 
-        cmd.cloneRepos(container, imageDef);
+        cmd.cloneRepos(container, imageDef, false);
 
         // Reference clone command
         verify(incus).shellExecInteractiveAsUser("test", "agentuser",
@@ -841,9 +841,9 @@ class BuildCommandTest {
         var cmd = spy(new BuildCommand());
         cmd.incus = incus;
         var ref = new BuildCommand.RepoReference("ref-repo", "/mnt/ref/repo");
-        doReturn(ref).when(cmd).tryMountReference(eq(container), eq(repo.getUrl()), any());
+        doReturn(ref).when(cmd).tryMountReference(eq(container), eq(repo.getUrl()), any(), eq(false));
 
-        cmd.cloneRepos(container, imageDef);
+        cmd.cloneRepos(container, imageDef, false);
 
         // Should fall back to normal clone
         verify(incus).shellExecInteractiveAsUser("test", "agentuser",

--- a/src/test/java/dev/incusspawn/incus/IncusApiLiveTest.java
+++ b/src/test/java/dev/incusspawn/incus/IncusApiLiveTest.java
@@ -130,8 +130,10 @@ class IncusApiLiveTest {
         assertTrue(imagesResp.isSuccess());
 
         String imageFingerprint = null;
+        String imageType = "container";
         for (var img : imagesResp.body().path("metadata")) {
             imageFingerprint = img.path("fingerprint").asText();
+            imageType = img.path("type").asText("container");
             break;
         }
 
@@ -148,7 +150,7 @@ class IncusApiLiveTest {
             // Create (privileged to avoid nested idmap issues in CI/nested environments)
             var createBody = new java.util.LinkedHashMap<String, Object>();
             createBody.put("name", name);
-            createBody.put("type", "container");
+            createBody.put("type", imageType);
             createBody.put("source", java.util.Map.of("type", "image", "fingerprint", imageFingerprint));
             createBody.put("config", java.util.Map.of("security.privileged", "true"));
             var createResp = http.requestAndWait("POST", "/1.0/instances", createBody);
@@ -238,19 +240,18 @@ class IncusApiLiveTest {
     void copyInstance() throws Exception {
         if (skip()) return;
 
-        var imagesResp = http.get("/1.0/images?recursion=1");
-        if (imagesResp.body().path("metadata").size() == 0) {
+        var image = testImage();
+        if (image == null) {
             System.out.println("Skipping copy test: no local images."); return;
         }
-        var fingerprint = imagesResp.body().path("metadata").get(0).path("fingerprint").asText();
         String src = "isx-copy-src-" + System.currentTimeMillis() % 10000;
         String dst = src + "-copy";
 
         try {
             var createBody = new java.util.LinkedHashMap<String, Object>();
             createBody.put("name", src);
-            createBody.put("type", "container");
-            createBody.put("source", java.util.Map.of("type", "image", "fingerprint", fingerprint));
+            createBody.put("type", image.type());
+            createBody.put("source", java.util.Map.of("type", "image", "fingerprint", image.fingerprint()));
             createBody.put("config", java.util.Map.of("security.privileged", "true",
                     "user.test-marker", "original"));
             assertTrue(http.requestAndWait("POST", "/1.0/instances", createBody).isSuccess(),
@@ -285,13 +286,15 @@ class IncusApiLiveTest {
         if (imagesResp.body().path("metadata").size() == 0) {
             System.out.println("Skipping launch test: no local images."); return;
         }
-        var fingerprint = imagesResp.body().path("metadata").get(0).path("fingerprint").asText();
+        var imageNode = imagesResp.body().path("metadata").get(0);
+        var fingerprint = imageNode.path("fingerprint").asText();
+        var imageType = imageNode.path("type").asText("container");
 
         String name = "isx-launch-test-" + System.currentTimeMillis() % 10000;
         try {
             var createBody = new java.util.LinkedHashMap<String, Object>();
             createBody.put("name", name);
-            createBody.put("type", "container");
+            createBody.put("type", imageType);
             createBody.put("source", java.util.Map.of("type", "image", "fingerprint", fingerprint));
             createBody.put("config", java.util.Map.of("security.privileged", "true"));
             var createResp = http.requestAndWait("POST", "/1.0/instances", createBody);
@@ -320,17 +323,16 @@ class IncusApiLiveTest {
     void deviceConfigSet() throws Exception {
         if (skip()) return;
 
-        var imagesResp = http.get("/1.0/images?recursion=1");
-        if (imagesResp.body().path("metadata").size() == 0) {
+        var image = testImage();
+        if (image == null) {
             System.out.println("Skipping deviceConfigSet test: no local images."); return;
         }
-        var fingerprint = imagesResp.body().path("metadata").get(0).path("fingerprint").asText();
         String name = "isx-devset-test-" + System.currentTimeMillis() % 10000;
         try {
             var createBody = new java.util.LinkedHashMap<String, Object>();
             createBody.put("name", name);
-            createBody.put("type", "container");
-            createBody.put("source", java.util.Map.of("type", "image", "fingerprint", fingerprint));
+            createBody.put("type", image.type());
+            createBody.put("source", java.util.Map.of("type", "image", "fingerprint", image.fingerprint()));
             createBody.put("config", java.util.Map.of("security.privileged", "true"));
             assertTrue(http.requestAndWait("POST", "/1.0/instances", createBody).isSuccess());
 
@@ -353,19 +355,22 @@ class IncusApiLiveTest {
     // Exec via WebSocket
     // =========================================================================
 
-    private static String testImageFingerprint() throws Exception {
+    private record TestImage(String fingerprint, String type) {}
+
+    private static TestImage testImage() throws Exception {
         if (skip()) return null;
         var r = http.get("/1.0/images?recursion=1");
         var meta = r.body().path("metadata");
         if (meta.size() == 0) return null;
-        return meta.get(0).path("fingerprint").asText();
+        var img = meta.get(0);
+        return new TestImage(img.path("fingerprint").asText(), img.path("type").asText("container"));
     }
 
-    private static String createAndStartContainer(String name, String fingerprint) throws Exception {
+    private static String createAndStartContainer(String name, TestImage image) throws Exception {
         var body = new java.util.LinkedHashMap<String, Object>();
         body.put("name", name);
-        body.put("type", "container");
-        body.put("source", java.util.Map.of("type", "image", "fingerprint", fingerprint));
+        body.put("type", image.type());
+        body.put("source", java.util.Map.of("type", "image", "fingerprint", image.fingerprint()));
         body.put("config", java.util.Map.of("security.privileged", "true"));
         assertTrue(http.requestAndWait("POST", "/1.0/instances", body).isSuccess());
         assertTrue(http.requestAndWait("PUT", "/1.0/instances/" + name + "/state",
@@ -385,12 +390,12 @@ class IncusApiLiveTest {
     @Timeout(30)
     void execCaptureReturnsStdoutStderrAndExitCode() throws Exception {
         if (skip()) return;
-        var fp = testImageFingerprint();
-        if (fp == null) { System.out.println("Skipping exec test: no images."); return; }
+        var image = testImage();
+        if (image == null) { System.out.println("Skipping exec test: no images."); return; }
 
         String name = "isx-exec-test-" + System.currentTimeMillis() % 10000;
         try {
-            createAndStartContainer(name, fp);
+            createAndStartContainer(name, image);
 
             var result = http.execCapture(name,
                     List.of("sh", "-c", "echo hello-stdout; echo hello-stderr >&2; exit 7"),
@@ -411,12 +416,12 @@ class IncusApiLiveTest {
     @Timeout(30)
     void execCaptureWithUserAndGroup() throws Exception {
         if (skip()) return;
-        var fp = testImageFingerprint();
-        if (fp == null) { System.out.println("Skipping exec user test: no images."); return; }
+        var image = testImage();
+        if (image == null) { System.out.println("Skipping exec user test: no images."); return; }
 
         String name = "isx-execuser-test-" + System.currentTimeMillis() % 10000;
         try {
-            createAndStartContainer(name, fp);
+            createAndStartContainer(name, image);
 
             // Run id as root (uid=0)
             var rootResult = http.execCapture(name, List.of("id", "-u"), 0, 0, "/root", java.util.Map.of());
@@ -448,12 +453,12 @@ class IncusApiLiveTest {
     @Timeout(30)
     void execStreamWritesToOutputStreams() throws Exception {
         if (skip()) return;
-        var fp = testImageFingerprint();
-        if (fp == null) { System.out.println("Skipping execStream test: no images."); return; }
+        var image = testImage();
+        if (image == null) { System.out.println("Skipping execStream test: no images."); return; }
 
         String name = "isx-stream-test-" + System.currentTimeMillis() % 10000;
         try {
-            createAndStartContainer(name, fp);
+            createAndStartContainer(name, image);
 
             var stdoutBuf = new java.io.ByteArrayOutputStream();
             var stderrBuf = new java.io.ByteArrayOutputStream();
@@ -473,12 +478,12 @@ class IncusApiLiveTest {
     @Test
     void getLogReturnsContent() throws Exception {
         if (skip()) return;
-        var fp = testImageFingerprint();
-        if (fp == null) { System.out.println("Skipping log test: no images."); return; }
+        var image = testImage();
+        if (image == null) { System.out.println("Skipping log test: no images."); return; }
 
         String name = "isx-log-test-" + System.currentTimeMillis() % 10000;
         try {
-            createAndStartContainer(name, fp);
+            createAndStartContainer(name, image);
             var logsResp = http.get("/1.0/instances/" + name + "/logs");
             assertTrue(logsResp.isSuccess(), "logs endpoint should return 200");
             var logs = logsResp.body().path("metadata");
@@ -526,19 +531,18 @@ class IncusApiLiveTest {
         if (skip()) return;
 
         // Need a running instance for file push
-        var imagesResp = http.get("/1.0/images?recursion=1");
-        if (imagesResp.body().path("metadata").size() == 0) {
+        var image = testImage();
+        if (image == null) {
             System.out.println("Skipping file push test: no local images.");
             return;
         }
-        var imageFingerprint = imagesResp.body().path("metadata").get(0).path("fingerprint").asText();
         String name = "isx-filepush-test-" + System.currentTimeMillis() % 10000;
 
         try {
             var createBody = new java.util.LinkedHashMap<String, Object>();
             createBody.put("name", name);
-            createBody.put("type", "container");
-            createBody.put("source", java.util.Map.of("type", "image", "fingerprint", imageFingerprint));
+            createBody.put("type", image.type());
+            createBody.put("source", java.util.Map.of("type", "image", "fingerprint", image.fingerprint()));
             createBody.put("config", java.util.Map.of("security.privileged", "true"));
             assertTrue(http.requestAndWait("POST", "/1.0/instances", createBody).isSuccess());
 


### PR DESCRIPTION
Goes together with another PR on incus-spawn-images: https://github.com/Sanne/incus-spawn-images/pull/2

I can't guarantee this is high quality code, but I can say that it allowed me to start a VM with isx, and to run claude + isx within that VM. So I'll consider that progress.

The way it works:

1. You specify `type: vm` in your template.
2. incus-spawn will build your template as VM. If the parent is not a VM, it'll spawn a VM from scratch and apply parents one after another before applying the template.
3. You start/run your instance as any other instance, except you can actually install incus inside it -- allowing full integration testing of, say, incus-spawn.