### PR TITLE
Add built-in headroom tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -580,6 +580,19 @@ zmx run isx-my-branch git status      # run a command in the container's session
 
 All zmx commands work natively, including interactive `zmx attach`. On macOS, where Incus runs inside a VM, host-side socket sharing is not available. zmx sessions still work inside containers — `isx shell` (or Enter in the TUI) auto-attaches, and sessions persist across disconnections.
 
+### Context Optimization (headroom)
+
+The built-in `headroom` tool installs [Headroom](https://github.com/nicobrenner/headroom), a context optimization proxy for Claude Code. It runs as a local proxy on port 8787 that compresses conversation context, reducing token usage and improving response quality on long sessions. An MCP server is also registered with Claude Code for direct integration.
+
+```yaml
+name: tpl-agent
+parent: tpl-java
+tools:
+  - headroom    # auto-installs claude via requires
+```
+
+The tool sets `ANTHROPIC_BASE_URL=http://localhost:8787` so Claude Code routes through the optimization proxy. The proxy runs as a systemd user service and starts automatically on container boot.
+
 ### Tool Parameters
 
 Tools can define parameters for build-time configuration. Parameter types: `string` (with optional `pattern`), `integer` (with `min`/`max`), `boolean`, and `enum` (with `options`). Use `${param_name}` to reference values in scripts, env, and file content:

--- a/src/main/java/dev/incusspawn/tool/ToolDefLoader.java
+++ b/src/main/java/dev/incusspawn/tool/ToolDefLoader.java
@@ -23,6 +23,7 @@ public class ToolDefLoader {
 
     private static final String RESOURCE_DIR = "tools/";
     private static final List<String> BUILTIN_TOOLS = List.of(
+            "headroom.yaml",
             "podman.yaml",
             "maven-3.yaml",
             "sshd.yaml",

--- a/src/main/resources/tools/headroom.yaml
+++ b/src/main/resources/tools/headroom.yaml
@@ -1,0 +1,44 @@
+name: headroom
+description: Headroom context optimization for Claude Code
+requires:
+  - claude
+
+packages:
+  - python3-pip
+
+run:
+  - loginctl enable-linger agentuser
+  - |
+    mkdir -p /etc/systemd/system/user@.service.d
+    cat > /etc/systemd/system/user@.service.d/xdg-runtime.conf << 'EOF'
+    [Service]
+    Environment=XDG_RUNTIME_DIR=/run/user/%i
+    EOF
+
+run_as_user:
+  - pip install --user --quiet 'headroom-ai[proxy,mcp]'
+  - claude mcp add headroom -s user -- headroom mcp serve
+  - |
+    mkdir -p ~/.config/systemd/user/default.target.wants
+    cat > ~/.config/systemd/user/headroom-proxy.service << 'EOF'
+    [Unit]
+    Description=Headroom optimization proxy
+    After=network.target
+
+    [Service]
+    ExecStart=%h/.local/bin/headroom proxy
+    Restart=on-failure
+    RestartSec=3
+
+    [Install]
+    WantedBy=default.target
+    EOF
+    ln -sf ../headroom-proxy.service ~/.config/systemd/user/default.target.wants/headroom-proxy.service
+
+env:
+  - name: ANTHROPIC_BASE_URL
+    value: "http://localhost:8787"
+
+verify: /home/agentuser/.local/bin/headroom --version
+
+ready: curl -sf http://localhost:8787/livez

--- a/src/main/resources/tools/headroom.yaml
+++ b/src/main/resources/tools/headroom.yaml
@@ -23,7 +23,6 @@ run_as_user:
     cat > ~/.config/systemd/user/headroom-proxy.service << 'EOF'
     [Unit]
     Description=Headroom optimization proxy
-    After=network.target
 
     [Service]
     ExecStart=%h/.local/bin/headroom proxy

--- a/src/test/java/dev/incusspawn/tool/ToolDefTest.java
+++ b/src/test/java/dev/incusspawn/tool/ToolDefTest.java
@@ -772,6 +772,34 @@ class ToolDefTest {
         assertNotEquals(a.contentFingerprint(), b.contentFingerprint());
     }
 
+    @Test
+    void builtinHeadroomToolLoads() throws Exception {
+        try (var is = getClass().getClassLoader().getResourceAsStream("tools/headroom.yaml")) {
+            assertNotNull(is, "headroom.yaml must be on the classpath");
+            var def = ToolDef.loadFromStream(is);
+
+            assertEquals("headroom", def.getName());
+            assertEquals(List.of("claude"),
+                    def.getRequires().stream().map(ToolDef.ToolRef::getName).toList());
+            assertEquals(List.of("python3-pip"), def.getPackages());
+            assertNotNull(def.getRun());
+            assertFalse(def.getRun().isEmpty());
+            assertNotNull(def.getRunAsUser());
+            assertFalse(def.getRunAsUser().isEmpty());
+            assertNotNull(def.getVerify());
+            assertNotNull(def.getReady());
+
+            var envNames = def.getEnv().stream()
+                    .filter(e -> !e.isRaw())
+                    .map(e -> e.getName())
+                    .toList();
+            assertTrue(envNames.contains("ANTHROPIC_BASE_URL"),
+                    "headroom must set ANTHROPIC_BASE_URL");
+            assertFalse(envNames.contains("HEADROOM_TLS_STRICT"),
+                    "headroom should not set HEADROOM_TLS_STRICT (root cause is fixed in cert generation)");
+        }
+    }
+
     private static ByteArrayInputStream toStream(String yaml) {
         return new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8));
     }


### PR DESCRIPTION
Add [Headroom](https://github.com/nicobrenner/headroom) as a built-in YAML tool. It installs a context optimization proxy for Claude Code that compresses conversation context, reducing token usage on long sessions.

The tool:
- Installs `headroom-ai[proxy,mcp]` via pip
- Registers an MCP server with Claude Code
- Runs the optimization proxy as a systemd user service (port 8787)
- Sets `ANTHROPIC_BASE_URL=http://localhost:8787` so Claude Code routes through it

**Depends on #411** — without the AKI/SKI cert fix, Python 3.14 / OpenSSL 3.5 rejects the MITM proxy's certificates, and headroom would need a `HEADROOM_TLS_STRICT=0` workaround. With the fix, no workaround is needed.

## Test plan

- [x] YAML tool definition loads and parses correctly (unit test)
- [x] Built a template with headroom, branched a container — headroom installed, service running, port listening, MCP registered
- [x] No `HEADROOM_TLS_STRICT` in env (root cause fixed by #411)