### PR TITLE
CI: test rebase on latest main

### DIFF
--- a/.github/scripts/run-integration-tests.sh
+++ b/.github/scripts/run-integration-tests.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+# Standalone integration test runner for incus-spawn.
+#
+# Prerequisites: isx and Incus must be installed and initialized (isx init).
+# The MITM proxy must be running (isx proxy start).
+#
+# Usage:
+#   .github/scripts/run-integration-tests.sh               # container only
+#   .github/scripts/run-integration-tests.sh --with-vm      # container + VM
+#
+# What it does:
+#   1. Builds tpl-minimal as a container (and optionally as a VM)
+#   2. Branches an instance from each template
+#   3. Pushes the test script into each instance and runs it
+#   4. Cleans up all test instances
+#
+# The test script (.github/scripts/test-instance.sh) exercises 6 major
+# isx features: proxy interception, git clone, sudo, systemd, DNS, and
+# login shell environment.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TEST_SCRIPT="$SCRIPT_DIR/test-instance.sh"
+WITH_VM=false
+FAILED=false
+
+for arg in "$@"; do
+    case "$arg" in
+        --with-vm) WITH_VM=true ;;
+        *) echo "Unknown argument: $arg"; exit 1 ;;
+    esac
+done
+
+if [ ! -f "$TEST_SCRIPT" ]; then
+    echo "Error: test script not found at $TEST_SCRIPT"
+    exit 1
+fi
+
+cleanup() {
+    echo ""
+    echo "--- Cleanup ---"
+    isx destroy isx-test-container 2>/dev/null || true
+    if $WITH_VM; then
+        isx destroy isx-test-vm 2>/dev/null || true
+    fi
+}
+trap cleanup EXIT
+
+run_tests() {
+    local instance="$1"
+    echo ""
+    echo "--- Running tests in $instance ---"
+    incus file push "$TEST_SCRIPT" "$instance/tmp/"
+    incus exec "$instance" -- bash /tmp/test-instance.sh
+}
+
+# --- Container ---
+echo "=== Building tpl-minimal (container) ==="
+isx build tpl-minimal --yes
+
+echo ""
+echo "=== Branching and starting container ==="
+isx branch isx-test-container --from tpl-minimal --no-start
+incus start isx-test-container
+echo "Waiting for container network..."
+incus exec isx-test-container -- bash -c '
+    systemctl start systemd-networkd 2>/dev/null
+    for i in $(seq 1 30); do
+        ip -4 -o addr show eth0 | grep -q "inet " && break
+        sleep 0.5
+    done'
+
+run_tests isx-test-container || FAILED=true
+
+# --- VM (optional) ---
+if $WITH_VM; then
+    echo ""
+    echo "=== Building tpl-minimal --type vm ==="
+    isx build tpl-minimal --type vm --yes
+
+    echo ""
+    echo "=== Branching and starting VM ==="
+    isx branch isx-test-vm --from tpl-minimal --no-start
+    incus start isx-test-vm
+    echo "Waiting for VM agent..."
+    for i in $(seq 1 60); do
+        if incus exec isx-test-vm -- true 2>/dev/null; then
+            echo "VM agent ready after ${i}s"
+            break
+        fi
+        sleep 1
+    done
+
+    run_tests isx-test-vm || FAILED=true
+fi
+
+if $FAILED; then
+    echo ""
+    echo "SOME TESTS FAILED"
+    exit 1
+fi
+
+echo ""
+echo "ALL TESTS PASSED"

