### PR TITLE
Fix default-action and git remotes when branching from a clone

### DIFF
--- a/src/main/java/dev/incusspawn/command/InstancePrep.java
+++ b/src/main/java/dev/incusspawn/command/InstancePrep.java
@@ -39,6 +39,11 @@ public class InstancePrep {
             return null;
         }
 
+        // Prefer PROFILE (always the leaf template name) for chain resolution;
+        // PARENT may point to a clone when branching from another clone.
+        var profile = incus.configGet(name, Metadata.PROFILE);
+        var templateName = (profile != null && !profile.isEmpty()) ? profile : parent;
+
         var networkMode = incus.configGet(name, Metadata.NETWORK_MODE);
         if (!NetworkMode.AIRGAP.name().equals(networkMode)) {
             if (!ProxyHealthCheck.checkOrWarn(incus)) return null;
@@ -57,7 +62,7 @@ public class InstancePrep {
 
         GuiPassthrough.checkGuiHealth(incus, name);
 
-        return parent;
+        return templateName;
     }
 
     private static void fixCaMismatch(IncusClient incus, String container) {

--- a/src/main/java/dev/incusspawn/command/ListCommand.java
+++ b/src/main/java/dev/incusspawn/command/ListCommand.java
@@ -2241,6 +2241,18 @@ public class ListCommand extends BaseCommand {
         }
     }
 
+    /**
+     * Resolve the template name for chain resolution: prefer PROFILE (always the leaf
+     * template name, even when the instance was branched from another clone) over PARENT.
+     */
+    private static String resolveTemplateName(InstanceInfo instance) {
+        var profile = instance.profile;
+        if (profile != null && !profile.isEmpty() && !"-".equals(profile)) return profile;
+        var parent = instance.parent;
+        if (parent != null && !parent.isEmpty() && !"-".equals(parent)) return parent;
+        return null;
+    }
+
     private List<dev.incusspawn.config.ImageDef> getInheritanceChain(String templateName) {
         var chain = new ArrayList<dev.incusspawn.config.ImageDef>();
         var current = imageDefs.get(templateName);
@@ -2468,7 +2480,8 @@ public class ListCommand extends BaseCommand {
 
     private String resolveDefaultActionRef(InstanceInfo instance) {
         // Walk the template YAML chain (child wins over parent).
-        var chain = getInheritanceChain(instance.parent);
+        var templateName = resolveTemplateName(instance);
+        var chain = templateName != null ? getInheritanceChain(templateName) : List.<dev.incusspawn.config.ImageDef>of();
         if (!chain.isEmpty()) {
             for (int i = chain.size() - 1; i >= 0; i--) {
                 var def = chain.get(i);
@@ -2574,7 +2587,16 @@ public class ListCommand extends BaseCommand {
         return false;
     }
 
-    private String resolveDefaultCommandFromTemplate(String templateName) {
+    private String resolveDefaultCommandFromTemplate(String source) {
+        // When the source is a clone (not a template), resolve via its PROFILE metadata
+        var templateName = source;
+        if (!imageDefs.containsKey(templateName)) {
+            var profile = incus.configGet(source, Metadata.PROFILE);
+            if (profile != null && !profile.isEmpty()) {
+                templateName = profile;
+            }
+        }
+
         String ref = null;
         var chain = getInheritanceChain(templateName);
         if (!chain.isEmpty()) {
@@ -2586,7 +2608,7 @@ public class ListCommand extends BaseCommand {
                 }
             }
         } else {
-            var refValue = incus.configGet(templateName, Metadata.DEFAULT_ACTION);
+            var refValue = incus.configGet(source, Metadata.DEFAULT_ACTION);
             ref = (refValue == null || refValue.isBlank()) ? null : refValue;
         }
         if (ref == null) return null;
@@ -2641,9 +2663,9 @@ public class ListCommand extends BaseCommand {
 
     private java.util.Set<String> collectInstalledTools(InstanceInfo instance) {
         var tools = new java.util.LinkedHashSet<String>();
-        var parent = instance.parent;
-        if (parent == null || parent.isEmpty() || "-".equals(parent)) return tools;
-        var chain = getInheritanceChain(parent);
+        var templateName = resolveTemplateName(instance);
+        if (templateName == null) return tools;
+        var chain = getInheritanceChain(templateName);
         for (var def : chain) {
             for (var toolRef : def.getTools()) {
                 tools.add(toolRef.getName());
@@ -2660,9 +2682,9 @@ public class ListCommand extends BaseCommand {
 
     private java.util.List<ActionContext.RepoInfo> collectRepos(InstanceInfo instance) {
         var repos = new ArrayList<ActionContext.RepoInfo>();
-        var parent = instance.parent;
-        if (parent == null || parent.isEmpty() || "-".equals(parent)) return repos;
-        var chain = getInheritanceChain(parent);
+        var templateName = resolveTemplateName(instance);
+        if (templateName == null) return repos;
+        var chain = getInheritanceChain(templateName);
         for (var def : chain) {
             for (var repo : def.getRepos()) {
                 var path = repo.getPath();

--- a/src/main/java/dev/incusspawn/git/GitRemoteUtils.java
+++ b/src/main/java/dev/incusspawn/git/GitRemoteUtils.java
@@ -170,11 +170,15 @@ public final class GitRemoteUtils {
     public static List<ImageDef.RepoEntry> collectReposForInstance(String instanceName, IncusClient incus) {
         var repos = new ArrayList<ImageDef.RepoEntry>();
         try {
+            // Prefer PROFILE (always the leaf template name) for chain resolution;
+            // PARENT may point to a clone when branching from another clone.
+            var profile = incus.configGet(instanceName, Metadata.PROFILE);
             var parent = incus.configGet(instanceName, Metadata.PARENT);
-            if (parent.isEmpty()) return repos;
+            var templateName = (profile != null && !profile.isEmpty()) ? profile : parent;
+            if (templateName.isEmpty()) return repos;
 
             var allDefs = ImageDef.loadAll();
-            var current = allDefs.get(parent);
+            var current = allDefs.get(templateName);
             while (current != null) {
                 repos.addAll(current.getRepos());
                 if (current.isRoot() || current.getParent() == null) break;


### PR DESCRIPTION
## Summary

- When branching from a clone (not a template), `tagMetadata` sets `PARENT` to the clone name. All template-chain-dependent resolution (`collectInstalledTools`, `collectRepos`, `resolveDefaultActionRef`, `collectReposForInstance`) looks up `PARENT` in `ImageDef.loadAll()`, but clones aren't in that map, so the chain comes back empty. This breaks default-action resolution and prevents git remotes from being added on the host.
- Use `PROFILE` metadata (always the leaf template name, set at build time and preserved through `incus copy`) for template chain resolution, falling back to `PARENT` for backward compatibility.
- Fixes both TUI and CLI code paths (`ListCommand`, `RunCommand` via `InstancePrep`, `AutoRemoteService` via `GitRemoteUtils`).

## Test plan

- [ ] Branch an instance from a template with a `default-action` → verify the default action works (Enter in TUI, `isx run`)
- [ ] Branch a second instance from that clone → verify the default action still works on the clone-of-clone
- [ ] Verify git remotes are added on the host for both branches
- [ ] Verify `isx run <clone-of-clone>` resolves and executes the default action