### PR TITLE
Add Claude Code settings parameters to the claude tool

### DIFF
--- a/src/main/java/dev/incusspawn/tool/ClaudeSetup.java
+++ b/src/main/java/dev/incusspawn/tool/ClaudeSetup.java
@@ -43,13 +43,54 @@ public class ClaudeSetup implements ToolSetup {
 
     @Override
     public Map<String, ToolDef.ParameterDef> parameters() {
+        var params = new java.util.LinkedHashMap<String, ToolDef.ParameterDef>();
+
         var model = new ToolDef.ParameterDef();
         model.setType("string");
         model.setDescription("Claude model ID (e.g. claude-opus-4-6, claude-sonnet-4-6, claude-haiku-4-5-20251001)");
         model.setPattern("^claude-[a-z0-9][-a-z0-9.]*$");
         model.setOptional(true);
         model.setReconfigurable(true);
-        return Map.of("model", model);
+        params.put("model", model);
+
+        var attributionCommit = new ToolDef.ParameterDef();
+        attributionCommit.setType("string");
+        attributionCommit.setDescription("Git commit attribution trailer (e.g. 'Assisted-By: Claude Code <noreply@anthropic.com>')");
+        attributionCommit.setOptional(true);
+        attributionCommit.setReconfigurable(true);
+        params.put("attribution-commit", attributionCommit);
+
+        var attributionPr = new ToolDef.ParameterDef();
+        attributionPr.setType("string");
+        attributionPr.setDescription("Pull request attribution text (empty string to omit)");
+        attributionPr.setOptional(true);
+        attributionPr.setReconfigurable(true);
+        params.put("attribution-pr", attributionPr);
+
+        var theme = new ToolDef.ParameterDef();
+        theme.setType("string");
+        theme.setDescription("Color theme (dark, light, dark-daltonized, light-daltonized)");
+        theme.setPattern("^(dark|light|dark-daltonized|light-daltonized)$");
+        theme.setOptional(true);
+        theme.setReconfigurable(true);
+        params.put("theme", theme);
+
+        var editorMode = new ToolDef.ParameterDef();
+        editorMode.setType("string");
+        editorMode.setDescription("Input editor mode (normal, vim)");
+        editorMode.setPattern("^(normal|vim)$");
+        editorMode.setOptional(true);
+        editorMode.setReconfigurable(true);
+        params.put("editor-mode", editorMode);
+
+        var outputStyle = new ToolDef.ParameterDef();
+        outputStyle.setType("string");
+        outputStyle.setDescription("Response style (Default, Proactive, Explanatory, Learning)");
+        outputStyle.setOptional(true);
+        outputStyle.setReconfigurable(true);
+        params.put("output-style", outputStyle);
+
+        return params;
     }
 
     @Override
@@ -75,13 +116,13 @@ public class ClaudeSetup implements ToolSetup {
     public void install(Container c, java.util.Map<String, String> resolvedParams) {
         installBinary(c);
         var claude = SpawnConfig.load().getClaude();
-        configureSettings(c, claude, resolvedParams.get("model"));
+        configureSettings(c, claude, resolvedParams);
     }
 
     @Override
     public void reconfigure(Container c, java.util.Map<String, String> resolvedParams) {
         var claude = SpawnConfig.load().getClaude();
-        configureSettings(c, claude, resolvedParams.get("model"));
+        configureSettings(c, claude, resolvedParams);
     }
 
     private void installBinary(Container c) {
@@ -139,12 +180,13 @@ public class ClaudeSetup implements ToolSetup {
     }
 
     static final String MANAGED_SETTINGS_PATH = "/etc/claude-code/managed-settings.json";
+    static final String USER_SETTINGS_PATH = "/home/agentuser/.claude/settings.json";
 
     void configureSettings(Container c, SpawnConfig.ClaudeConfig claudeConfig) {
-        configureSettings(c, claudeConfig, null);
+        configureSettings(c, claudeConfig, Map.of());
     }
 
-    void configureSettings(Container c, SpawnConfig.ClaudeConfig claudeConfig, String model) {
+    void configureSettings(Container c, SpawnConfig.ClaudeConfig claudeConfig, Map<String, String> params) {
         System.out.println("Configuring Claude Code for agent use...");
         var managedSettingsJson = """
                 {
@@ -175,14 +217,7 @@ public class ClaudeSetup implements ToolSetup {
         c.sh("mkdir -p /etc/claude-code");
         c.writeFile(MANAGED_SETTINGS_PATH, managedSettingsJson);
 
-        var settingsJsonBuilder = new StringBuilder();
-        settingsJsonBuilder.append("{\n");
-        settingsJsonBuilder.append("  \"disableDeepLinkRegistration\": \"disable\"");
-        if (model != null) {
-            settingsJsonBuilder.append(",\n  \"model\": \"").append(model).append("\"");
-        }
-        settingsJsonBuilder.append("\n}\n");
-        var settingsJson = settingsJsonBuilder.toString();
+        var settingsJson = buildUserSettings(params);
         var claudeJsonBuilder = new StringBuilder();
         claudeJsonBuilder.append("""
                 {
@@ -214,10 +249,42 @@ public class ClaudeSetup implements ToolSetup {
                 """);
         var claudeJson = claudeJsonBuilder.toString();
         c.sh("mkdir -p /home/agentuser/.claude");
-        c.writeFile("/home/agentuser/.claude/settings.json", settingsJson);
+        c.writeFile(USER_SETTINGS_PATH, settingsJson);
         c.writeFile("/home/agentuser/.claude.json", claudeJson);
         c.chown("/home/agentuser/.claude", "agentuser:agentuser");
         c.chown("/home/agentuser/.claude.json", "agentuser:agentuser");
+    }
+
+    static String buildUserSettings(Map<String, String> params) {
+        var root = JSON.createObjectNode();
+        root.put("disableDeepLinkRegistration", "disable");
+
+        putIfPresent(root, params, "model", "model");
+        putIfPresent(root, params, "theme", "theme");
+        putIfPresent(root, params, "editor-mode", "editorMode");
+        putIfPresent(root, params, "output-style", "outputStyle");
+
+        var commitTrailer = params.get("attribution-commit");
+        var prAttribution = params.get("attribution-pr");
+        if (commitTrailer != null || prAttribution != null) {
+            var attribution = root.putObject("attribution");
+            if (commitTrailer != null) attribution.put("commit", commitTrailer);
+            if (prAttribution != null) attribution.put("pr", prAttribution);
+        }
+
+        try {
+            return JSON.writerWithDefaultPrettyPrinter().writeValueAsString(root) + "\n";
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to serialize settings JSON", e);
+        }
+    }
+
+    private static void putIfPresent(com.fasterxml.jackson.databind.node.ObjectNode node,
+                                      Map<String, String> params, String paramKey, String jsonKey) {
+        var value = params.get(paramKey);
+        if (value != null) {
+            node.put(jsonKey, value);
+        }
     }
 
 }

--- a/src/test/java/dev/incusspawn/tool/ClaudeSetupTest.java
+++ b/src/test/java/dev/incusspawn/tool/ClaudeSetupTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -75,7 +76,7 @@ class ClaudeSetupTest {
         var incus = mock(IncusClient.class);
         when(incus.shellExec(anyString(), any(String[].class))).thenReturn(OK);
 
-        new ClaudeSetup().configureSettings(new Container(incus, CONTAINER), new SpawnConfig.ClaudeConfig());
+        new ClaudeSetup().configureSettings(new Container(incus, CONTAINER), new SpawnConfig.ClaudeConfig(), Map.of());
 
         verify(incus).shellExec(eq(CONTAINER),
                 eq("sh"), eq("-c"), contains("/etc/claude-code/managed-settings.json"));
@@ -90,7 +91,7 @@ class ClaudeSetupTest {
         var incus = mock(IncusClient.class);
         when(incus.shellExec(anyString(), any(String[].class))).thenReturn(OK);
 
-        new ClaudeSetup().configureSettings(new Container(incus, CONTAINER), new SpawnConfig.ClaudeConfig());
+        new ClaudeSetup().configureSettings(new Container(incus, CONTAINER), new SpawnConfig.ClaudeConfig(), Map.of());
 
         // bypassPermissions should only be in managed settings, not user settings
         // User settings file is ~/.claude/settings.json
@@ -116,11 +117,8 @@ class ClaudeSetupTest {
         var incus = mock(IncusClient.class);
         when(incus.shellExec(anyString(), any(String[].class))).thenReturn(OK);
 
-        new ClaudeSetup().configureSettings(new Container(incus, CONTAINER), claude);
+        new ClaudeSetup().configureSettings(new Container(incus, CONTAINER), claude, Map.of());
 
-        // The trust-prompt bypass only applies to direct API key auth; in OAuth mode
-        // Claude Code never goes through that flow, so it shouldn't reference the
-        // placeholder API key at all.
         verify(incus, never()).shellExec(eq(CONTAINER),
                 eq("sh"), eq("-c"), contains("customApiKeyResponses"));
     }
@@ -131,7 +129,7 @@ class ClaudeSetupTest {
         when(incus.shellExec(anyString(), any(String[].class))).thenReturn(OK);
 
         new ClaudeSetup().configureSettings(new Container(incus, CONTAINER),
-                new SpawnConfig.ClaudeConfig(), "claude-sonnet-4-6");
+                new SpawnConfig.ClaudeConfig(), Map.of("model", "claude-sonnet-4-6"));
 
         var captor = org.mockito.ArgumentCaptor.forClass(String.class);
         verify(incus, atLeastOnce()).shellExec(eq(CONTAINER),
@@ -140,7 +138,7 @@ class ClaudeSetupTest {
         var settingsWrite = captor.getAllValues().stream()
                 .filter(cmd -> cmd.contains(".claude/settings.json") && !cmd.contains("/etc/claude-code"))
                 .findFirst().orElseThrow();
-        assertTrue(settingsWrite.contains("\"model\": \"claude-sonnet-4-6\""),
+        assertTrue(settingsWrite.contains("\"model\" : \"claude-sonnet-4-6\""),
                 "User settings.json should contain model when parameter is set");
     }
 
@@ -150,7 +148,7 @@ class ClaudeSetupTest {
         when(incus.shellExec(anyString(), any(String[].class))).thenReturn(OK);
 
         new ClaudeSetup().configureSettings(new Container(incus, CONTAINER),
-                new SpawnConfig.ClaudeConfig());
+                new SpawnConfig.ClaudeConfig(), Map.of());
 
         var captor = org.mockito.ArgumentCaptor.forClass(String.class);
         verify(incus, atLeastOnce()).shellExec(eq(CONTAINER),
@@ -169,7 +167,7 @@ class ClaudeSetupTest {
         when(incus.shellExec(anyString(), any(String[].class))).thenReturn(OK);
 
         new ClaudeSetup().reconfigure(new Container(incus, CONTAINER),
-                java.util.Map.of("model", "claude-opus-4-6"));
+                Map.of("model", "claude-opus-4-6"));
 
         var captor = org.mockito.ArgumentCaptor.forClass(String.class);
         verify(incus, atLeastOnce()).shellExec(eq(CONTAINER),
@@ -177,22 +175,70 @@ class ClaudeSetupTest {
 
         var commands = captor.getAllValues();
         assertTrue(commands.stream().anyMatch(cmd ->
-                        cmd.contains(".claude/settings.json") && cmd.contains("\"model\": \"claude-opus-4-6\"")),
+                        cmd.contains(".claude/settings.json") && cmd.contains("\"model\" : \"claude-opus-4-6\"")),
                 "reconfigure should write model to settings.json");
         assertFalse(commands.stream().anyMatch(cmd -> cmd.contains(".local/bin/claude")),
                 "reconfigure should not install the binary");
     }
 
     @Test
-    void parametersDeclaresModelAsOptionalReconfigurable() {
+    void parametersDeclaresAllSettingsAsOptionalReconfigurable() {
         var params = new ClaudeSetup().parameters();
-        assertTrue(params.containsKey("model"));
-        var model = params.get("model");
-        assertEquals("string", model.getType());
-        assertNotNull(model.getPattern());
-        assertNull(model.getDefault());
-        assertTrue(model.isOptional());
-        assertTrue(model.isReconfigurable());
+
+        for (var name : List.of("model", "attribution-commit", "attribution-pr",
+                "theme", "editor-mode", "output-style")) {
+            assertTrue(params.containsKey(name), "Should declare parameter: " + name);
+            var p = params.get(name);
+            assertEquals("string", p.getType());
+            assertTrue(p.isOptional(), name + " should be optional");
+            assertTrue(p.isReconfigurable(), name + " should be reconfigurable");
+        }
+
+        assertNotNull(params.get("model").getPattern());
+        assertNotNull(params.get("theme").getPattern());
+        assertNotNull(params.get("editor-mode").getPattern());
+    }
+
+    @Test
+    void buildUserSettingsWithAllParams() {
+        var params = Map.of(
+                "model", "claude-opus-4-6",
+                "attribution-commit", "Assisted-By: Claude Code <noreply@anthropic.com>",
+                "attribution-pr", "",
+                "theme", "dark",
+                "editor-mode", "vim",
+                "output-style", "Proactive"
+        );
+
+        var json = ClaudeSetup.buildUserSettings(params);
+
+        assertTrue(json.contains("\"disableDeepLinkRegistration\" : \"disable\""));
+        assertTrue(json.contains("\"model\" : \"claude-opus-4-6\""));
+        assertTrue(json.contains("\"theme\" : \"dark\""));
+        assertTrue(json.contains("\"editorMode\" : \"vim\""));
+        assertTrue(json.contains("\"outputStyle\" : \"Proactive\""));
+        assertTrue(json.contains("\"attribution\""));
+        assertTrue(json.contains("\"commit\" : \"Assisted-By: Claude Code <noreply@anthropic.com>\""));
+        assertTrue(json.contains("\"pr\" : \"\""));
+    }
+
+    @Test
+    void buildUserSettingsMinimal() {
+        var json = ClaudeSetup.buildUserSettings(Map.of());
+
+        assertTrue(json.contains("\"disableDeepLinkRegistration\" : \"disable\""));
+        assertFalse(json.contains("\"model\""));
+        assertFalse(json.contains("\"theme\""));
+        assertFalse(json.contains("\"attribution\""));
+    }
+
+    @Test
+    void buildUserSettingsAttributionPartial() {
+        var json = ClaudeSetup.buildUserSettings(
+                Map.of("attribution-commit", "Custom trailer"));
+
+        assertTrue(json.contains("\"commit\" : \"Custom trailer\""));
+        assertFalse(json.contains("\"pr\""));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Add reconfigurable parameters for commonly customized Claude Code settings: `attribution-commit`, `attribution-pr`, `theme`, `editor-mode`, and `output-style`
- Templates can now set these declaratively instead of copying a `.claude/settings.json` file that overwrites isx-generated config
- Refactors `configureSettings()` to use Jackson `ObjectNode` for proper JSON generation

### Example usage in a template

```yaml
tools:
  - claude:
      model: claude-opus-4-6
      attribution-commit: "Assisted-By: Claude Code <noreply@anthropic.com>"
      attribution-pr: ""
      editor-mode: vim
```

## Test plan
- [x] All 749 unit tests pass
- [x] Built a test template with all parameters, verified `settings.json` content in the container
- [x] Claude Code starts without warnings in the built template

🤖 Generated with [Claude Code](https://claude.com/claude-code)