### PR TITLE
Drop the sudo wrapper from the podman tool — run rootless

### DIFF
--- a/src/main/resources/tools/podman.yaml
+++ b/src/main/resources/tools/podman.yaml
@@ -3,19 +3,10 @@ description: Podman container runtime configured for Testcontainers
 
 packages:
   - podman
+  - podman-docker
   - fuse-overlayfs
 
 run:
-  - |
-    printf '#!/bin/sh\nexec sudo /usr/bin/podman "$@"\n' > /usr/local/bin/podman &&
-    chmod +x /usr/local/bin/podman &&
-    ln -sf /usr/local/bin/podman /usr/local/bin/docker
-  - |
-    if grep -q '^#\?mount_program' /etc/containers/storage.conf 2>/dev/null; then
-      sed -i 's|^#\?mount_program.*|mount_program = "/usr/bin/fuse-overlayfs"|' /etc/containers/storage.conf
-    elif grep -q '^\[storage.options.overlay\]' /etc/containers/storage.conf 2>/dev/null; then
-      sed -i '/^\[storage.options.overlay\]/a mount_program = "/usr/bin/fuse-overlayfs"' /etc/containers/storage.conf
-    fi
   - |
     systemctl enable --no-reload podman.socket &&
     mkdir -p /run/podman &&


### PR DESCRIPTION
## Summary

- Remove the `/usr/local/bin/podman` sudo wrapper script — podman now runs rootless
- Replace the manual docker symlink with the `podman-docker` package
- Remove dead storage.conf sed commands (they targeted `/etc/containers/storage.conf` which never existed — the vendor default lives at `/usr/share/containers/storage.conf`)

## Why

The sudo wrapper was introduced when `security.idmap.size` was 65536 — too few UIDs for podman's nested user namespace inside the container's own namespace. Commit 6a03c87 bumped the idmap to 165536 and configured subuid/subgid, making rootless podman viable, but the wrapper was never removed.

Without this fix, `podman run --userns=keep-id` (used by hibernate.org's build) fails because rootful podman cannot create the UID mapping: the container's idmap range (0–165535) doesn't cover the 1,000,000+ UIDs that rootful podman's user namespace needs. Rootless podman maps within the subuid range (100000–165535), which fits within the container's idmap.

## What's preserved

- **Rootful podman socket** (Testcontainers): `SocketMode=0666` lets any user connect without group membership — unchanged
- **Docker CLI compatibility**: handled by the `podman-docker` package (`/usr/bin/docker`)
- **OCI blob caching**: The MITM proxy caches OCI blobs by SHA256 digest, so images are not re-downloaded even though rootful (socket) and rootless (CLI) use separate storage paths

## Test plan

Tested from a clean rebuild (deleted all templates, rebuilt tpl-minimal → tpl-dev → tpl-java → tpl-websites with the new isx, branched an instance):

- [x] No sudo wrapper exists (`/usr/local/bin/podman` is absent)
- [x] `/usr/bin/docker` comes from `podman-docker` package
- [x] Podman socket active with `SocketMode=0666`
- [x] Rootful socket API responds (Docker API v1.44)
- [x] Rootful container run works via socket
- [x] Rootless `podman run --userns=keep-id` works (uid=1000 preserved)
- [x] Full hibernate.org site build: `rake setup && rake clean gen` passes (66 tests, 0 failures)
- [x] Unit tests: 746 tests, 0 failures

**Note**: Templates need to be rebuilt after upgrading isx to pick up this change.