--- a/.github/scripts/test-instance.sh
+++ b/.github/scripts/test-instance.sh
@@ -1,0 +1,138 @@
+#!/bin/bash
+# Functional integration tests for incus-spawn instances.
+# Exercises end-to-end behavior: proxy interception, git, sudo, systemd.
+#
+# Usage: incus file push test-instance.sh <instance>/tmp/
+#        incus exec <instance> -- bash /tmp/test-instance.sh
+
+TESTS=0
+PASS=0
+FAIL=0
+ERRORS=""
+
+assert() {
+    local desc="$1"; shift
+    local output
+    TESTS=$((TESTS + 1))
+    if output=$("$@" 2>&1); then
+        printf '  \033[32mPASS\033[0m  %s\n' "$desc"
+        PASS=$((PASS + 1))
+    else
+        printf '  \033[31mFAIL\033[0m  %s\n' "$desc"
+        if [ -n "$output" ]; then
+            printf '         %s\n' "$output" | head -5
+        fi
+        FAIL=$((FAIL + 1))
+        ERRORS="${ERRORS}  - ${desc}\n"
+    fi
+}
+
+assert_eq() {
+    local desc="$1" expected="$2"; shift 2
+    local actual
+    actual=$("$@" 2>/dev/null)
+    TESTS=$((TESTS + 1))
+    if [ "$actual" = "$expected" ]; then
+        printf '  \033[32mPASS\033[0m  %s\n' "$desc"
+        PASS=$((PASS + 1))
+    else
+        printf '  \033[31mFAIL\033[0m  %s  (expected: %s, got: %s)\n' "$desc" "$expected" "$actual"
+        FAIL=$((FAIL + 1))
+        ERRORS="${ERRORS}  - ${desc} (expected '${expected}', got '${actual}')\n"
+    fi
+}
+
+echo "========================================"
+echo " incus-spawn functional integration tests"
+echo "========================================"
+echo ""
+
+# --- 1. Maven artifact download (MITM proxy interception) ---
+# Verifies the full MITM chain: DNS override resolves repo1.maven.org
+# to the bridge gateway, iptables redirects :443 to the proxy on :18443,
+# proxy terminates TLS with its CA, re-encrypts to upstream Maven Central.
+echo "[1] Maven Artifact Download (Proxy Interception)"
+assert "download Maven POM through proxy" \
+    bash -c "curl -sf https://repo1.maven.org/maven2/junit/junit/4.13.2/junit-4.13.2.pom \
+        | grep -q '<artifactId>junit</artifactId>'"
+assert "download Maven JAR checksum through proxy" \
+    bash -c "curl -sf https://repo1.maven.org/maven2/junit/junit/4.13.2/junit-4.13.2.jar.sha1 \
+        | grep -qE '^[0-9a-f]{40}$'"
+echo ""
+
+# --- 2. Git clone over HTTPS (proxy + git) ---
+# Tests GitHub domain interception. The proxy relays without injecting
+# auth for public repos (no GitHub token configured on CI).
+echo "[2] Git Clone over HTTPS (Proxy)"
+assert "clone public GitHub repo through proxy" \
+    bash -c "rm -rf /tmp/test-clone && \
+        git clone --depth 1 -q https://github.com/octocat/Hello-World.git /tmp/test-clone && \
+        test -d /tmp/test-clone/.git"
+assert "cloned repo has commits" \
+    bash -c "cd /tmp/test-clone && git log --oneline | head -1 | grep -q ."
+rm -rf /tmp/test-clone
+echo ""
+
+# --- 3. Passwordless sudo ---
+# isx creates agentuser with a sudoers rule during template build.
+echo "[3] Passwordless Sudo"
+assert "agentuser can sudo without password" \
+    su -l agentuser -c "sudo -n true"
+assert "agentuser can run commands as root via sudo" \
+    su -l agentuser -c "sudo cat /etc/shadow"
+echo ""
+
+# --- 4. Systemd service lifecycle ---
+# Full system containers run systemd as init — services, timers, and
+# nested containers all work, unlike Docker-style app containers.
+echo "[4] Systemd Service Lifecycle"
+cat > /etc/systemd/system/isx-test.service << 'UNIT'
+[Service]
+Type=oneshot
+ExecStart=/bin/touch /tmp/isx-service-ran
+UNIT
+systemctl daemon-reload
+rm -f /tmp/isx-service-ran
+assert "start a oneshot systemd service" systemctl start isx-test
+assert "service produced its side effect" test -f /tmp/isx-service-ran
+assert "systemctl reports service as inactive (finished)" \
+    bash -c "systemctl is-active isx-test 2>&1 | grep -q inactive"
+rm -f /tmp/isx-service-ran /etc/systemd/system/isx-test.service
+echo ""
+
+# --- 5. DNS interception ---
+# Intercepted domains (Maven, GitHub, Docker) resolve to the bridge
+# gateway where the proxy listens, not their real IPs. This is how isx
+# routes traffic through the proxy without modifying any tools.
+echo "[5] DNS Interception"
+gateway=$(grep nameserver /etc/resolv.conf | head -1 | cut -d' ' -f2)
+assert "repo1.maven.org resolves to proxy gateway" \
+    bash -c "getent ahostsv4 repo1.maven.org | grep -q '$gateway'"
+assert "github.com resolves to proxy gateway" \
+    bash -c "getent ahostsv4 github.com | grep -q '$gateway'"
+echo ""
+
+# --- 6. Login shell environment ---
+# isx sets ISX_TEMPLATE and ISX_CONTAINER in agentuser's .bashrc so
+# tools can detect they're running inside an isx container.
+echo "[6] Login Shell Environment"
+assert_eq "ISX_TEMPLATE is tpl-minimal" "tpl-minimal" \
+    su -l agentuser -c 'bash -c "source ~/.bashrc 2>/dev/null; echo \$ISX_TEMPLATE"'
+assert "ISX_CONTAINER is set (matches hostname)" \
+    su -l agentuser -c 'bash -c "source ~/.bashrc 2>/dev/null; test -n \"\$ISX_CONTAINER\""'
+echo ""
+
+echo "========================================"
+printf " Results: \033[1m%d/%d passed\033[0m" "$PASS" "$TESTS"
+if [ "$FAIL" -gt 0 ]; then
+    printf ", \033[31m%d failed\033[0m" "$FAIL"
+fi
+echo ""
+echo "========================================"
+
+if [ "$FAIL" -gt 0 ]; then
+    echo ""
+    echo "Failed tests:"
+    printf "$ERRORS"
+    exit 1
+fi

