### PR TITLE
Add AKI/SKI extensions to MITM proxy certificates

### DIFF
--- a/.github/scripts/test-instance.sh
+++ b/.github/scripts/test-instance.sh
@@ -122,6 +122,26 @@ assert "ISX_CONTAINER is set (matches hostname)" \
     su -l agentuser -c 'bash -c "source ~/.bashrc 2>/dev/null; test -n \"\$ISX_CONTAINER\""'
 echo ""
 
+# --- 7. TLS certificate quality (AKI/SKI extensions) ---
+# Python 3.14+ (OpenSSL 3.5+) rejects MITM leaf certs missing Authority
+# Key Identifier or Subject Key Identifier extensions.
+echo "[7] TLS Certificate Quality (AKI/SKI)"
+dnf install -y -q python3 openssl 2>/dev/null
+assert "Python accepts MITM proxy cert chain" \
+    python3 -c "
+import urllib.request
+urllib.request.urlopen(
+    'https://repo1.maven.org/maven2/junit/junit/4.13.2/junit-4.13.2.pom',
+    timeout=30)
+"
+assert "leaf cert has Authority Key Identifier" \
+    bash -c "echo | openssl s_client -connect repo1.maven.org:443 2>/dev/null \
+        | openssl x509 -noout -text | grep -q 'Authority Key Identifier'"
+assert "leaf cert has Subject Key Identifier" \
+    bash -c "echo | openssl s_client -connect repo1.maven.org:443 2>/dev/null \
+        | openssl x509 -noout -text | grep -q 'Subject Key Identifier'"
+echo ""
+
 echo "========================================"
 printf " Results: \033[1m%d/%d passed\033[0m" "$PASS" "$TESTS"
 if [ "$FAIL" -gt 0 ]; then

--- a/src/main/java/dev/incusspawn/DerEncoder.java
+++ b/src/main/java/dev/incusspawn/DerEncoder.java
@@ -24,15 +24,19 @@ public final class DerEncoder {
 
     // --- Extension OIDs ---
 
-    private static final byte[] OID_BASIC_CONSTRAINTS = {0x06, 0x03, 0x55, 0x1d, 0x13}; // 2.5.29.19
-    private static final byte[] OID_SUBJECT_ALT_NAME  = {0x06, 0x03, 0x55, 0x1d, 0x11}; // 2.5.29.17
-    private static final byte[] OID_KEY_USAGE          = {0x06, 0x03, 0x55, 0x1d, 0x0f}; // 2.5.29.15
+    private static final byte[] OID_BASIC_CONSTRAINTS        = {0x06, 0x03, 0x55, 0x1d, 0x13}; // 2.5.29.19
+    private static final byte[] OID_SUBJECT_ALT_NAME         = {0x06, 0x03, 0x55, 0x1d, 0x11}; // 2.5.29.17
+    private static final byte[] OID_KEY_USAGE                 = {0x06, 0x03, 0x55, 0x1d, 0x0f}; // 2.5.29.15
+    private static final byte[] OID_SUBJECT_KEY_IDENTIFIER   = {0x06, 0x03, 0x55, 0x1d, 0x0e}; // 2.5.29.14
+    private static final byte[] OID_AUTHORITY_KEY_IDENTIFIER = {0x06, 0x03, 0x55, 0x1d, 0x23}; // 2.5.29.35
 
     public static byte[] sha256WithRsaAid()    { return SHA256_WITH_RSA_AID.clone(); }
     public static byte[] sha384WithEcdsaAid()  { return SHA384_WITH_ECDSA_AID.clone(); }
     public static byte[] oidBasicConstraints() { return OID_BASIC_CONSTRAINTS.clone(); }
     public static byte[] oidSubjectAltName()   { return OID_SUBJECT_ALT_NAME.clone(); }
-    public static byte[] oidKeyUsage()         { return OID_KEY_USAGE.clone(); }
+    public static byte[] oidKeyUsage()                { return OID_KEY_USAGE.clone(); }
+    public static byte[] oidSubjectKeyIdentifier()   { return OID_SUBJECT_KEY_IDENTIFIER.clone(); }
+    public static byte[] oidAuthorityKeyIdentifier() { return OID_AUTHORITY_KEY_IDENTIFIER.clone(); }
 
     // --- Core DER primitives ---
 

--- a/src/main/java/dev/incusspawn/proxy/CertStore.java
+++ b/src/main/java/dev/incusspawn/proxy/CertStore.java
@@ -86,6 +86,9 @@ public class CertStore {
         } catch (Exception e) {
             return false;
         }
+        // Re-mint if the cert lacks AKI or SKI (pre-fix certs without RFC 5280 extensions).
+        if (cert.getExtensionValue("2.5.29.35") == null
+                || cert.getExtensionValue("2.5.29.14") == null) return false;
         // Re-mint if expired or close to expiry.
         return cert.getNotAfter().after(new Date(System.currentTimeMillis() + RENEW_BEFORE_EXPIRY_MS));
     }

