### PR TITLE
Add AKI/SKI to MITM certs and built-in headroom tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -580,6 +580,19 @@ zmx run isx-my-branch git status      # run a command in the container's session
 
 All zmx commands work natively, including interactive `zmx attach`. On macOS, where Incus runs inside a VM, host-side socket sharing is not available. zmx sessions still work inside containers — `isx shell` (or Enter in the TUI) auto-attaches, and sessions persist across disconnections.
 
+### Context Optimization (headroom)
+
+The built-in `headroom` tool installs [Headroom](https://github.com/nicobrenner/headroom), a context optimization proxy for Claude Code. It runs as a local proxy on port 8787 that compresses conversation context, reducing token usage and improving response quality on long sessions. An MCP server is also registered with Claude Code for direct integration.
+
+```yaml
+name: tpl-agent
+parent: tpl-java
+tools:
+  - headroom    # auto-installs claude via requires
+```
+
+The tool sets `ANTHROPIC_BASE_URL=http://localhost:8787` so Claude Code routes through the optimization proxy. The proxy runs as a systemd user service and starts automatically on container boot.
+
 ### Tool Parameters
 
 Tools can define parameters for build-time configuration. Parameter types: `string` (with optional `pattern`), `integer` (with `min`/`max`), `boolean`, and `enum` (with `options`). Use `${param_name}` to reference values in scripts, env, and file content:

--- a/src/main/java/dev/incusspawn/DerEncoder.java
+++ b/src/main/java/dev/incusspawn/DerEncoder.java
@@ -24,15 +24,19 @@ public final class DerEncoder {
 
     // --- Extension OIDs ---
 
-    private static final byte[] OID_BASIC_CONSTRAINTS = {0x06, 0x03, 0x55, 0x1d, 0x13}; // 2.5.29.19
-    private static final byte[] OID_SUBJECT_ALT_NAME  = {0x06, 0x03, 0x55, 0x1d, 0x11}; // 2.5.29.17
-    private static final byte[] OID_KEY_USAGE          = {0x06, 0x03, 0x55, 0x1d, 0x0f}; // 2.5.29.15
+    private static final byte[] OID_BASIC_CONSTRAINTS        = {0x06, 0x03, 0x55, 0x1d, 0x13}; // 2.5.29.19
+    private static final byte[] OID_SUBJECT_ALT_NAME         = {0x06, 0x03, 0x55, 0x1d, 0x11}; // 2.5.29.17
+    private static final byte[] OID_KEY_USAGE                 = {0x06, 0x03, 0x55, 0x1d, 0x0f}; // 2.5.29.15
+    private static final byte[] OID_SUBJECT_KEY_IDENTIFIER   = {0x06, 0x03, 0x55, 0x1d, 0x0e}; // 2.5.29.14
+    private static final byte[] OID_AUTHORITY_KEY_IDENTIFIER = {0x06, 0x03, 0x55, 0x1d, 0x23}; // 2.5.29.35
 
     public static byte[] sha256WithRsaAid()    { return SHA256_WITH_RSA_AID.clone(); }
     public static byte[] sha384WithEcdsaAid()  { return SHA384_WITH_ECDSA_AID.clone(); }
     public static byte[] oidBasicConstraints() { return OID_BASIC_CONSTRAINTS.clone(); }
     public static byte[] oidSubjectAltName()   { return OID_SUBJECT_ALT_NAME.clone(); }
-    public static byte[] oidKeyUsage()         { return OID_KEY_USAGE.clone(); }
+    public static byte[] oidKeyUsage()                { return OID_KEY_USAGE.clone(); }
+    public static byte[] oidSubjectKeyIdentifier()   { return OID_SUBJECT_KEY_IDENTIFIER.clone(); }
+    public static byte[] oidAuthorityKeyIdentifier() { return OID_AUTHORITY_KEY_IDENTIFIER.clone(); }
 
     // --- Core DER primitives ---
 

--- a/src/main/java/dev/incusspawn/proxy/CertStore.java
+++ b/src/main/java/dev/incusspawn/proxy/CertStore.java
@@ -86,6 +86,8 @@ public class CertStore {
         } catch (Exception e) {
             return false;
         }
+        // Re-mint if the cert lacks AKI (pre-fix certs without RFC 5280 extensions).
+        if (cert.getExtensionValue("2.5.29.35") == null) return false;
         // Re-mint if expired or close to expiry.
         return cert.getNotAfter().after(new Date(System.currentTimeMillis() + RENEW_BEFORE_EXPIRY_MS));
     }

--- a/src/main/java/dev/incusspawn/proxy/CertificateAuthority.java
+++ b/src/main/java/dev/incusspawn/proxy/CertificateAuthority.java
@@ -12,7 +12,9 @@ import java.nio.file.Path;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.security.KeyFactory;
 import java.security.KeyPairGenerator;
+import java.security.MessageDigest;
 import java.security.PrivateKey;
+import java.security.PublicKey;
 import java.security.SecureRandom;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
@@ -89,6 +91,11 @@ public class CertificateAuthority {
             var expiry = new Date(notBefore.getTime() + 366L * 24 * 60 * 60 * 1000);
             var serial = new BigInteger(128, new SecureRandom());
 
+            var caKeyId = computeKeyIdentifier(caCert.getPublicKey());
+            // AKI value: SEQUENCE { [0] IMPLICIT KeyIdentifier }
+            var akiValue = derSequence(concat(
+                    new byte[]{(byte) 0x80}, derLength(caKeyId.length), caKeyId));
+
             var algId = sha256WithRsaAid();
             var tbsCert = derSequence(concat(
                     derExplicit(0, derInteger(BigInteger.valueOf(2))),   // v3
@@ -102,7 +109,10 @@ public class CertificateAuthority {
                             derExtension(oidBasicConstraints(), true,
                                     derSequence(new byte[]{0x01, 0x01, 0x00})),
                             derExtension(oidSubjectAltName(), false,
-                                    derSequence(derDnsName(domain)))
+                                    derSequence(derDnsName(domain))),
+                            derExtension(oidSubjectKeyIdentifier(), false,
+                                    derOctetString(computeKeyIdentifier(keyPair.getPublic()))),
+                            derExtension(oidAuthorityKeyIdentifier(), false, akiValue)
                     )))
             ));
 