--- a/.github/scripts/test-podman.sh
+++ b/.github/scripts/test-podman.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+# Tests rootless podman inside an incus-spawn container.
+# Validates subordinate UID/GID support (security.idmap.size + subuid/subgid)
+# by running a PostgreSQL container as agentuser without root privileges.
+#
+# Usage: incus file push test-podman.sh <instance>/tmp/
+#        incus exec <instance> -- bash /tmp/test-podman.sh
+
+set -uo pipefail
+
+PASS=0
+FAIL=0
+ERRORS=""
+
+assert_eq() {
+    local desc="$1" expected="$2"; shift 2
+    local actual
+    actual=$("$@" 2>/dev/null) || true
+    if [ "$actual" = "$expected" ]; then
+        printf '  \033[32mPASS\033[0m  %s\n' "$desc"
+        PASS=$((PASS + 1))
+    else
+        printf '  \033[31mFAIL\033[0m  %s  (expected: %s, got: %s)\n' "$desc" "$expected" "$actual"
+        FAIL=$((FAIL + 1))
+        ERRORS="${ERRORS}  - ${desc} (expected '${expected}', got '${actual}')\n"
+    fi
+}
+
+echo "========================================"
+echo " Rootless podman integration test"
+echo "========================================"
+echo ""
+
+echo "[1] Rootless PostgreSQL via podman"
+
+# Diagnostics — helps debug user namespace issues
+echo "  subuid: $(cat /etc/subuid)"
+echo "  subgid: $(cat /etc/subgid)"
+echo "  newuidmap: $(which newuidmap 2>&1 || echo 'not found')"
+echo "  newuidmap perms: $(ls -la "$(which newuidmap 2>/dev/null)" 2>&1 || echo 'n/a')"
+echo "  user_namespaces max: $(cat /proc/sys/user/max_user_namespaces 2>/dev/null || echo 'unknown')"
+echo "  unprivileged_userns_clone: $(cat /proc/sys/kernel/unprivileged_userns_clone 2>/dev/null || echo 'not present')"
+echo "  apparmor: $(cat /sys/module/apparmor/parameters/enabled 2>/dev/null || echo 'unknown')"
+su -l agentuser -c "id"
+echo "  unshare --user test:"
+su -l agentuser -c "unshare --user true" 2>&1 && echo "    OK" || echo "    FAILED"
+su -l agentuser -c "podman info --format '{{.Host.IDMappings.UIDMap}}'" 2>&1 || true
+
+# Run PostgreSQL as agentuser (rootless podman).
+# This requires working subordinate UID/GID mappings:
+# - security.idmap.size must cover the subordinate range
+# - /etc/subuid and /etc/subgid must have entries for agentuser
+echo "  Pulling PostgreSQL image (with retries)..."
+pull_ok=false
+for attempt in 1 2 3; do
+    if su -l agentuser -c 'podman pull docker.io/library/postgres:17-alpine' 2>&1; then
+        pull_ok=true
+        break
+    fi
+    echo "  Pull attempt $attempt failed, retrying..."
+    sleep 2
+done
+
+echo "  Starting PostgreSQL container as agentuser (rootless)..."
+if ! $pull_ok; then
+    echo "  FAIL: podman pull failed after 3 attempts"
+    FAIL=$((FAIL + 1))
+    ERRORS="${ERRORS}  - podman pull failed\n"
+elif ! su -l agentuser -c '
+    podman run -d --name test-pg \
+        -e POSTGRES_PASSWORD=testpass \
+        -p 15432:5432 \
+        docker.io/library/postgres:17-alpine
+' 2>&1; then
+    echo "  FAIL: podman run failed (see diagnostics above)"
+    FAIL=$((FAIL + 1))
+    ERRORS="${ERRORS}  - podman run failed\n"
+else
+    echo "  Waiting for PostgreSQL to be ready..."
+    pg_ready=false
+    for i in $(seq 1 30); do
+        if su -l agentuser -c "podman exec test-pg pg_isready -U postgres" >/dev/null 2>&1; then
+            echo "  PostgreSQL ready after ${i}s"
+            pg_ready=true
+            break
+        fi
+        sleep 1
+    done
+    if ! $pg_ready; then
+        echo "  PostgreSQL did not become ready within 30s"
+        su -l agentuser -c "podman logs test-pg" 2>&1 | tail -20
+        FAIL=$((FAIL + 1))
+        ERRORS="${ERRORS}  - PostgreSQL did not start\n"
+    else
+        assert_eq "SELECT 1 returns 1" "1" \
+            su -l agentuser -c "podman exec test-pg psql -U postgres -tAc 'SELECT 1'"
+    fi
+fi
+
+echo ""
+echo "  Cleaning up..."
+su -l agentuser -c "podman rm -f test-pg" >/dev/null 2>&1
+
+echo ""
+echo "========================================"
+TOTAL=$((PASS + FAIL))
+printf " Results: \033[1m%d/%d passed\033[0m" "$PASS" "$TOTAL"
+if [ "$FAIL" -gt 0 ]; then
+    printf ", \033[31m%d failed\033[0m" "$FAIL"
+fi
+echo ""
+echo "========================================"
+
+if [ "$FAIL" -gt 0 ]; then
+    echo ""
+    echo "Failed tests:"
+    printf "$ERRORS"
+    exit 1
+fi

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -121,3 +121,184 @@ jobs:
           name: vm-console-log
           path: vm-console.log
           retention-days: 7