--- a/src/main/java/dev/incusspawn/proxy/CertificateAuthority.java
+++ b/src/main/java/dev/incusspawn/proxy/CertificateAuthority.java
@@ -12,7 +12,9 @@ import java.nio.file.Path;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.security.KeyFactory;
 import java.security.KeyPairGenerator;
+import java.security.MessageDigest;
 import java.security.PrivateKey;
+import java.security.PublicKey;
 import java.security.SecureRandom;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
@@ -89,6 +91,11 @@ public class CertificateAuthority {
             var expiry = new Date(notBefore.getTime() + 366L * 24 * 60 * 60 * 1000);
             var serial = new BigInteger(128, new SecureRandom());
 
+            var caKeyId = computeKeyIdentifier(caCert.getPublicKey());
+            // AKI value: SEQUENCE { [0] IMPLICIT KeyIdentifier }
+            var akiValue = derSequence(concat(
+                    new byte[]{(byte) 0x80}, derLength(caKeyId.length), caKeyId));
+
             var algId = sha256WithRsaAid();
             var tbsCert = derSequence(concat(
                     derExplicit(0, derInteger(BigInteger.valueOf(2))),   // v3
@@ -102,7 +109,10 @@ public class CertificateAuthority {
                             derExtension(oidBasicConstraints(), true,
                                     derSequence(new byte[]{0x01, 0x01, 0x00})),
                             derExtension(oidSubjectAltName(), false,
-                                    derSequence(derDnsName(domain)))
+                                    derSequence(derDnsName(domain))),
+                            derExtension(oidSubjectKeyIdentifier(), false,
+                                    derOctetString(computeKeyIdentifier(keyPair.getPublic()))),
+                            derExtension(oidAuthorityKeyIdentifier(), false, akiValue)
                     )))
             ));
 