@@ -182,6 +192,51 @@ public class CertificateAuthority {
 
     // --- Private helpers ---
 
+    /**
+     * Compute the key identifier per RFC 5280 §4.2.1.2 method 1:
+     * SHA-1 hash of the BIT STRING subjectPublicKey value (excluding
+     * tag, length, and unused-bits octet) from SubjectPublicKeyInfo.
+     */
+    static byte[] computeKeyIdentifier(PublicKey key) throws Exception {
+        var spki = key.getEncoded();
+        // SubjectPublicKeyInfo = SEQUENCE { AlgorithmIdentifier, BIT STRING }
+        // Skip outer SEQUENCE tag+length, then skip AlgorithmIdentifier TLV
+        int pos = 1 + derLengthSize(spki, 1);
+        pos += tlvLength(spki, pos);
+        // Now at BIT STRING: skip tag, length, unused-bits byte
+        pos += 1 + derLengthSize(spki, pos + 1) + 1;
+        var keyBytes = new byte[spki.length - pos];
+        System.arraycopy(spki, pos, keyBytes, 0, keyBytes.length);
+        return MessageDigest.getInstance("SHA-1").digest(keyBytes);
+    }
+
+    /** Return the number of bytes in a DER length field starting at {@code offset}. */
+    private static int derLengthSize(byte[] data, int offset) {
+        int first = data[offset] & 0xff;
+        if (first < 128) return 1;
+        return 1 + (first & 0x7f);
+    }
+
+    /** Return the total TLV (tag + length + value) byte count of the element at {@code offset}. */
+    private static int tlvLength(byte[] data, int offset) {
+        int start = offset;
+        offset++; // skip tag
+        int first = data[offset] & 0xff;
+        int len;
+        if (first < 128) {
+            len = first;
+            offset++;
+        } else {
+            int numBytes = first & 0x7f;
+            len = 0;
+            offset++;
+            for (int i = 0; i < numBytes; i++) {
+                len = (len << 8) | (data[offset++] & 0xff);
+            }
+        }
+        return (offset - start) + len;
+    }
+
     private static CertificateAuthority load() throws Exception {
         var key = loadPrivateKey(caKeyFile());
         var cert = loadCertificate(caCertFile());
@@ -216,7 +271,9 @@ public class CertificateAuthority {
                 derExplicit(3, derSequence(concat(
                         derExtension(oidBasicConstraints(), true,
                                 derSequence(new byte[]{0x01, 0x01, (byte) 0xff})),
-                        derExtension(oidKeyUsage(), true, keyUsageBits)
+                        derExtension(oidKeyUsage(), true, keyUsageBits),
+                        derExtension(oidSubjectKeyIdentifier(), false,
+                                derOctetString(computeKeyIdentifier(keyPair.getPublic())))
                 )))
         ));
 

--- a/src/main/java/dev/incusspawn/tool/ToolDefLoader.java
+++ b/src/main/java/dev/incusspawn/tool/ToolDefLoader.java
@@ -23,6 +23,7 @@ public class ToolDefLoader {
 
     private static final String RESOURCE_DIR = "tools/";
     private static final List<String> BUILTIN_TOOLS = List.of(
+            "headroom.yaml",
             "podman.yaml",
             "maven-3.yaml",
             "sshd.yaml",

--- a/src/main/resources/tools/headroom.yaml
+++ b/src/main/resources/tools/headroom.yaml
@@ -1,0 +1,44 @@
+name: headroom
+description: Headroom context optimization for Claude Code
+requires:
+  - claude
+
+packages:
+  - python3-pip
+
+run:
+  - loginctl enable-linger agentuser
+  - |
+    mkdir -p /etc/systemd/system/user@.service.d
+    cat > /etc/systemd/system/user@.service.d/xdg-runtime.conf << 'EOF'
+    [Service]
+    Environment=XDG_RUNTIME_DIR=/run/user/%i
+    EOF
+
+run_as_user:
+  - pip install --user --quiet 'headroom-ai[proxy,mcp]'
+  - claude mcp add headroom -s user -- headroom mcp serve
+  - |
+    mkdir -p ~/.config/systemd/user/default.target.wants
+    cat > ~/.config/systemd/user/headroom-proxy.service << 'EOF'
+    [Unit]
+    Description=Headroom optimization proxy
+    After=network.target
+
+    [Service]
+    ExecStart=%h/.local/bin/headroom proxy
+    Restart=on-failure
+    RestartSec=3
+
+    [Install]
+    WantedBy=default.target
+    EOF
+    ln -sf ../headroom-proxy.service ~/.config/systemd/user/default.target.wants/headroom-proxy.service
+
+env:
+  - name: ANTHROPIC_BASE_URL
+    value: "http://localhost:8787"
+
+verify: /home/agentuser/.local/bin/headroom --version
+
+ready: curl -sf http://localhost:8787/livez

--- a/src/test/java/dev/incusspawn/proxy/CertStoreTest.java
+++ b/src/test/java/dev/incusspawn/proxy/CertStoreTest.java
@@ -1,14 +1,23 @@
 package dev.incusspawn.proxy;
 
+import dev.incusspawn.DerEncoder;
 import dev.incusspawn.config.SpawnConfig;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import java.io.ByteArrayInputStream;
+import java.math.BigInteger;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.security.KeyPairGenerator;
+import java.security.SecureRandom;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import java.util.Date;
 
+import static dev.incusspawn.DerEncoder.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 class CertStoreTest {
@@ -78,5 +87,90 @@ class CertStoreTest {
         // is comfortably in the past relative to now.
         assertTrue(entry.cert().getNotBefore().toInstant().isBefore(java.time.Instant.now().minusSeconds(3600)),
                 "notBefore should be backdated well before now");
+    }
+
+    @Test
+    void leafCertHasAkiAndSki() throws Exception {
+        var ca = CertificateAuthority.loadOrCreate();
+        var entry = new CertStore(ca).get("aki-ski.example.com");
+        var cert = entry.cert();
+
+        assertNotNull(cert.getExtensionValue("2.5.29.14"),
+                "leaf cert must have Subject Key Identifier");
+        assertNotNull(cert.getExtensionValue("2.5.29.35"),
+                "leaf cert must have Authority Key Identifier");
+
+        // The AKI key identifier must match the SHA-1 of the CA's public key
+        var caKeyId = CertificateAuthority.computeKeyIdentifier(ca.caCert().getPublicKey());
+        var akiRaw = cert.getExtensionValue("2.5.29.35");
+        assertNotNull(akiRaw);
+        // akiRaw is an OCTET STRING wrapping the extension value;
+        // verify it contains the CA key identifier bytes
+        var akiHex = java.util.HexFormat.of().formatHex(akiRaw);
+        var caKeyIdHex = java.util.HexFormat.of().formatHex(caKeyId);
+        assertTrue(akiHex.contains(caKeyIdHex),
+                "AKI must contain the CA's key identifier");
+    }
+
+    @Test
+    void caCertHasSki() throws Exception {
+        var ca = CertificateAuthority.loadOrCreate();
+        assertNotNull(ca.caCert().getExtensionValue("2.5.29.14"),
+                "CA cert must have Subject Key Identifier");
+    }
+
+    @Test
+    void remintsLegacyCertWithoutAki() throws Exception {
+        var ca = CertificateAuthority.loadOrCreate();
+
+        // Build a leaf cert the way the old code did: basicConstraints + SAN only,
+        // no AKI/SKI. This simulates what's on disk after an upgrade.
+        var domain = "legacy.example.com";
+        var keyGen = KeyPairGenerator.getInstance("RSA");
+        keyGen.initialize(2048);
+        var keyPair = keyGen.generateKeyPair();
+        var notBefore = new Date(System.currentTimeMillis() - 86400_000L);
+        var expiry = new Date(notBefore.getTime() + 366L * 24 * 60 * 60 * 1000);
+        var serial = new BigInteger(128, new SecureRandom());
+        var algId = sha256WithRsaAid();
+        var tbsCert = derSequence(concat(
+                derExplicit(0, derInteger(BigInteger.valueOf(2))),
+                derInteger(serial),
+                algId,
+                ca.caCert().getSubjectX500Principal().getEncoded(),
+                derSequence(concat(derUtcTime(notBefore), derUtcTime(expiry))),
+                derDistinguishedName(domain),
+                keyPair.getPublic().getEncoded(),
+                derExplicit(3, derSequence(concat(
+                        derExtension(oidBasicConstraints(), true,
+                                derSequence(new byte[]{0x01, 0x01, 0x00})),
+                        derExtension(oidSubjectAltName(), false,
+                                derSequence(derDnsName(domain)))
+                )))
+        ));
+        var sig = java.security.Signature.getInstance("SHA256withRSA");
+        sig.initSign(ca.caKey());
+        sig.update(tbsCert);
+        var certDer = derSequence(concat(tbsCert, algId, derBitString(sig.sign())));
+        var legacyCert = (X509Certificate) CertificateFactory.getInstance("X.509")
+                .generateCertificate(new ByteArrayInputStream(certDer));
+
+        // Sanity: the handcrafted cert has no AKI
+        assertNull(legacyCert.getExtensionValue("2.5.29.35"));
+
+        // Persist it to the cert store directory, mimicking the old proxy
+        var certsDir = SpawnConfig.configDir().resolve("certs");
+        Files.createDirectories(certsDir);
+        Files.writeString(certsDir.resolve(domain + ".crt"),
+                toPem("CERTIFICATE", legacyCert.getEncoded()));
+        Files.writeString(certsDir.resolve(domain + ".key"),
+                toPem("PRIVATE KEY", keyPair.getPrivate().getEncoded()));
+
+        // A fresh CertStore must reject the legacy cert and re-mint
+        var reminted = new CertStore(ca).get(domain);
+        assertNotEquals(serial, reminted.cert().getSerialNumber(),
+                "legacy cert without AKI must be re-minted, not reused");
+        assertNotNull(reminted.cert().getExtensionValue("2.5.29.35"),
+                "re-minted cert must have AKI");
     }
 }

--- a/src/test/java/dev/incusspawn/tool/ToolDefTest.java
+++ b/src/test/java/dev/incusspawn/tool/ToolDefTest.java
@@ -772,6 +772,34 @@ class ToolDefTest {
         assertNotEquals(a.contentFingerprint(), b.contentFingerprint());
     }
 
+    @Test
+    void builtinHeadroomToolLoads() throws Exception {
+        try (var is = getClass().getClassLoader().getResourceAsStream("tools/headroom.yaml")) {
+            assertNotNull(is, "headroom.yaml must be on the classpath");
+            var def = ToolDef.loadFromStream(is);
+
+            assertEquals("headroom", def.getName());
+            assertEquals(List.of("claude"),
+                    def.getRequires().stream().map(ToolDef.ToolRef::getName).toList());
+            assertEquals(List.of("python3-pip"), def.getPackages());
+            assertNotNull(def.getRun());
+            assertFalse(def.getRun().isEmpty());
+            assertNotNull(def.getRunAsUser());
+            assertFalse(def.getRunAsUser().isEmpty());
+            assertNotNull(def.getVerify());
+            assertNotNull(def.getReady());
+
+            var envNames = def.getEnv().stream()
+                    .filter(e -> !e.isRaw())
+                    .map(e -> e.getName())
+                    .toList();
+            assertTrue(envNames.contains("ANTHROPIC_BASE_URL"),
+                    "headroom must set ANTHROPIC_BASE_URL");
+            assertFalse(envNames.contains("HEADROOM_TLS_STRICT"),
+                    "headroom should not set HEADROOM_TLS_STRICT (root cause is fixed in cert generation)");
+        }
+    }
+
     private static ByteArrayInputStream toStream(String yaml) {
         return new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8));
     }


### PR DESCRIPTION
## Summary

- **Fix MITM proxy certificates** for Python 3.14 / OpenSSL 3.5 compatibility: add Subject Key Identifier (SKI) and Authority Key Identifier (AKI) extensions per RFC 5280. Existing cached leaf certs without AKI are automatically re-minted on the next proxy start.
- **Add headroom as a built-in tool** so any template can use it without a search path. Installs `headroom-ai[proxy,mcp]`, registers the MCP server with Claude Code, and runs the optimization proxy as a systemd user service. No `HEADROOM_TLS_STRICT=0` workaround needed since the cert fix addresses the root cause.

## Test plan

- [x] `mvn test` — all new cert and tool tests pass (8/8)
- [x] Built isx from modified source, regenerated CA — new CA has `basicConstraints`, `keyUsage`, and `SKI`
- [x] Leaf certs include both `SKI` and `AKI` (verified via `openssl x509 -text`)
- [x] AKI key identifier matches CA's public key hash
- [x] Built `tpl-test-headroom` template with headroom from built-in (no search path override)
- [x] Branched container, verified: headroom installed, systemd service active, port 8787 listening, `ANTHROPIC_BASE_URL` set
- [x] Python 3.14 / OpenSSL 3.5 TLS validation succeeds without `HEADROOM_TLS_STRICT` — root cause confirmed fixed