+
+  isx-integration-tests:
+    needs: [unit-tests]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install Incus
+        run: |
+          curl -fsSL https://pkgs.zabbly.com/key.asc | gpg --dearmor \
+            | sudo tee /etc/apt/keyrings/zabbly.gpg >/dev/null
+          codename=$(. /etc/os-release && echo "$VERSION_CODENAME")
+          echo "deb [signed-by=/etc/apt/keyrings/zabbly.gpg] https://pkgs.zabbly.com/incus/stable $codename main" \
+            | sudo tee /etc/apt/sources.list.d/zabbly-incus-stable.list
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq incus btrfs-progs qemu-system-x86
+          sudo usermod -aG incus-admin "$USER"
+
+          # Pre-initialize Incus and create a small btrfs CoW pool so
+          # isx init doesn't hang creating an unbounded one (timed out at 19min on CI).
+          # Use sudo for both commands — admin init creates ~/.config/incus/config.yml
+          # as root, so subsequent commands must also use sudo to read it.
+          sg incus-admin -c "sudo incus admin init --minimal"
+          sudo chown -R "$USER:$USER" ~/.config/incus/
+          sg incus-admin -c "incus storage create cow btrfs size=5GiB"
+
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
+            | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Install Oracle GraalVM JDK 25
+        uses: graalvm/setup-graalvm@v1
+        with:
+          java-version: '25'
+          distribution: 'graalvm'
+
+      - name: Build and install isx
+        run: |
+          mvn package -DskipTests -q
+          mkdir -p "$HOME/.local/bin"
+          printf '#!/bin/sh\nexec java -jar %s/target/quarkus-app/quarkus-run.jar "$@"\n' "$PWD" \
+            > "$HOME/.local/bin/isx"
+          chmod +x "$HOME/.local/bin/isx"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Initialize isx
+        run: |
+          # Run isx init non-interactively (empty stdin skips all prompts)
+          sg incus-admin -c "yes '' | isx init"
+
+      - name: Start MITM proxy
+        run: |
+          # Set a placeholder API key so the proxy starts (it needs claude.hasAuth() == true)
+          sed -i 's/apiKey: ""/apiKey: "sk-ant-placeholder-for-ci"/' \
+              ~/.config/incus-spawn/config.yaml
+
+          # Start the proxy in the background (no systemd user session on CI)
+          sg incus-admin -c "isx proxy start" &
+
+          # Wait for the proxy health endpoint
+          GATEWAY=$(sg incus-admin -c "incus network get incusbr0 ipv4.address" | cut -d/ -f1)
+          echo "Waiting for proxy..."
+          for i in $(seq 1 30); do
+            if curl -sf "http://$GATEWAY:18080/health" >/dev/null 2>&1; then
+              echo "Proxy ready after ${i}s"
+              break
+            fi
+            if [ "$i" -eq 30 ]; then
+              echo "::error::Proxy did not become healthy within 30s"
+              exit 1
+            fi
+            sleep 1
+          done
+
+      - name: 'Container: build tpl-minimal'
+        run: sg incus-admin -c "isx build tpl-minimal --yes"
+
+      - name: 'Container: branch and start'
+        run: |
+          sg incus-admin -c "isx branch test-container --from tpl-minimal --no-start"
+          sg incus-admin -c "incus start test-container"
+          # Wait for network — isx branch normally does this in setupRuntime,
+          # but --no-start skips it. Without DHCP, DNS queries can't be sent.
+          echo "Waiting for container network..."
+          sg incus-admin -c "incus exec test-container -- bash -c '
+            systemctl start systemd-networkd 2>/dev/null
+            for i in \$(seq 1 30); do
+              ip -4 -o addr show eth0 | grep -q \"inet \" && break
+              sleep 0.5
+            done'"
+          echo "Container network ready"
+
+      - name: 'Container: run integration tests'
+        run: |
+          sg incus-admin -c "incus file push .github/scripts/test-instance.sh test-container/tmp/"
+          sg incus-admin -c "incus exec test-container -- bash /tmp/test-instance.sh"
+
+      - name: 'Container: cleanup'
+        if: always()
+        run: sg incus-admin -c "isx destroy test-container" || true
+
+      - name: 'Podman: allow unprivileged user namespaces'
+        run: |
+          # Ubuntu 24.04 restricts unprivileged user namespace creation via AppArmor.
+          # Rootless podman inside Incus containers needs user namespaces for UID mapping.
+          sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+
+      - name: 'Podman: create test template and build'
+        run: |
+          mkdir -p ~/.config/incus-spawn/images
+          cat > ~/.config/incus-spawn/images/test-podman.yaml << 'EOF'
+          name: tpl-test-podman
+          parent: tpl-minimal
+          packages:
+            - podman
+            - fuse-overlayfs
+          EOF
+          sg incus-admin -c "isx build tpl-test-podman --yes"
+
+      - name: 'Podman: branch and start'
+        run: |
+          sg incus-admin -c "isx branch test-podman --from tpl-test-podman --no-start"
+          sg incus-admin -c "incus start test-podman"
+          echo "Waiting for container network..."
+          sg incus-admin -c "incus exec test-podman -- bash -c '
+            systemctl start systemd-networkd 2>/dev/null
+            for i in \$(seq 1 30); do
+              ip -4 -o addr show eth0 | grep -q \"inet \" && break
+              sleep 0.5
+            done'"
+          echo "Container network ready"
+
+      - name: 'Podman: check container config'
+        run: |
+          echo "security.nesting: $(sg incus-admin -c 'incus config get test-podman security.nesting')"
+          echo "security.idmap.size: $(sg incus-admin -c 'incus config get test-podman security.idmap.size')"
+          echo "raw.idmap: $(sg incus-admin -c 'incus config get test-podman raw.idmap')"
+          echo "raw.lxc: $(sg incus-admin -c 'incus config get test-podman raw.lxc')"
+
+      - name: 'Podman: run rootless PostgreSQL'
+        run: |
+          sg incus-admin -c "incus file push .github/scripts/test-podman.sh test-podman/tmp/"
+          sg incus-admin -c "incus exec test-podman -- bash /tmp/test-podman.sh"
+
+      - name: 'Podman: cleanup'
+        if: always()
+        run: sg incus-admin -c "isx destroy test-podman" || true
+
+      - name: 'VM: build tpl-minimal --type vm'
+        run: sg incus-admin -c "isx build tpl-minimal --type vm --yes"
+
+      - name: 'VM: branch and start'
+        run: |
+          sg incus-admin -c "isx branch test-vm --from tpl-minimal --no-start"
+          sg incus-admin -c "incus start test-vm"
+          echo "Waiting for VM agent..."
+          for i in $(seq 1 60); do
+            if sg incus-admin -c "incus exec test-vm -- true" 2>/dev/null; then
+              echo "VM agent ready after ${i}s"
+              break
+            fi
+            if [ "$i" -eq 60 ]; then
+              echo "::error::VM agent did not become ready within 60s"
+              exit 1
+            fi
+            sleep 1
+          done
+
+      - name: 'VM: run integration tests'
+        run: |
+          sg incus-admin -c "incus file push .github/scripts/test-instance.sh test-vm/tmp/"
+          sg incus-admin -c "incus exec test-vm -- bash /tmp/test-instance.sh"
+
+      - name: 'VM: cleanup'
+        if: always()
+        run: sg incus-admin -c "isx destroy test-vm" || true


### PR DESCRIPTION
Test run after rebasing on latest main. Removed firewalld/iptables workarounds since isx init now handles them.