@@ -182,6 +192,51 @@ public class CertificateAuthority {
 
     // --- Private helpers ---
 
+    /**
+     * Compute the key identifier per RFC 5280 §4.2.1.2 method 1:
+     * SHA-1 hash of the BIT STRING subjectPublicKey value (excluding
+     * tag, length, and unused-bits octet) from SubjectPublicKeyInfo.
+     */
+    static byte[] computeKeyIdentifier(PublicKey key) throws Exception {
+        var spki = key.getEncoded();
+        // SubjectPublicKeyInfo = SEQUENCE { AlgorithmIdentifier, BIT STRING }
+        // Skip outer SEQUENCE tag+length, then skip AlgorithmIdentifier TLV
+        int pos = 1 + derLengthSize(spki, 1);
+        pos += tlvLength(spki, pos);
+        // Now at BIT STRING: skip tag, length, unused-bits byte
+        pos += 1 + derLengthSize(spki, pos + 1) + 1;
+        var keyBytes = new byte[spki.length - pos];
+        System.arraycopy(spki, pos, keyBytes, 0, keyBytes.length);
+        return MessageDigest.getInstance("SHA-1").digest(keyBytes);
+    }
+
+    /** Return the number of bytes in a DER length field starting at {@code offset}. */
+    private static int derLengthSize(byte[] data, int offset) {
+        int first = data[offset] & 0xff;
+        if (first < 128) return 1;
+        return 1 + (first & 0x7f);
+    }
+
+    /** Return the total TLV (tag + length + value) byte count of the element at {@code offset}. */
+    private static int tlvLength(byte[] data, int offset) {
+        int start = offset;
+        offset++; // skip tag
+        int first = data[offset] & 0xff;
+        int len;
+        if (first < 128) {
+            len = first;
+            offset++;
+        } else {
+            int numBytes = first & 0x7f;
+            len = 0;
+            offset++;
+            for (int i = 0; i < numBytes; i++) {
+                len = (len << 8) | (data[offset++] & 0xff);
+            }
+        }
+        return (offset - start) + len;
+    }
+
     private static CertificateAuthority load() throws Exception {
         var key = loadPrivateKey(caKeyFile());
         var cert = loadCertificate(caCertFile());
@@ -216,7 +271,9 @@ public class CertificateAuthority {
                 derExplicit(3, derSequence(concat(
                         derExtension(oidBasicConstraints(), true,
                                 derSequence(new byte[]{0x01, 0x01, (byte) 0xff})),
-                        derExtension(oidKeyUsage(), true, keyUsageBits)
+                        derExtension(oidKeyUsage(), true, keyUsageBits),
+                        derExtension(oidSubjectKeyIdentifier(), false,
+                                derOctetString(computeKeyIdentifier(keyPair.getPublic())))
                 )))
         ));
 

--- a/src/test/java/dev/incusspawn/proxy/CertStoreTest.java
+++ b/src/test/java/dev/incusspawn/proxy/CertStoreTest.java
@@ -6,9 +6,17 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import java.io.ByteArrayInputStream;
+import java.math.BigInteger;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.security.KeyPairGenerator;
+import java.security.SecureRandom;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import java.util.Date;
 
+import static dev.incusspawn.DerEncoder.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 class CertStoreTest {
@@ -78,5 +86,93 @@ class CertStoreTest {
         // is comfortably in the past relative to now.
         assertTrue(entry.cert().getNotBefore().toInstant().isBefore(java.time.Instant.now().minusSeconds(3600)),
                 "notBefore should be backdated well before now");
+    }
+
+    @Test
+    void leafCertHasAkiAndSki() throws Exception {
+        var ca = CertificateAuthority.loadOrCreate();
+        var entry = new CertStore(ca).get("aki-ski.example.com");
+        var cert = entry.cert();
+
+        assertNotNull(cert.getExtensionValue("2.5.29.14"),
+                "leaf cert must have Subject Key Identifier");
+        assertNotNull(cert.getExtensionValue("2.5.29.35"),
+                "leaf cert must have Authority Key Identifier");
+
+        // The AKI key identifier must match the SHA-1 of the CA's public key
+        var caKeyId = CertificateAuthority.computeKeyIdentifier(ca.caCert().getPublicKey());
+        var akiRaw = cert.getExtensionValue("2.5.29.35");
+        assertNotNull(akiRaw);
+        // akiRaw is an OCTET STRING wrapping the extension value;
+        // verify it contains the CA key identifier bytes
+        var akiHex = java.util.HexFormat.of().formatHex(akiRaw);
+        var caKeyIdHex = java.util.HexFormat.of().formatHex(caKeyId);
+        assertTrue(akiHex.contains(caKeyIdHex),
+                "AKI must contain the CA's key identifier");
+    }
+
+    @Test
+    void caCertHasSki() throws Exception {
+        var ca = CertificateAuthority.loadOrCreate();
+        assertNotNull(ca.caCert().getExtensionValue("2.5.29.14"),
+                "CA cert must have Subject Key Identifier");
+    }
+
+    @Test
+    void remintsLegacyCertWithoutAki() throws Exception {
+        var ca = CertificateAuthority.loadOrCreate();
+
+        // Build a leaf cert the way the old code did: basicConstraints + SAN only,
+        // no AKI/SKI. This simulates what's on disk after an upgrade.
+        var domain = "legacy.example.com";
+        var keyGen = KeyPairGenerator.getInstance("RSA");
+        keyGen.initialize(2048);
+        var keyPair = keyGen.generateKeyPair();
+        var notBefore = new Date(System.currentTimeMillis() - 86400_000L);
+        var expiry = new Date(notBefore.getTime() + 366L * 24 * 60 * 60 * 1000);
+        var serial = new BigInteger(128, new SecureRandom());
+        var algId = sha256WithRsaAid();
+        var tbsCert = derSequence(concat(
+                derExplicit(0, derInteger(BigInteger.valueOf(2))),
+                derInteger(serial),
+                algId,
+                ca.caCert().getSubjectX500Principal().getEncoded(),
+                derSequence(concat(derUtcTime(notBefore), derUtcTime(expiry))),
+                derDistinguishedName(domain),
+                keyPair.getPublic().getEncoded(),
+                derExplicit(3, derSequence(concat(
+                        derExtension(oidBasicConstraints(), true,
+                                derSequence(new byte[]{0x01, 0x01, 0x00})),
+                        derExtension(oidSubjectAltName(), false,
+                                derSequence(derDnsName(domain)))
+                )))
+        ));
+        var sig = java.security.Signature.getInstance("SHA256withRSA");
+        sig.initSign(ca.caKey());
+        sig.update(tbsCert);
+        var certDer = derSequence(concat(tbsCert, algId, derBitString(sig.sign())));
+        var legacyCert = (X509Certificate) CertificateFactory.getInstance("X.509")
+                .generateCertificate(new ByteArrayInputStream(certDer));
+
+        // Sanity: the handcrafted cert has no AKI or SKI
+        assertNull(legacyCert.getExtensionValue("2.5.29.35"));
+        assertNull(legacyCert.getExtensionValue("2.5.29.14"));
+
+        // Persist it to the cert store directory, mimicking the old proxy
+        var certsDir = SpawnConfig.configDir().resolve("certs");
+        Files.createDirectories(certsDir);
+        Files.writeString(certsDir.resolve(domain + ".crt"),
+                toPem("CERTIFICATE", legacyCert.getEncoded()));
+        Files.writeString(certsDir.resolve(domain + ".key"),
+                toPem("PRIVATE KEY", keyPair.getPrivate().getEncoded()));
+
+        // A fresh CertStore must reject the legacy cert and re-mint
+        var reminted = new CertStore(ca).get(domain);
+        assertNotEquals(serial, reminted.cert().getSerialNumber(),
+                "legacy cert without AKI/SKI must be re-minted, not reused");
+        assertNotNull(reminted.cert().getExtensionValue("2.5.29.35"),
+                "re-minted cert must have AKI");
+        assertNotNull(reminted.cert().getExtensionValue("2.5.29.14"),
+                "re-minted cert must have SKI");
     }
 }


### PR DESCRIPTION
Python 3.14 / OpenSSL 3.5 rejects leaf certificates that lack Authority Key Identifier (AKI) and Subject Key Identifier (SKI) extensions. This breaks any Python-based tool that validates TLS connections through the MITM proxy (e.g. headroom, pip).

This PR adds both extensions per RFC 5280:
- **SKI** on CA certs (new CAs only; existing CAs on disk are not regenerated)
- **SKI + AKI** on leaf certs
- Existing cached leaf certs without AKI are automatically re-minted on the next proxy start

No impact on existing containers — leaf certs are re-minted with the same CA, so the trust chain is preserved.

## Test plan

- [x] Unit tests: AKI/SKI presence on leaf and CA certs, AKI key identifier matches CA public key, legacy certs without AKI are re-minted
- [x] Integration test: Python `urllib.request.urlopen()` through the MITM proxy + explicit `openssl` AKI/SKI checks (added to `test-instance.sh`)
- [x] `openssl x509 -text` confirms extensions on generated certs
- [x] Python 3.14 / OpenSSL 3.5 TLS validation succeeds against the MITM proxy