### PR TITLE
Fix install.sh version detection when JAVA_TOOL_OPTIONS is set

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -83,7 +83,7 @@ else
         echo "  Set JAVA_HOME to a Java 25+ installation, or build with --native to avoid the Java requirement."
         exit 1
     fi
-    JAVA_VER=$("$JAVA_BIN" -version 2>&1 | head -1 | grep -oE '"[^"]+"' | tr -d '"')
+    JAVA_VER=$("$JAVA_BIN" -version 2>&1 | grep -oE '"[^"]+"' | head -1 | tr -d '"')
     case "$JAVA_VER" in
         1.*) JAVA_MAJOR=$(echo "$JAVA_VER" | cut -d. -f2) ;;
         *)   JAVA_MAJOR=$(echo "$JAVA_VER" | cut -d. -f1) ;;


### PR DESCRIPTION
## Summary
- `install.sh` used `head -1 | grep` to extract the Java version, but `JAVA_TOOL_OPTIONS` prepends a "Picked up..." line to stderr, so `head -1` grabbed that instead of the version string
- Swap to `grep | head -1` so the quoted version string is found first regardless of noise lines
- Same class of fix as 9740a40 (which fixed `ProxyService.java`), now applied to `install.sh`

## Test plan
- [x] Verified: `JAVA_HOME=/usr/lib/jvm/java-25 ./install.sh` now succeeds with `JAVA_TOOL_OPTIONS` set