### PR TITLE
README: add the autonomy pillar to the hero

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ isx onboards agents the way you'd onboard a new teammate:
 - **A real machine of their own.** Each agent gets a full Linux workstation — its own filesystem, init system, networking, and process tree. It can `dnf install`, run Docker Compose, use `strace` and nested containers — everything works, because it *is* a real system, not an app container. Hardware-isolated KVM virtual machines are one flag away for untrusted code.
 - **Zero credential exposure.** API keys and tokens never enter the environment in any form. A host-side TLS proxy injects real credentials upstream, so `claude`, `pi`, `gh`, `git`, and `curl` work unmodified inside — with nothing worth stealing. See [Credential Isolation](#credential-isolation).
 - **Disposable in seconds.** Branch a prepared template like you'd branch a repo — instant copy-on-write clones. Review the agent's work as immutable git commits via [`isx://` remotes](#git-remotes), merge what you like, destroy the rest.
+- **Full autonomy, no babysitting.** Agents run without permission prompts — safe to let run, because the blast radius is the branch: the machine is disposable, the credentials aren't there, the agent acts under its own identity, and its work comes back as commits you review.
 
 Runs on Linux and macOS, on your hardware. Your code and credentials never leave the building.
 


### PR DESCRIPTION
Adds a fourth hero pillar: **Full autonomy, no babysitting.**

Agents running without permission prompts is the productivity payoff of the whole security model — disposable machine, no credentials, own identity, work delivered as reviewable commits — but the README only mentioned it in passing inside the Claude Code section. The new pillar states the claim with its honest bound ("the blast radius is the branch"), rather than implying nothing can go wrong.

The homepage gets the equivalent section when the cast embed lands (separately, #385).

🤖 Generated with [Claude Code](https://claude.com/claude-code)