### PR TITLE
Configure podman to use cgroupfs cgroup manager

### DIFF
--- a/src/main/resources/tools/podman.yaml
+++ b/src/main/resources/tools/podman.yaml
@@ -18,6 +18,12 @@ run:
     printf '[Socket]\nSocketMode=0666\n' \
       > /etc/systemd/system/podman.socket.d/override.conf
 
+files:
+  - path: /etc/containers/containers.conf
+    content: |
+      [engine]
+      cgroup_manager = "cgroupfs"
+
 env:
   - name: DOCKER_HOST
     value: unix:///var/run/docker.sock


### PR DESCRIPTION
## Summary
- Configure `cgroup_manager = "cgroupfs"` in `/etc/containers/containers.conf` via the podman tool

## Why

Incus exec sessions run inside the container without a full logind login session. Rootless podman defaults to the `systemd` cgroup manager, which requires a running systemd user instance (`user@<uid>.service`). Without one, podman falls back to `cgroupfs` and emits warning lines on every invocation.

Making `pam_systemd` start the user instance via `su -l` (see #419) is possible but requires `systemd-pam` + `dbus-broker` (~18 MB RSS overhead per container). Configuring `cgroupfs` as the primary cgroup manager avoids the fallback entirely with zero overhead.

## Test plan
- [ ] `podman run --rm alpine echo hello` prints only `hello`, no warnings
- [ ] `podman info --format '{{.Host.CgroupManager}}'` returns `cgroupfs`