### PR TITLE
Fixes to github email selection during setup

### DIFF
--- a/src/main/java/dev/incusspawn/command/InitCommand.java
+++ b/src/main/java/dev/incusspawn/command/InitCommand.java
@@ -1306,6 +1306,7 @@ public class InitCommand extends BaseCommand {
 
             if (result.email != null) {
                 config.getGithub().setToken(token);
+                config.getGithub().setEmail(result.email);
                 config.save();
                 System.out.println("  GitHub configuration saved.");
                 break;
@@ -1334,6 +1335,9 @@ public class InitCommand extends BaseCommand {
                 break;
             }
             config.getGithub().setToken(newToken);
+            if (newResult.email != null) {
+                config.getGithub().setEmail(newResult.email);
+            }
             config.save();
             if (newResult.email != null) {
                 System.out.println("  GitHub configuration saved.");
@@ -1399,19 +1403,63 @@ public class InitCommand extends BaseCommand {
                 return null;
             }
             var body = response.body();
-            var noreplyPattern = java.util.regex.Pattern.compile(
-                    "\"email\"\\s*:\\s*\"([^\"]+@users\\.noreply\\.github\\.com)\"");
-            var noreplyMatch = noreplyPattern.matcher(body);
-            if (noreplyMatch.find()) {
-                return noreplyMatch.group(1);
+
+            var verifiedEmails = new ArrayList<String>();
+            String primaryEmail = null;
+            var emailPattern = java.util.regex.Pattern.compile(
+                    "\\{[^}]*\"email\"\\s*:\\s*\"([^\"]+)\"[^}]*\"verified\"\\s*:\\s*true[^}]*\\}");
+            var emailMatcher = emailPattern.matcher(body);
+            while (emailMatcher.find()) {
+                var email = emailMatcher.group(1);
+                if (email.endsWith("@users.noreply.github.com")) continue;
+                verifiedEmails.add(email);
+                var obj = body.substring(emailMatcher.start(), emailMatcher.end());
+                if (obj.contains("\"primary\"") && obj.contains("true")) {
+                    primaryEmail = email;
+                }
             }
-            var primaryPattern = java.util.regex.Pattern.compile(
-                    "\"email\"\\s*:\\s*\"([^\"]+)\"[^}]*\"primary\"\\s*:\\s*true[^}]*\"verified\"\\s*:\\s*true");
-            var primaryMatch = primaryPattern.matcher(body);
-            if (primaryMatch.find()) {
-                return primaryMatch.group(1);
+            // Also match when "verified" appears before "email"
+            var altPattern = java.util.regex.Pattern.compile(
+                    "\\{[^}]*\"verified\"\\s*:\\s*true[^}]*\"email\"\\s*:\\s*\"([^\"]+)\"[^}]*\\}");
+            var altMatcher = altPattern.matcher(body);
+            while (altMatcher.find()) {
+                var email = altMatcher.group(1);
+                if (email.endsWith("@users.noreply.github.com")) continue;
+                if (!verifiedEmails.contains(email)) {
+                    verifiedEmails.add(email);
+                    var obj = body.substring(altMatcher.start(), altMatcher.end());
+                    if (obj.contains("\"primary\"") && obj.contains("true")) {
+                        primaryEmail = email;
+                    }
+                }
             }
-            return null;
+
+            if (verifiedEmails.isEmpty()) {
+                return null;
+            }
+            if (verifiedEmails.size() == 1) {
+                return verifiedEmails.get(0);
+            }
+
+            var console = System.console();
+            if (console == null) {
+                return primaryEmail != null ? primaryEmail : verifiedEmails.get(0);
+            }
+            System.out.println("  Multiple verified emails found:");
+            for (int i = 0; i < verifiedEmails.size(); i++) {
+                var label = verifiedEmails.get(i);
+                if (label.equals(primaryEmail)) label += " (primary)";
+                System.out.println("    " + (i + 1) + ". " + label);
+            }
+            System.out.print("  Select email for git commits (1-" + verifiedEmails.size() + "): ");
+            var choice = console.readLine().strip();
+            try {
+                int idx = Integer.parseInt(choice) - 1;
+                if (idx >= 0 && idx < verifiedEmails.size()) {
+                    return verifiedEmails.get(idx);
+                }
+            } catch (NumberFormatException ignored) {}
+            return primaryEmail != null ? primaryEmail : verifiedEmails.get(0);
         } catch (Exception e) {
             return null;
         }

--- a/src/main/java/dev/incusspawn/command/InitCommand.java
+++ b/src/main/java/dev/incusspawn/command/InitCommand.java
@@ -1352,6 +1352,8 @@ public class InitCommand extends BaseCommand {
 
     private record GitHubVerifyResult(String login, String email) {}
 
+    record EmailParseResult(java.util.List<String> verified, String primary) {}
+
     private GitHubVerifyResult verifyGitHubToken(String token) {
         System.out.println("  Testing GitHub token...");
         try {
@@ -1403,7 +1405,41 @@ public class InitCommand extends BaseCommand {
                 return null;
             }
 
-            var emails = new ObjectMapper().readTree(response.body());
+            var parsed = parseGitHubEmails(response.body());
+            if (parsed == null) {
+                return null;
+            }
+            if (parsed.verified.size() == 1) {
+                return parsed.verified.get(0);
+            }
+
+            var console = System.console();
+            if (console == null) {
+                return parsed.primary != null ? parsed.primary : parsed.verified.get(0);
+            }
+            System.out.println("  Multiple verified emails found:");
+            for (int i = 0; i < parsed.verified.size(); i++) {
+                var label = parsed.verified.get(i);
+                if (label.equals(parsed.primary)) label += " (primary)";
+                System.out.println("    " + (i + 1) + ". " + label);
+            }
+            System.out.print("  Select email for git commits (1-" + parsed.verified.size() + "): ");
+            var choice = console.readLine().strip();
+            try {
+                int idx = Integer.parseInt(choice) - 1;
+                if (idx >= 0 && idx < parsed.verified.size()) {
+                    return parsed.verified.get(idx);
+                }
+            } catch (NumberFormatException ignored) {}
+            return parsed.primary != null ? parsed.primary : parsed.verified.get(0);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    static EmailParseResult parseGitHubEmails(String json) {
+        try {
+            var emails = new ObjectMapper().readTree(json);
             var verifiedEmails = new ArrayList<String>();
             String primaryEmail = null;
             for (var entry : emails) {
@@ -1415,33 +1451,10 @@ public class InitCommand extends BaseCommand {
                     primaryEmail = email;
                 }
             }
-
             if (verifiedEmails.isEmpty()) {
                 return null;
             }
-            if (verifiedEmails.size() == 1) {
-                return verifiedEmails.get(0);
-            }
-
-            var console = System.console();
-            if (console == null) {
-                return primaryEmail != null ? primaryEmail : verifiedEmails.get(0);
-            }
-            System.out.println("  Multiple verified emails found:");
-            for (int i = 0; i < verifiedEmails.size(); i++) {
-                var label = verifiedEmails.get(i);
-                if (label.equals(primaryEmail)) label += " (primary)";
-                System.out.println("    " + (i + 1) + ". " + label);
-            }
-            System.out.print("  Select email for git commits (1-" + verifiedEmails.size() + "): ");
-            var choice = console.readLine().strip();
-            try {
-                int idx = Integer.parseInt(choice) - 1;
-                if (idx >= 0 && idx < verifiedEmails.size()) {
-                    return verifiedEmails.get(idx);
-                }
-            } catch (NumberFormatException ignored) {}
-            return primaryEmail != null ? primaryEmail : verifiedEmails.get(0);
+            return new EmailParseResult(java.util.List.copyOf(verifiedEmails), primaryEmail);
         } catch (Exception e) {
             return null;
         }

--- a/src/main/java/dev/incusspawn/command/InitCommand.java
+++ b/src/main/java/dev/incusspawn/command/InitCommand.java
@@ -29,6 +29,8 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 @CommandDefinition(
         name = "init",
         description = "One-time host setup: install Incus, configure auth, test connectivity",
@@ -1365,20 +1367,18 @@ public class InitCommand extends BaseCommand {
                 return null;
             }
 
-            var loginMatch = java.util.regex.Pattern.compile("\"login\"\\s*:\\s*\"([^\"]+)\"")
-                    .matcher(response.body());
-            var login = loginMatch.find() ? loginMatch.group(1) : null;
-
-            var email = extractJsonString(response.body(), "email");
+            var json = new ObjectMapper().readTree(response.body());
+            var login = json.has("login") ? json.get("login").asText(null) : null;
+            var email = json.has("email") && !json.get("email").isNull() ? json.get("email").asText(null) : null;
             if (email == null) {
                 email = checkGitHubEmail(client, token);
             }
 
             if (login != null) {
                 if (email != null) {
-                    System.out.println("  \u001B[1;32m✓ Token verified. Authenticated as: " + login + " <" + email + ">\u001B[0m");
+                    System.out.println("  \u001B[1;32m\u2713 Token verified. Authenticated as: " + login + " <" + email + ">\u001B[0m");
                 } else {
-                    System.out.println("  \u001B[1;32m✓ Token verified. Authenticated as: " + login + "\u001B[0m");
+                    System.out.println("  \u001B[1;32m\u2713 Token verified. Authenticated as: " + login + "\u001B[0m");
                 }
             } else {
                 System.out.println("  Token verified (could not determine username).");
@@ -1402,35 +1402,17 @@ public class InitCommand extends BaseCommand {
             if (response.statusCode() != 200) {
                 return null;
             }
-            var body = response.body();
 
+            var emails = new ObjectMapper().readTree(response.body());
             var verifiedEmails = new ArrayList<String>();
             String primaryEmail = null;
-            var emailPattern = java.util.regex.Pattern.compile(
-                    "\\{[^}]*\"email\"\\s*:\\s*\"([^\"]+)\"[^}]*\"verified\"\\s*:\\s*true[^}]*\\}");
-            var emailMatcher = emailPattern.matcher(body);
-            while (emailMatcher.find()) {
-                var email = emailMatcher.group(1);
-                if (email.endsWith("@users.noreply.github.com")) continue;
+            for (var entry : emails) {
+                if (!entry.path("verified").asBoolean(false)) continue;
+                var email = entry.path("email").asText(null);
+                if (email == null || email.endsWith("@users.noreply.github.com")) continue;
                 verifiedEmails.add(email);
-                var obj = body.substring(emailMatcher.start(), emailMatcher.end());
-                if (obj.contains("\"primary\"") && obj.contains("true")) {
+                if (entry.path("primary").asBoolean(false)) {
                     primaryEmail = email;
-                }
-            }
-            // Also match when "verified" appears before "email"
-            var altPattern = java.util.regex.Pattern.compile(
-                    "\\{[^}]*\"verified\"\\s*:\\s*true[^}]*\"email\"\\s*:\\s*\"([^\"]+)\"[^}]*\\}");
-            var altMatcher = altPattern.matcher(body);
-            while (altMatcher.find()) {
-                var email = altMatcher.group(1);
-                if (email.endsWith("@users.noreply.github.com")) continue;
-                if (!verifiedEmails.contains(email)) {
-                    verifiedEmails.add(email);
-                    var obj = body.substring(altMatcher.start(), altMatcher.end());
-                    if (obj.contains("\"primary\"") && obj.contains("true")) {
-                        primaryEmail = email;
-                    }
                 }
             }
 
@@ -1463,12 +1445,6 @@ public class InitCommand extends BaseCommand {
         } catch (Exception e) {
             return null;
         }
-    }
-
-    private static String extractJsonString(String json, String key) {
-        var pattern = java.util.regex.Pattern.compile("\"" + key + "\"\\s*:\\s*\"([^\"]+)\"");
-        var match = pattern.matcher(json);
-        return match.find() ? match.group(1) : null;
     }
 
     private static String patSettingsUrl(String token) {

--- a/src/main/java/dev/incusspawn/command/InitCommand.java
+++ b/src/main/java/dev/incusspawn/command/InitCommand.java
@@ -689,7 +689,7 @@ public class InitCommand extends BaseCommand {
         System.err.println("  incus-spawn expects: " + entry);
         var console = System.console();
         if (console != null) {
-            System.err.print("  [1;33mReplace it? (y/N): [0m");
+            System.err.print("  \u001B[1;33mReplace it? (y/N): \u001B[0m");
             var answer = console.readLine().strip();
             if (answer.equalsIgnoreCase("y")) {
                 runHost("sudo", "sed", "-i", "s/^" + Pattern.quote(existing.get()) + "$/" + entry + "/", path);
@@ -1263,9 +1263,10 @@ public class InitCommand extends BaseCommand {
                 "code, and manage issues on your behalf. For best security,",
                 "create a dedicated bot account (e.g. yourname-ai-bot) with",
                 "collaborator access, or use a fine-grained PAT scoped to",
-                "specific repos and permissions. For example, grant Contents,",
-                "Issues, and Pull requests (read/write) — avoid admin, org,",
-                "and delete permissions unless needed.",
+                "specific repos and permissions. Grant Contents, Issues, and",
+                "Pull requests (read/write), plus Email addresses (read) under",
+                "Account permissions (needed for git commit identity).",
+                "Avoid admin, org, and delete permissions unless needed.",
                 "Create one at: https://github.com/settings/personal-access-tokens");
         var config = SpawnConfig.load();
         var console = System.console();
@@ -1292,47 +1293,141 @@ public class InitCommand extends BaseCommand {
                 break;
             }
 
-            // Test the token using the GitHub API directly, isolated from host credentials
-            System.out.println("  Testing GitHub token...");
-            boolean verified = false;
-            try {
-                var client = getHttpClient();
-                var request = HttpRequest.newBuilder()
-                        .uri(URI.create("https://api.github.com/user"))
-                        .header("Authorization", "token " + token)
-                        .header("Accept", "application/vnd.github+json")
-                        .GET().build();
-                var response = client.send(request, HttpResponse.BodyHandlers.ofString());
-                if (response.statusCode() == 200) {
-                    var loginMatch = java.util.regex.Pattern.compile("\"login\"\\s*:\\s*\"([^\"]+)\"")
-                            .matcher(response.body());
-                    if (loginMatch.find()) {
-                        System.out.println("  \u001B[1;32m✓ Token verified. Authenticated as: " + loginMatch.group(1) + "\u001B[0m");
-                    } else {
-                        System.out.println("  Token verified (could not determine username).");
-                    }
-                    verified = true;
-                } else {
-                    System.out.println("  Authentication failed (HTTP " + response.statusCode() + ").");
-                }
-            } catch (Exception e) {
-                System.out.println("  Could not test token: " + e.getMessage());
-            }
-
-            if (verified) {
-                config.getGithub().setToken(token);
-                config.save();
-                System.out.println("  GitHub configuration saved.");
-                break;
-            } else {
+            var result = verifyGitHubToken(token);
+            if (result == null) {
                 System.out.print("  Try again? (Y/n): ");
                 var retry = console.readLine().strip();
                 if (retry.equalsIgnoreCase("n")) {
                     System.out.println("  Skipped GitHub setup. You can configure it later by re-running 'isx init'.");
                     break;
                 }
+                continue;
             }
+
+            if (result.email != null) {
+                config.getGithub().setToken(token);
+                config.save();
+                System.out.println("  GitHub configuration saved.");
+                break;
+            }
+
+            System.out.println("  \u001B[1;33m⚠ No email accessible — git commits will have no author email.\u001B[0m");
+            System.out.println("  To fix this, either:");
+            System.out.println("    • Add 'Email addresses' (read) under Account permissions on your PAT");
+            System.out.println("      " + patSettingsUrl(token));
+            System.out.println("    • Or make your email public at https://github.com/settings/profile");
+            System.out.print("  Enter new PAT with email permission, or press Enter to continue without: ");
+            var newToken = new String(console.readPassword());
+            if (newToken.isBlank()) {
+                config.getGithub().setToken(token);
+                config.save();
+                System.out.println("  GitHub configuration saved (without email).");
+                break;
+            }
+
+            var newResult = verifyGitHubToken(newToken);
+            if (newResult == null) {
+                System.out.println("  New token failed verification — keeping the original token.");
+                config.getGithub().setToken(token);
+                config.save();
+                System.out.println("  GitHub configuration saved (without email).");
+                break;
+            }
+            config.getGithub().setToken(newToken);
+            config.save();
+            if (newResult.email != null) {
+                System.out.println("  GitHub configuration saved.");
+            } else {
+                System.out.println("  GitHub configuration saved (still without email).");
+            }
+            break;
         }
+    }
+
+    private record GitHubVerifyResult(String login, String email) {}
+
+    private GitHubVerifyResult verifyGitHubToken(String token) {
+        System.out.println("  Testing GitHub token...");
+        try {
+            var client = getHttpClient();
+            var request = HttpRequest.newBuilder()
+                    .uri(URI.create("https://api.github.com/user"))
+                    .header("Authorization", "token " + token)
+                    .header("Accept", "application/vnd.github+json")
+                    .GET().build();
+            var response = client.send(request, HttpResponse.BodyHandlers.ofString());
+            if (response.statusCode() != 200) {
+                System.out.println("  Authentication failed (HTTP " + response.statusCode() + ").");
+                return null;
+            }
+
+            var loginMatch = java.util.regex.Pattern.compile("\"login\"\\s*:\\s*\"([^\"]+)\"")
+                    .matcher(response.body());
+            var login = loginMatch.find() ? loginMatch.group(1) : null;
+
+            var email = extractJsonString(response.body(), "email");
+            if (email == null) {
+                email = checkGitHubEmail(client, token);
+            }
+
+            if (login != null) {
+                if (email != null) {
+                    System.out.println("  \u001B[1;32m✓ Token verified. Authenticated as: " + login + " <" + email + ">\u001B[0m");
+                } else {
+                    System.out.println("  \u001B[1;32m✓ Token verified. Authenticated as: " + login + "\u001B[0m");
+                }
+            } else {
+                System.out.println("  Token verified (could not determine username).");
+            }
+
+            return new GitHubVerifyResult(login, email);
+        } catch (Exception e) {
+            System.out.println("  Could not test token: " + e.getMessage());
+            return null;
+        }
+    }
+
+    private String checkGitHubEmail(java.net.http.HttpClient client, String token) {
+        try {
+            var request = HttpRequest.newBuilder()
+                    .uri(URI.create("https://api.github.com/user/emails"))
+                    .header("Authorization", "token " + token)
+                    .header("Accept", "application/vnd.github+json")
+                    .GET().build();
+            var response = client.send(request, HttpResponse.BodyHandlers.ofString());
+            if (response.statusCode() != 200) {
+                return null;
+            }
+            var body = response.body();
+            var noreplyPattern = java.util.regex.Pattern.compile(
+                    "\"email\"\\s*:\\s*\"([^\"]+@users\\.noreply\\.github\\.com)\"");
+            var noreplyMatch = noreplyPattern.matcher(body);
+            if (noreplyMatch.find()) {
+                return noreplyMatch.group(1);
+            }
+            var primaryPattern = java.util.regex.Pattern.compile(
+                    "\"email\"\\s*:\\s*\"([^\"]+)\"[^}]*\"primary\"\\s*:\\s*true[^}]*\"verified\"\\s*:\\s*true");
+            var primaryMatch = primaryPattern.matcher(body);
+            if (primaryMatch.find()) {
+                return primaryMatch.group(1);
+            }
+            return null;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private static String extractJsonString(String json, String key) {
+        var pattern = java.util.regex.Pattern.compile("\"" + key + "\"\\s*:\\s*\"([^\"]+)\"");
+        var match = pattern.matcher(json);
+        return match.find() ? match.group(1) : null;
+    }
+
+    private static String patSettingsUrl(String token) {
+        if (token.startsWith("github_pat_")) {
+            return "https://github.com/settings/personal-access-tokens";
+        }
+        return "https://github.com/settings/tokens";
     }
 
     private void printNumberedPaths(java.util.List<String> paths) {

--- a/src/main/java/dev/incusspawn/config/SpawnConfig.java
+++ b/src/main/java/dev/incusspawn/config/SpawnConfig.java
@@ -73,9 +73,12 @@ public class SpawnConfig {
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static class GitHubConfig {
         private String token = "";
+        private String email = "";
 
         public String getToken() { return token; }
         public void setToken(String token) { this.token = token == null ? "" : token; }
+        public String getEmail() { return email; }
+        public void setEmail(String email) { this.email = email == null ? "" : email; }
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/java/dev/incusspawn/tool/GhSetup.java
+++ b/src/main/java/dev/incusspawn/tool/GhSetup.java
@@ -1,6 +1,7 @@
 package dev.incusspawn.tool;
 
 import dev.incusspawn.config.EnvEntry;
+import dev.incusspawn.config.SpawnConfig;
 import dev.incusspawn.incus.Container;
 import static dev.incusspawn.incus.Container.shellQuote;
 
@@ -67,14 +68,18 @@ public class GhSetup implements ToolSetup {
         }
 
         if (!hasEmail) {
-            var email = findEmailFromApi(c);
+            var configEmail = SpawnConfig.load().getGithub().getEmail();
+            var email = configEmail.isBlank() ? null : configEmail;
+            if (email == null) {
+                email = findEmailFromApi(c);
+            }
             if (email == null && parts.length >= 3 && !parts[2].isEmpty()) {
                 email = parts[2];
             }
             if (email != null) {
                 gitConfig(c, "user.email", email);
             } else {
-                System.out.println("  No email found — grant the 'user:email' scope on your GitHub token to enable noreply email detection.");
+                System.out.println("  No email found — re-run 'isx init' to configure GitHub with email access.");
             }
         }
     }
@@ -82,8 +87,9 @@ public class GhSetup implements ToolSetup {
     private String findEmailFromApi(Container c) {
         var result = c.sh("GH_TOKEN=" + PLACEHOLDER_TOKEN
                 + " gh api user/emails --jq '"
-                + "([.[] | select(.email | endswith(\"@users.noreply.github.com\")) | .email] | first)"
-                + " // ([.[] | select(.primary and .verified) | .email] | first)'");
+                + "([.[] | select(.primary and .verified) | .email] | first)"
+                + " // ([.[] | select(.verified and (.email | endswith(\"@users.noreply.github.com\") | not)) | .email] | first)"
+                + " // ([.[] | select(.email | endswith(\"@users.noreply.github.com\")) | .email] | first)'");
         if (!result.success() || result.stdout().isBlank() || result.stdout().strip().equals("null")) {
             return null;
         }

--- a/src/test/java/dev/incusspawn/command/InitCommandTest.java
+++ b/src/test/java/dev/incusspawn/command/InitCommandTest.java
@@ -2,9 +2,7 @@ package dev.incusspawn.command;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 class InitCommandTest {
 
@@ -70,5 +68,84 @@ class InitCommandTest {
     void subidRangeCoversMalformedLine() {
         assertFalse(InitCommand.subidRangeCovers("root:abc:1", "root", 1000, 1));
         assertFalse(InitCommand.subidRangeCovers("root", "root", 1000, 1));
+    }
+
+    // --- parseGitHubEmails ---
+
+    @Test
+    void parseEmailsReturnsPrimaryVerifiedEmail() {
+        var json = """
+                [
+                  {"email":"primary@example.com","primary":true,"verified":true},
+                  {"email":"other@example.com","primary":false,"verified":true}
+                ]""";
+        var result = InitCommand.parseGitHubEmails(json);
+        assertNotNull(result);
+        assertEquals(java.util.List.of("primary@example.com", "other@example.com"), result.verified());
+        assertEquals("primary@example.com", result.primary());
+    }
+
+    @Test
+    void parseEmailsFiltersUnverified() {
+        var json = """
+                [
+                  {"email":"unverified@example.com","primary":false,"verified":false},
+                  {"email":"verified@example.com","primary":false,"verified":true}
+                ]""";
+        var result = InitCommand.parseGitHubEmails(json);
+        assertNotNull(result);
+        assertEquals(java.util.List.of("verified@example.com"), result.verified());
+        assertNull(result.primary());
+    }
+
+    @Test
+    void parseEmailsFiltersNoreply() {
+        var json = """
+                [
+                  {"email":"12345+user@users.noreply.github.com","primary":false,"verified":true},
+                  {"email":"real@example.com","primary":false,"verified":true}
+                ]""";
+        var result = InitCommand.parseGitHubEmails(json);
+        assertNotNull(result);
+        assertEquals(java.util.List.of("real@example.com"), result.verified());
+    }
+
+    @Test
+    void parseEmailsReturnsNullWhenAllNoreply() {
+        var json = """
+                [{"email":"12345+user@users.noreply.github.com","primary":true,"verified":true}]""";
+        assertNull(InitCommand.parseGitHubEmails(json));
+    }
+
+    @Test
+    void parseEmailsReturnsNullOnEmptyArray() {
+        assertNull(InitCommand.parseGitHubEmails("[]"));
+    }
+
+    @Test
+    void parseEmailsReturnsNullOnMalformedJson() {
+        assertNull(InitCommand.parseGitHubEmails("not json"));
+    }
+
+    @Test
+    void parseEmailsDoesNotMisidentifyPrimaryFalseAsTrue() {
+        var json = """
+                [
+                  {"email":"not-primary@example.com","primary":false,"verified":true},
+                  {"email":"actual-primary@example.com","primary":true,"verified":true}
+                ]""";
+        var result = InitCommand.parseGitHubEmails(json);
+        assertNotNull(result);
+        assertEquals("actual-primary@example.com", result.primary());
+    }
+
+    @Test
+    void parseEmailsHandlesFieldsInAnyOrder() {
+        var json = """
+                [{"verified":true,"primary":true,"email":"any-order@example.com"}]""";
+        var result = InitCommand.parseGitHubEmails(json);
+        assertNotNull(result);
+        assertEquals(java.util.List.of("any-order@example.com"), result.verified());
+        assertEquals("any-order@example.com", result.primary());
     }
 }


### PR DESCRIPTION
- Verify that GitHub PAT allows access to emails during init
- Prefer verified/primary emails over no-reply ones
- When there are more than 1 verified/primary emails, allow users to select which one to use
- Save the selected email during init in config, so it can be used when building containers
- If no email is saved, revert to asking GitHub again when building containers