### PR TITLE
Configure podman for cgroupfs and permissive short image names

### DIFF
--- a/src/main/resources/tools/podman.yaml
+++ b/src/main/resources/tools/podman.yaml
@@ -18,6 +18,12 @@ run:
     printf '[Socket]\nSocketMode=0666\n' \
       > /etc/systemd/system/podman.socket.d/override.conf
 
+files:
+  - path: /etc/containers/containers.conf
+    content: |
+      [engine]
+      cgroup_manager = "cgroupfs"
+
 env:
   - name: DOCKER_HOST
     value: unix:///var/run/docker.sock

--- a/src/main/resources/tools/podman.yaml
+++ b/src/main/resources/tools/podman.yaml
@@ -23,6 +23,10 @@ files:
     content: |
       [engine]
       cgroup_manager = "cgroupfs"
+  - path: /etc/containers/registries.conf.d/10-short-names.conf
+    content: |
+      short-name-mode = "permissive"
+      unqualified-search-registries = ["docker.io"]
 
 env:
   - name: DOCKER_HOST


### PR DESCRIPTION
## Summary
- Configure `cgroup_manager = "cgroupfs"` in `/etc/containers/containers.conf` via the podman tool
- Configure `short-name-mode = "permissive"` with `docker.io` as the default registry, so `podman run alpine ...` works without prompting

## Why

**cgroupfs**: Incus exec sessions run inside the container without a full logind login session. Rootless podman defaults to the `systemd` cgroup manager, which requires a running systemd user instance (`user@<uid>.service`). Without one, podman falls back to `cgroupfs` and emits warning lines on every invocation. Configuring `cgroupfs` as the primary cgroup manager avoids the fallback entirely with zero overhead.

**short-names**: Previously this config lived in the `podman-full` template tool, but it's useful for any podman user. Moving it to the built-in tool means all containers with podman get it.

## Test plan
- [ ] `podman run --rm alpine echo hello` prints only `hello`, no warnings or registry prompts
- [ ] `podman info --format '{{.Host.CgroupManager}}'` returns `cgroupfs`