### PR TITLE
Fix stale iptables redirect when Incus bridge IP changes

### DIFF
--- a/src/main/java/dev/incusspawn/command/DoctorCommand.java
+++ b/src/main/java/dev/incusspawn/command/DoctorCommand.java
@@ -556,12 +556,19 @@ public class DoctorCommand extends BaseCommand {
 
     private Finding checkUfwRedirect() {
         try {
+            var gatewayIp = MitmProxy.resolveGatewayIp(RuntimeServices.incus());
             var beforeRules = UfwCheck.readBeforeRules();
             if (beforeRules.isEmpty()) {
                 return Finding.warn("Firewall PREROUTING redirect", "(could not read /etc/ufw/before.rules)", null);
             }
-            if (UfwCheck.hasPreRoutingRedirect(beforeRules, MitmProxy.DEFAULT_MITM_PORT)) {
+            if (UfwCheck.hasPreRoutingRedirect(beforeRules, MitmProxy.DEFAULT_MITM_PORT, gatewayIp)) {
                 return Finding.ok("Firewall PREROUTING redirect (UFW)", "443 -> " + MitmProxy.DEFAULT_MITM_PORT);
+            }
+            var staleIp = UfwCheck.extractRedirectGatewayIp(beforeRules, MitmProxy.DEFAULT_MITM_PORT);
+            if (staleIp != null) {
+                return Finding.fail("Firewall PREROUTING redirect",
+                        "rule points to stale gateway " + staleIp + " (current: " + gatewayIp + ")",
+                        new Remediation("Re-run 'isx init' to update firewall rules", false, null));
             }
             return Finding.fail("Firewall PREROUTING redirect", "rule not found in /etc/ufw/before.rules",
                     new Remediation("Re-run 'isx init' to configure firewall rules", false, null));

--- a/src/main/java/dev/incusspawn/command/DoctorCommand.java
+++ b/src/main/java/dev/incusspawn/command/DoctorCommand.java
@@ -537,8 +537,15 @@ public class DoctorCommand extends BaseCommand {
             if (exitCode != 0) {
                 return Finding.warn("Firewall PREROUTING redirect", "(could not query firewalld rules)", null);
             }
-            if (isPreRoutingRulePresent(output, MitmProxy.DEFAULT_MITM_PORT)) {
+            var gatewayIp = MitmProxy.resolveGatewayIp(RuntimeServices.incus());
+            if (isPreRoutingRulePresent(output, MitmProxy.DEFAULT_MITM_PORT, gatewayIp)) {
                 return Finding.ok("Firewall PREROUTING redirect (firewalld)", "443 -> " + MitmProxy.DEFAULT_MITM_PORT);
+            }
+            var staleIp = FirewalldCheck.extractRedirectGatewayIp(output, MitmProxy.DEFAULT_MITM_PORT);
+            if (staleIp != null) {
+                return Finding.fail("Firewall PREROUTING redirect",
+                        "rule points to stale gateway " + staleIp + " (current: " + gatewayIp + ")",
+                        new Remediation("Re-run 'isx init' to update iptables rules", false, null));
             }
             return Finding.fail("Firewall PREROUTING redirect", "rule not found",
                     new Remediation("Re-run 'isx init' to configure iptables rules", false, null));
@@ -563,8 +570,8 @@ public class DoctorCommand extends BaseCommand {
         }
     }
 
-    static boolean isPreRoutingRulePresent(String firewalldOutput, int mitmPort) {
-        return FirewalldCheck.isPreRoutingRulePresent(firewalldOutput, mitmPort);
+    static boolean isPreRoutingRulePresent(String firewalldOutput, int mitmPort, String gatewayIp) {
+        return FirewalldCheck.isPreRoutingRulePresent(firewalldOutput, mitmPort, gatewayIp);
     }
 
     // ---- Layer 6: Templates ----

--- a/src/main/java/dev/incusspawn/command/InitCommand.java
+++ b/src/main/java/dev/incusspawn/command/InitCommand.java
@@ -670,12 +670,23 @@ public class InitCommand extends BaseCommand {
 
     private void configureMitmProxyFirewalld(String gatewayIp) {
         var rulesOutput = captureOutput("firewall-cmd", "--direct", "--get-all-rules");
-        boolean hasRedirect = FirewalldCheck.isPreRoutingRulePresent(rulesOutput, MitmProxy.DEFAULT_MITM_PORT);
+        boolean hasRedirect = FirewalldCheck.isPreRoutingRulePresent(rulesOutput, MitmProxy.DEFAULT_MITM_PORT, gatewayIp);
 
         if (hasRedirect) {
             System.out.println("  PREROUTING redirect already configured (" + gatewayIp + ":443 -> "
                     + MitmProxy.DEFAULT_MITM_PORT + ").");
         } else {
+            // Remove stale redirect rule pointing to a previous gateway IP
+            var staleIp = FirewalldCheck.extractRedirectGatewayIp(rulesOutput, MitmProxy.DEFAULT_MITM_PORT);
+            if (staleIp != null) {
+                System.out.println("  Removing stale PREROUTING redirect (old gateway " + staleIp + ")...");
+                runHostQuiet("sudo", "firewall-cmd", "--permanent", "--direct",
+                        "--remove-rule", "ipv4", "nat", "PREROUTING", "0",
+                        "-i", "incusbr0", "-d", staleIp, "-p", "tcp", "--dport",
+                        String.valueOf(MitmProxy.CONTAINER_FACING_PORT),
+                        "-j", "REDIRECT", "--to-port",
+                        String.valueOf(MitmProxy.DEFAULT_MITM_PORT));
+            }
             System.out.println("  Adding iptables PREROUTING redirect (" + gatewayIp + ":443 -> "
                     + MitmProxy.DEFAULT_MITM_PORT + " on incusbr0)...");
             runHostQuiet("sudo", "firewall-cmd", "--permanent", "--direct",

--- a/src/main/java/dev/incusspawn/command/InitCommand.java
+++ b/src/main/java/dev/incusspawn/command/InitCommand.java
@@ -711,12 +711,16 @@ public class InitCommand extends BaseCommand {
             System.err.println("  Warning: could not read /etc/ufw/before.rules. Skipping PREROUTING redirect.");
             return;
         }
-        boolean hasRedirect = UfwCheck.hasPreRoutingRedirect(beforeRules, MitmProxy.DEFAULT_MITM_PORT);
+        boolean hasRedirect = UfwCheck.hasPreRoutingRedirect(beforeRules, MitmProxy.DEFAULT_MITM_PORT, gatewayIp);
 
         if (hasRedirect) {
             System.out.println("  PREROUTING redirect already configured (" + gatewayIp + ":443 -> "
                     + MitmProxy.DEFAULT_MITM_PORT + ").");
         } else {
+            var staleIp = UfwCheck.extractRedirectGatewayIp(beforeRules, MitmProxy.DEFAULT_MITM_PORT);
+            if (staleIp != null) {
+                System.out.println("  Removing stale PREROUTING redirect (old gateway " + staleIp + ")...");
+            }
             System.out.println("  Adding PREROUTING redirect (" + gatewayIp + ":443 -> "
                     + MitmProxy.DEFAULT_MITM_PORT + " on incusbr0) to UFW before.rules...");
             var subnet = CidrUtils.deriveSubnet(gatewayIp);

--- a/src/main/java/dev/incusspawn/incus/FirewalldCheck.java
+++ b/src/main/java/dev/incusspawn/incus/FirewalldCheck.java
@@ -50,10 +50,10 @@ public final class FirewalldCheck {
         }
     }
 
-    public static boolean isPreRoutingRulePresent(String firewalldOutput, int mitmPort) {
+    public static boolean isPreRoutingRulePresent(String firewalldOutput, int mitmPort, String gatewayIp) {
         for (var line : firewalldOutput.split("\n")) {
             if (line.contains("nat") && line.contains("PREROUTING")
-                    && line.contains("incusbr0") && line.contains("-d ")
+                    && line.contains("incusbr0") && line.contains("-d " + gatewayIp)
                     && line.contains("--dport 443")
                     && line.contains("REDIRECT")
                     && line.contains("--to-port " + mitmPort)) {
@@ -61,6 +61,25 @@ public final class FirewalldCheck {
             }
         }
         return false;
+    }
+
+    /** Extract the gateway IP from an existing PREROUTING redirect rule, or null if none found. */
+    public static String extractRedirectGatewayIp(String firewalldOutput, int mitmPort) {
+        for (var line : firewalldOutput.split("\n")) {
+            if (line.contains("nat") && line.contains("PREROUTING")
+                    && line.contains("incusbr0") && line.contains("-d ")
+                    && line.contains("--dport 443")
+                    && line.contains("REDIRECT")
+                    && line.contains("--to-port " + mitmPort)) {
+                int idx = line.indexOf("-d ");
+                if (idx >= 0) {
+                    var rest = line.substring(idx + 3).strip();
+                    int end = rest.indexOf(' ');
+                    return end > 0 ? rest.substring(0, end) : rest;
+                }
+            }
+        }
+        return null;
     }
 
     public static boolean isForwardRulePresent(String firewalldOutput, String interfaceFlag, String interfaceName) {

--- a/src/main/java/dev/incusspawn/incus/UfwCheck.java
+++ b/src/main/java/dev/incusspawn/incus/UfwCheck.java
@@ -96,6 +96,35 @@ public final class UfwCheck {
                 && block.contains("--to-port " + mitmPort);
     }
 
+    public static boolean hasPreRoutingRedirect(String beforeRulesContent, int mitmPort, String gatewayIp) {
+        if (!hasNatBlock(beforeRulesContent)) return false;
+        var block = extractBlock(beforeRulesContent, MARKER_NAT_BEGIN, MARKER_NAT_END);
+        return block.contains("PREROUTING")
+                && block.contains("incusbr0")
+                && block.contains("-d " + gatewayIp)
+                && block.contains("--dport 443")
+                && block.contains("REDIRECT")
+                && block.contains("--to-port " + mitmPort);
+    }
+
+    public static String extractRedirectGatewayIp(String beforeRulesContent, int mitmPort) {
+        if (!hasNatBlock(beforeRulesContent)) return null;
+        var block = extractBlock(beforeRulesContent, MARKER_NAT_BEGIN, MARKER_NAT_END);
+        for (var line : block.split("\n")) {
+            if (line.contains("PREROUTING") && line.contains("incusbr0")
+                    && line.contains("-d ") && line.contains("--dport 443")
+                    && line.contains("REDIRECT") && line.contains("--to-port " + mitmPort)) {
+                int idx = line.indexOf("-d ");
+                if (idx >= 0) {
+                    var rest = line.substring(idx + 3).strip();
+                    int end = rest.indexOf(' ');
+                    return end > 0 ? rest.substring(0, end) : rest;
+                }
+            }
+        }
+        return null;
+    }
+
     public static boolean hasMasquerade(String beforeRulesContent, String subnet) {
         if (!hasNatBlock(beforeRulesContent)) return false;
         var block = extractBlock(beforeRulesContent, MARKER_NAT_BEGIN, MARKER_NAT_END);

--- a/src/test/java/dev/incusspawn/command/DoctorCommandTest.java
+++ b/src/test/java/dev/incusspawn/command/DoctorCommandTest.java
@@ -89,7 +89,7 @@ class DoctorCommandTest {
                 ipv4 filter FORWARD 0 -o incusbr0 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
                 ipv4 nat PREROUTING 0 -i incusbr0 -d 10.166.11.1 -p tcp --dport 443 -j REDIRECT --to-port 18443
                 """;
-        assertTrue(DoctorCommand.isPreRoutingRulePresent(output, 18443));
+        assertTrue(DoctorCommand.isPreRoutingRulePresent(output, 18443, "10.166.11.1"));
     }
 
     @Test
@@ -97,7 +97,7 @@ class DoctorCommandTest {
         var output = """
                 ipv4 filter FORWARD 0 -o incusbr0 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
                 """;
-        assertFalse(DoctorCommand.isPreRoutingRulePresent(output, 18443));
+        assertFalse(DoctorCommand.isPreRoutingRulePresent(output, 18443, "10.166.11.1"));
     }
 
     @Test
@@ -105,7 +105,7 @@ class DoctorCommandTest {
         var output = """
                 ipv4 nat PREROUTING 0 -i incusbr0 -d 10.166.11.1 -p tcp --dport 443 -j REDIRECT --to-port 9999
                 """;
-        assertFalse(DoctorCommand.isPreRoutingRulePresent(output, 18443));
+        assertFalse(DoctorCommand.isPreRoutingRulePresent(output, 18443, "10.166.11.1"));
     }
 
     @Test
@@ -113,7 +113,7 @@ class DoctorCommandTest {
         var output = """
                 ipv4 nat PREROUTING 0 -i docker0 -d 10.166.11.1 -p tcp --dport 443 -j REDIRECT --to-port 18443
                 """;
-        assertFalse(DoctorCommand.isPreRoutingRulePresent(output, 18443));
+        assertFalse(DoctorCommand.isPreRoutingRulePresent(output, 18443, "10.166.11.1"));
     }
 
     @Test
@@ -121,12 +121,20 @@ class DoctorCommandTest {
         var output = """
                 ipv4 nat PREROUTING 0 -i incusbr0 -d 10.166.11.1 -p tcp --dport 8080 -j REDIRECT --to-port 18443
                 """;
-        assertFalse(DoctorCommand.isPreRoutingRulePresent(output, 18443));
+        assertFalse(DoctorCommand.isPreRoutingRulePresent(output, 18443, "10.166.11.1"));
+    }
+
+    @Test
+    void iptablesRuleNotMatchedWithStaleGateway() {
+        var output = """
+                ipv4 nat PREROUTING 0 -i incusbr0 -d 10.73.232.1 -p tcp --dport 443 -j REDIRECT --to-port 18443
+                """;
+        assertFalse(DoctorCommand.isPreRoutingRulePresent(output, 18443, "10.166.11.1"));
     }
 
     @Test
     void iptablesEmptyOutputReturnsFalse() {
-        assertFalse(DoctorCommand.isPreRoutingRulePresent("", 18443));
+        assertFalse(DoctorCommand.isPreRoutingRulePresent("", 18443, "10.166.11.1"));
     }
 
     // ---- Config permissions evaluation ----

--- a/src/test/java/dev/incusspawn/incus/FirewalldCheckTest.java
+++ b/src/test/java/dev/incusspawn/incus/FirewalldCheckTest.java
@@ -16,7 +16,12 @@ class FirewalldCheckTest {
 
     @Test
     void preRoutingRuleDetected() {
-        assertTrue(FirewalldCheck.isPreRoutingRulePresent(TYPICAL_OUTPUT, 18443));
+        assertTrue(FirewalldCheck.isPreRoutingRulePresent(TYPICAL_OUTPUT, 18443, "10.166.11.1"));
+    }
+
+    @Test
+    void preRoutingRuleNotMatchedWithWrongGateway() {
+        assertFalse(FirewalldCheck.isPreRoutingRulePresent(TYPICAL_OUTPUT, 18443, "10.99.99.1"));
     }
 
     @Test
@@ -24,7 +29,7 @@ class FirewalldCheckTest {
         var output = """
                 ipv4 filter FORWARD 0 -i incusbr0 -j ACCEPT
                 """;
-        assertFalse(FirewalldCheck.isPreRoutingRulePresent(output, 18443));
+        assertFalse(FirewalldCheck.isPreRoutingRulePresent(output, 18443, "10.166.11.1"));
     }
 
     @Test
@@ -32,7 +37,7 @@ class FirewalldCheckTest {
         var output = """
                 ipv4 nat PREROUTING 0 -i incusbr0 -p tcp --dport 443 -j REDIRECT --to-port 18443
                 """;
-        assertFalse(FirewalldCheck.isPreRoutingRulePresent(output, 18443));
+        assertFalse(FirewalldCheck.isPreRoutingRulePresent(output, 18443, "10.166.11.1"));
     }
 
     @Test
@@ -40,12 +45,40 @@ class FirewalldCheckTest {
         var output = """
                 ipv4 nat PREROUTING 0 -i incusbr0 -d 10.166.11.1 -p tcp --dport 443 -j REDIRECT --to-port 9999
                 """;
-        assertFalse(FirewalldCheck.isPreRoutingRulePresent(output, 18443));
+        assertFalse(FirewalldCheck.isPreRoutingRulePresent(output, 18443, "10.166.11.1"));
     }
 
     @Test
     void preRoutingEmptyOutput() {
-        assertFalse(FirewalldCheck.isPreRoutingRulePresent("", 18443));
+        assertFalse(FirewalldCheck.isPreRoutingRulePresent("", 18443, "10.166.11.1"));
+    }
+
+    // ---- extractRedirectGatewayIp ----
+
+    @Test
+    void extractGatewayIpFromTypicalOutput() {
+        assertEquals("10.166.11.1", FirewalldCheck.extractRedirectGatewayIp(TYPICAL_OUTPUT, 18443));
+    }
+
+    @Test
+    void extractGatewayIpReturnsNullWhenNoRule() {
+        var output = """
+                ipv4 filter FORWARD 0 -i incusbr0 -j ACCEPT
+                """;
+        assertNull(FirewalldCheck.extractRedirectGatewayIp(output, 18443));
+    }
+
+    @Test
+    void extractGatewayIpReturnsNullForEmptyOutput() {
+        assertNull(FirewalldCheck.extractRedirectGatewayIp("", 18443));
+    }
+
+    @Test
+    void extractGatewayIpReturnsNullForWrongPort() {
+        var output = """
+                ipv4 nat PREROUTING 0 -i incusbr0 -d 10.166.11.1 -p tcp --dport 443 -j REDIRECT --to-port 9999
+                """;
+        assertNull(FirewalldCheck.extractRedirectGatewayIp(output, 18443));
     }
 
     // ---- isForwardRulePresent ----

--- a/src/test/java/dev/incusspawn/incus/UfwCheckTest.java
+++ b/src/test/java/dev/incusspawn/incus/UfwCheckTest.java
@@ -168,6 +168,50 @@ class UfwCheckTest {
         assertFalse(UfwCheck.hasPreRoutingRedirect("", 18443));
     }
 
+    // ---- hasPreRoutingRedirect (gateway-aware) ----
+
+    @Test
+    void hasPreRoutingRedirectMatchesCorrectGateway() {
+        var natBlock = UfwCheck.generateNatBlock("10.166.11.1", "10.166.11.0/24", 443, 18443);
+        var content = UfwCheck.insertNatBlock(TYPICAL_BEFORE_RULES, natBlock);
+        assertTrue(UfwCheck.hasPreRoutingRedirect(content, 18443, "10.166.11.1"));
+    }
+
+    @Test
+    void hasPreRoutingRedirectFalseForStaleGateway() {
+        var natBlock = UfwCheck.generateNatBlock("10.166.11.1", "10.166.11.0/24", 443, 18443);
+        var content = UfwCheck.insertNatBlock(TYPICAL_BEFORE_RULES, natBlock);
+        assertFalse(UfwCheck.hasPreRoutingRedirect(content, 18443, "10.73.232.1"));
+    }
+
+    // ---- extractRedirectGatewayIp ----
+
+    @Test
+    void extractRedirectGatewayIpFindsIp() {
+        var natBlock = UfwCheck.generateNatBlock("10.166.11.1", "10.166.11.0/24", 443, 18443);
+        var content = UfwCheck.insertNatBlock(TYPICAL_BEFORE_RULES, natBlock);
+        assertEquals("10.166.11.1", UfwCheck.extractRedirectGatewayIp(content, 18443));
+    }
+
+    @Test
+    void extractRedirectGatewayIpReturnsNullWhenNoRedirect() {
+        var natBlock = UfwCheck.generateNatBlockWithoutRedirect("10.166.11.0/24");
+        var content = UfwCheck.insertNatBlock(TYPICAL_BEFORE_RULES, natBlock);
+        assertNull(UfwCheck.extractRedirectGatewayIp(content, 18443));
+    }
+
+    @Test
+    void extractRedirectGatewayIpReturnsNullWhenNoNatBlock() {
+        assertNull(UfwCheck.extractRedirectGatewayIp(TYPICAL_BEFORE_RULES, 18443));
+    }
+
+    @Test
+    void extractRedirectGatewayIpReturnsNullForWrongPort() {
+        var natBlock = UfwCheck.generateNatBlock("10.166.11.1", "10.166.11.0/24", 443, 18443);
+        var content = UfwCheck.insertNatBlock(TYPICAL_BEFORE_RULES, natBlock);
+        assertNull(UfwCheck.extractRedirectGatewayIp(content, 9999));
+    }
+
     // ---- hasMasquerade ----
 
     @Test


### PR DESCRIPTION
When the Incus bridge is recreated (e.g. after a database reset or reinstall), it gets a new gateway IP. The firewalld PREROUTING redirect rule still pointed to the old IP, breaking proxy connectivity. isx init didn't detect this because isPreRoutingRulePresent matched any rule with the right shape regardless of destination IP.

Now isPreRoutingRulePresent checks the gateway IP, isx init removes stale rules before adding new ones, and isx doctor reports stale-IP rules specifically.

## Changes after rebase onto UFW support (#424)

- Rebased onto main (after #424 merge)
- Stale-IP fix applied to both firewalld and UFW paths:
  - `UfwCheck.hasPreRoutingRedirect(content, port, gatewayIp)` — gateway-aware overload
  - `UfwCheck.extractRedirectGatewayIp(content, port)` — extracts stale IP from `before.rules`
  - `DoctorCommand.checkUfwRedirect()` — reports stale-IP rules with current vs stale gateway
  - `InitCommand.configureMitmProxyUfw()` — detects and replaces stale redirect rules
- 4 new UFW tests for gateway-aware redirect detection and extraction