### PR TITLE
Populate the default profile when admin init is skipped

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -293,3 +293,93 @@ jobs:
           sg incus-admin -c "isx destroy test-container" || true
           sg incus-admin -c "isx destroy test-podman" || true
           sg incus-admin -c "isx destroy test-vm" || true
+
+  # Regression: isx init must produce a working setup on a machine where Incus has never been
+  # initialized. The isx-integration-tests job above runs 'incus admin init --minimal' first,
+  # which populates the default profile — so it cannot catch init leaving that profile empty.
+  # A pool without a default profile made every instance creation fail with
+  # "Failed getting root disk: No root device could be found", and was self-latching: once a
+  # pool existed, init reported "Incus already initialized" and skipped the repair forever.
+  fresh-daemon-init:
+    needs: [unit-tests]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install Incus (deliberately WITHOUT 'incus admin init')
+        run: |
+          curl -fsSL https://pkgs.zabbly.com/key.asc | gpg --dearmor \
+            | sudo tee /etc/apt/keyrings/zabbly.gpg >/dev/null
+          codename=$(. /etc/os-release && echo "$VERSION_CODENAME")
+          echo "deb [signed-by=/etc/apt/keyrings/zabbly.gpg] https://pkgs.zabbly.com/incus/stable $codename main" \
+            | sudo tee /etc/apt/sources.list.d/zabbly-incus-stable.list
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq incus btrfs-progs
+          sudo usermod -aG incus-admin "$USER"
+
+          # Create ONLY the storage pool — no admin init. This reproduces the reported broken
+          # state exactly (pool present, default profile empty) and, as a side effect, avoids
+          # isx init building an unbounded btrfs loop file (timed out at 19min on CI).
+          sg incus-admin -c "incus storage create cow btrfs size=5GiB"
+
+          echo "Default profile before isx init:"
+          sg incus-admin -c "incus profile show default"
+
+      - name: Install JDK 25
+        uses: actions/setup-java@v4
+        with:
+          java-version: '25'
+          distribution: 'oracle'
+
+      - name: Download isx
+        uses: actions/download-artifact@v6
+        with:
+          name: isx-quarkus-app
+          path: quarkus-app/
+
+      - name: Install isx wrapper
+        run: |
+          mkdir -p "$HOME/.local/bin"
+          printf '#!/bin/sh\nexec java -jar %s/quarkus-app/quarkus-run.jar "$@"\n' "$PWD" \
+            > "$HOME/.local/bin/isx"
+          chmod +x "$HOME/.local/bin/isx"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Run isx init
+        run: sg incus-admin -c "yes '' | isx init"
+
+      - name: Assert the default profile is usable
+        run: |
+          sg incus-admin -c "incus profile show default"
+
+          # Match on device *type*, not the conventional names — a profile can be valid with
+          # differently-named devices, and Incus only cares that a root disk exists.
+          root_type=$(sg incus-admin -c \
+            "incus query /1.0/profiles/default" | jq -r '[.devices[] | select(.type=="disk" and .path=="/")] | length')
+          nic_count=$(sg incus-admin -c \
+            "incus query /1.0/profiles/default" | jq -r '[.devices[] | select(.type=="nic")] | length')
+
+          if [ "$root_type" -lt 1 ]; then
+            echo "::error::isx init left the default profile without a root disk"
+            exit 1
+          fi
+          if [ "$nic_count" -lt 1 ]; then
+            echo "::error::isx init left the default profile without a NIC"
+            exit 1
+          fi
+          echo "Default profile has a root disk and a NIC."
+
+      - name: Assert an instance can actually be created
+        run: |
+          # The real assertion: a profile that merely looks right can still name a bad pool.
+          # This is the exact operation that failed with "No root device could be found".
+          # Rolling alias on purpose: a pinned version silently EOLs off the image server and
+          # the job then fails on image resolution rather than on what it means to test.
+          sg incus-admin -c "incus launch images:alpine/edge fresh-daemon-smoketest"
+          sg incus-admin -c "incus list fresh-daemon-smoketest"
+
+      - name: Cleanup
+        if: always()
+        run: sg incus-admin -c "incus delete -f fresh-daemon-smoketest" || true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,11 +110,29 @@ Resolution order for both images and tools (later overrides earlier): built-in -
 
 ## CI Integration Tests
 
-`.github/workflows/test-integration.yml` runs on every push/PR to `main`. Three test jobs:
+`.github/workflows/test-integration.yml` runs on every push/PR to `main`. Four test jobs:
 
 - **`unit-tests`**: `mvn package` (no Incus required)
 - **`integration-tests`**: boots the appliance VM image under QEMU, checks it reaches `ISX READY` and passes an Incus smoke test
 - **`isx-integration-tests`**: installs Incus on Ubuntu 24.04, builds isx from the unit-tests artifact, runs `isx init`, starts the MITM proxy, builds templates (`tpl-minimal`, `tpl-test-podman`, `tpl-test-vm`), then runs test scripts inside branched instances
+- **`fresh-daemon-init`**: verifies `isx init` on a daemon that has never been initialized
+
+Each job runs on its own freshly-provisioned runner, so jobs never inherit each other's Incus state.
+
+`fresh-daemon-init` exists because `isx-integration-tests` runs `incus admin init --minimal` *before*
+`isx init`, which populates the default profile — so it cannot catch `isx init` failing to populate it
+itself. It installs Incus and creates only the storage pool, with no `admin init`, reproducing the
+state where a pool exists but the default profile is empty (every instance creation then fails with
+"Failed getting root disk: No root device could be found"). It asserts the profile has a root disk and
+a NIC, then launches a real instance — a profile that merely looks right can still name a bad pool.
+
+Note that `isx init` cannot be tested against the QEMU appliance VM on Linux: isx connects to the
+*natively installed* Incus over `/run/incus/unix.socket` and the QEMU boot path exposes no vsock
+socket, so it would hit the runner's own daemon and report a misleading success (see the guard in
+`appliance/test-with-isx.sh`). The appliance also provisions Incus with its own shell script and never
+calls `isx init` — the "ensure default profile has a root disk and NIC" invariant is implemented twice,
+in `incus-spawn-vm-init` (shell, in-VM) and `IncusClient.ensureDefaultProfileDevices` (Java, host).
+Keep the two in sync.
 
 The `isx-integration-tests` job exercises three environments: a container (from `tpl-minimal`), a rootless-podman container (from `tpl-test-podman`), and a VM (from `tpl-test-vm`). Test scripts live in `.github/scripts/`:
 

--- a/appliance/root/usr/local/sbin/incus-spawn-smoke-test
+++ b/appliance/root/usr/local/sbin/incus-spawn-smoke-test
@@ -41,26 +41,34 @@ echo "  PASS: storage pool 'cow' exists"
 incus network show incusbr0 > /dev/null 2>&1 || fail "bridge 'incusbr0' not found"
 echo "  PASS: bridge 'incusbr0' exists"
 
-# Container creation is the check that actually exercises the default profile — a profile
-# without a root disk fails here with "No root device could be found". Fetching an image needs
-# working network and is genuinely environmental, so the two failure modes are kept apart:
-# only an unavailable *image* may SKIP; a *rejected creation* must FAIL. Previously both
-# collapsed into "SKIP: no network to fetch image", so a broken profile still reported PASSED.
+# A default profile with no root disk is what makes every instance creation fail with
+# "No root device could be found", and the old version of this check could not see that: a
+# rejected creation and an unfetchable image both collapsed into "SKIP: no network to fetch
+# image", so a broken profile still reported PASSED.
+#
+# Two constraints shape the replacement. rcS runs this script synchronously *before* it echoes
+# "ISX READY", so nothing here may block on the network — an earlier attempt to fetch an image
+# on demand hung the boot past the CI timeout. And the profile invariant is worth asserting even
+# when no image is available. So check the profile directly, offline, which is the part that
+# actually catches the regression, and attempt a real creation only opportunistically.
+#
+# These mirror the device names incus-spawn-vm-init writes; here that is the point, since what
+# is being verified is that vm-init populated the profile.
+incus profile device get default root pool > /dev/null 2>&1 \
+    || fail "default profile has no root disk (incus-spawn-vm-init did not populate it)"
+echo "  PASS: default profile has a root disk"
+
+incus profile device get default eth0 network > /dev/null 2>&1 \
+    || fail "default profile has no NIC (incus-spawn-vm-init did not populate it)"
+echo "  PASS: default profile has a NIC"
+
 # Filter to CONTAINER images — picking a VIRTUAL-MACHINE image would fail creation spuriously.
-image_fingerprint() {
-    incus image list --format csv --columns ft 2>/dev/null \
-        | grep -i ',container' | head -n1 | cut -d, -f1
-}
-
-IMAGE=$(image_fingerprint)
-if [ -z "$IMAGE" ]; then
-    # Reuse a cached image when present so this still runs with no network.
-    incus image copy images:alpine/edge local: > /dev/null 2>&1 || true
-    IMAGE=$(image_fingerprint)
-fi
+IMAGE=$(incus image list --format csv --columns ft 2>/dev/null \
+    | grep -i ',container' | head -n1 | cut -d, -f1)
 
 if [ -z "$IMAGE" ]; then
-    echo "  SKIP: container creation (no local image and none could be fetched)"
+    # Deliberately does not fetch one: see above. The profile is already covered.
+    echo "  SKIP: container creation (no image cached locally; not fetching during boot)"
 else
     if ! incus init "$IMAGE" smoke --no-start > /tmp/smoke-init.log 2>&1; then
         echo "  --- incus init output ---"

--- a/appliance/root/usr/local/sbin/incus-spawn-smoke-test
+++ b/appliance/root/usr/local/sbin/incus-spawn-smoke-test
@@ -41,13 +41,34 @@ echo "  PASS: storage pool 'cow' exists"
 incus network show incusbr0 > /dev/null 2>&1 || fail "bridge 'incusbr0' not found"
 echo "  PASS: bridge 'incusbr0' exists"
 
-if incus image list --format csv 2>/dev/null | grep -q alpine; then
-    echo "  SKIP: container creation (image already present)"
+# Container creation is the check that actually exercises the default profile — a profile
+# without a root disk fails here with "No root device could be found". Fetching an image needs
+# working network and is genuinely environmental, so the two failure modes are kept apart:
+# only an unavailable *image* may SKIP; a *rejected creation* must FAIL. Previously both
+# collapsed into "SKIP: no network to fetch image", so a broken profile still reported PASSED.
+# Filter to CONTAINER images — picking a VIRTUAL-MACHINE image would fail creation spuriously.
+image_fingerprint() {
+    incus image list --format csv --columns ft 2>/dev/null \
+        | grep -i ',container' | head -n1 | cut -d, -f1
+}
+
+IMAGE=$(image_fingerprint)
+if [ -z "$IMAGE" ]; then
+    # Reuse a cached image when present so this still runs with no network.
+    incus image copy images:alpine/edge local: > /dev/null 2>&1 || true
+    IMAGE=$(image_fingerprint)
+fi
+
+if [ -z "$IMAGE" ]; then
+    echo "  SKIP: container creation (no local image and none could be fetched)"
 else
-    incus init images:alpine/edge smoke --no-start 2>/dev/null && \
-        incus delete smoke 2>/dev/null && \
-        echo "  PASS: container creation works" || \
-        echo "  SKIP: container creation (no network to fetch image)"
+    if ! incus init "$IMAGE" smoke --no-start > /tmp/smoke-init.log 2>&1; then
+        echo "  --- incus init output ---"
+        cat /tmp/smoke-init.log
+        fail "container creation rejected (default profile may lack a root disk)"
+    fi
+    incus delete smoke > /dev/null 2>&1 || true
+    echo "  PASS: container creation works"
 fi
 
 echo "=== SMOKE TEST PASSED ==="

--- a/src/main/java/dev/incusspawn/command/InitCommand.java
+++ b/src/main/java/dev/incusspawn/command/InitCommand.java
@@ -780,8 +780,13 @@ public class InitCommand extends BaseCommand {
      * after the pool and bridge are known to exist.
      */
     private void ensureDefaultProfile() {
-        var pool = incus.findCowPool();
-        if (pool == null) pool = "default";
+        // Never guess a pool name here. A root disk pointing at a pool that does not exist leaves
+        // the profile worse than an empty one, and "default" is not guaranteed to be present.
+        var pool = incus.findUsablePool();
+        if (pool == null) {
+            System.err.println("  Warning: no storage pool found — skipping the default profile check.");
+            return;
+        }
         try {
             var added = incus.ensureDefaultProfileDevices(pool, "incusbr0");
             if (!added.isEmpty()) {
@@ -789,9 +794,11 @@ public class InitCommand extends BaseCommand {
                         + " (root disk on pool '" + pool + "').");
             }
         } catch (Exception e) {
-            System.err.println("  Warning: could not verify the default profile: " + e.getMessage());
+            System.err.println("  Warning: could not repair the default profile: " + e.getMessage());
             System.err.println("  If instance creation fails with 'No root device could be found', run:");
             System.err.println("    incus profile device add default root disk path=/ pool=" + pool);
+            System.err.println("  If containers come up without networking, also run:");
+            System.err.println("    incus profile device add default eth0 nic network=incusbr0");
         }
     }
 

--- a/src/main/java/dev/incusspawn/command/InitCommand.java
+++ b/src/main/java/dev/incusspawn/command/InitCommand.java
@@ -769,6 +769,30 @@ public class InitCommand extends BaseCommand {
         }
 
         checkStorageDriver();
+        ensureDefaultProfile();
+    }
+
+    /**
+     * The default profile gets its root disk and NIC from 'incus admin init --minimal', which is
+     * skipped whenever a storage pool already exists — and if it failed, checkStorageDriver() and
+     * createBridgeIfMissing() still produce a pool and a bridge, so init looked like it succeeded
+     * while every instance creation failed with "No root device could be found". Repair it here,
+     * after the pool and bridge are known to exist.
+     */
+    private void ensureDefaultProfile() {
+        var pool = incus.findCowPool();
+        if (pool == null) pool = "default";
+        try {
+            var added = incus.ensureDefaultProfileDevices(pool, "incusbr0");
+            if (!added.isEmpty()) {
+                System.out.println("  Default profile was incomplete — added " + added
+                        + " (root disk on pool '" + pool + "').");
+            }
+        } catch (Exception e) {
+            System.err.println("  Warning: could not verify the default profile: " + e.getMessage());
+            System.err.println("  If instance creation fails with 'No root device could be found', run:");
+            System.err.println("    incus profile device add default root disk path=/ pool=" + pool);
+        }
     }
 
     private void checkStorageDriver() {

--- a/src/main/java/dev/incusspawn/incus/IncusClient.java
+++ b/src/main/java/dev/incusspawn/incus/IncusClient.java
@@ -791,6 +791,93 @@ public class IncusClient {
         return true;
     }
 
+    /**
+     * Ensure the default profile has a root disk and a NIC.
+     *
+     * {@code incus admin init --minimal} normally populates these, but it is skipped whenever a
+     * storage pool already exists — and when it fails, {@link #createBridgeIfMissing} and the
+     * fallback CoW pool creation still leave a profile with no root device. Instances then fail
+     * to create with "Failed getting root disk: No root device could be found".
+     *
+     * Only missing devices are added; existing ones are never rewritten.
+     *
+     * @return names of the devices that were added (empty if the profile was already complete).
+     */
+    public List<String> ensureDefaultProfileDevices(String pool, String networkName) {
+        return ensureProfileDevices("default", pool, networkName);
+    }
+
+    /**
+     * As {@link #ensureDefaultProfileDevices}, for an arbitrary profile. Separate so tests can
+     * exercise the repair path against a scratch profile instead of breaking the real default one.
+     */
+    public List<String> ensureProfileDevices(String profile, String pool, String networkName) {
+        var resp = http().get("/1.0/profiles/" + profile);
+        if (!resp.isSuccess()) {
+            throw new IncusException("Failed to read profile '" + profile + "' "
+                    + "(HTTP " + resp.statusCode() + ")");
+        }
+        var existing = resp.body().path("metadata").path("devices");
+        // PATCH merges the devices map key-by-key, so sending only the additions leaves any
+        // devices the user configured themselves untouched.
+        var devices = new LinkedHashMap<String, Object>();
+        if (!hasDeviceOfType(existing, "disk", "/")) {
+            devices.put("root", Map.of("type", "disk", "path", "/", "pool", pool));
+        }
+        if (!hasDeviceOfType(existing, "nic", null)) {
+            devices.put("eth0", Map.of("type", "nic", "name", "eth0", "network", networkName));
+        }
+        if (devices.isEmpty()) return List.of();
+
+        var added = List.copyOf(devices.keySet());
+        var patchResp = http().requestAndWait("PATCH", "/1.0/profiles/" + profile,
+                Map.of("devices", devices));
+        if (!patchResp.isSuccess()) {
+            throw new IncusException("Failed to add " + added + " to profile '" + profile + "': "
+                    + patchResp.body().path("error").asText("unknown error"));
+        }
+        return added;
+    }
+
+    /** The devices map of a profile, as configured (not expanded). */
+    public JsonNode profileDevices(String name) {
+        var resp = http().get("/1.0/profiles/" + name);
+        if (!resp.isSuccess()) {
+            throw new IncusException("Failed to read profile " + name
+                    + " (HTTP " + resp.statusCode() + ")");
+        }
+        return resp.body().path("metadata").path("devices");
+    }
+
+    /** Create an empty profile. No-op if it already exists. */
+    public void createProfile(String name) {
+        var resp = http().requestAndWait("POST", "/1.0/profiles", Map.of("name", name));
+        if (!resp.isSuccess() && resp.statusCode() != 409) {
+            throw new IncusException("Failed to create profile " + name
+                    + " (HTTP " + resp.statusCode() + ")");
+        }
+    }
+
+    public void deleteProfile(String name) {
+        var resp = http().requestAndWait("DELETE", "/1.0/profiles/" + name, null);
+        if (!resp.isSuccess() && resp.statusCode() != 404) {
+            throw new IncusException("Failed to delete profile " + name
+                    + " (HTTP " + resp.statusCode() + ")");
+        }
+    }
+
+    /**
+     * Checks for a device of the given type, optionally requiring a specific {@code path}.
+     * Device names are conventional, not guaranteed, so match on type rather than on "root"/"eth0".
+     */
+    private static boolean hasDeviceOfType(JsonNode devices, String type, String path) {
+        for (var device : devices) {
+            if (!type.equals(device.path("type").asText())) continue;
+            if (path == null || path.equals(device.path("path").asText())) return true;
+        }
+        return false;
+    }
+
     public void deleteNetwork(String networkName) {
         var resp = http().requestAndWait("DELETE", "/1.0/networks/" + networkName, null);
         if (!resp.isSuccess() && resp.statusCode() != 404) {

--- a/src/main/java/dev/incusspawn/incus/IncusClient.java
+++ b/src/main/java/dev/incusspawn/incus/IncusClient.java
@@ -459,6 +459,27 @@ public class IncusClient {
     }
 
     /**
+     * Name of a storage pool that can back a root disk, preferring a CoW pool but falling back to
+     * any pool the daemon has. Returns null if there are none.
+     *
+     * {@link #findCowPool} returning null only means no <em>btrfs/zfs/lvm</em> pool exists — a
+     * perfectly usable {@code dir} pool under some other name may still be there. Callers that
+     * need a pool name to write into a profile must not assume "default" exists; pointing a root
+     * disk at a nonexistent pool leaves the profile worse than it was found.
+     */
+    public String findUsablePool() {
+        var cow = findCowPool();
+        if (cow != null) return cow;
+        var resp = http().get("/1.0/storage-pools?recursion=1");
+        if (!resp.isSuccess()) return null;
+        for (var pool : resp.body().path("metadata")) {
+            var name = pool.path("name").asText("");
+            if (!name.isEmpty()) return name;
+        }
+        return null;
+    }
+
+    /**
      * Return storage pool resource usage as a human-readable string.
      * Queries the pool's /resources endpoint for disk space details.
      */

--- a/src/test/java/dev/incusspawn/incus/InitSafetyIT.java
+++ b/src/test/java/dev/incusspawn/incus/InitSafetyIT.java
@@ -114,6 +114,10 @@ class InitSafetyIT {
         var pool = client.findCowPool();
         Assumptions.assumeTrue(pool != null, "No CoW pool — skipping");
         var before = client.profileDevices(TEST_PROFILE).path("root").deepCopy();
+        // Without this the test passes vacuously if the profile was never repaired: a missing
+        // node compares equal to a missing node, and nothing would have been preserved.
+        assertFalse(before.isMissingNode(),
+                "Precondition: the profile must already have a root disk to preserve");
 
         client.ensureProfileDevices(TEST_PROFILE, "some-other-pool", "some-other-bridge");
 

--- a/src/test/java/dev/incusspawn/incus/InitSafetyIT.java
+++ b/src/test/java/dev/incusspawn/incus/InitSafetyIT.java
@@ -2,6 +2,8 @@ package dev.incusspawn.incus;
 
 import org.junit.jupiter.api.*;
 
+import java.util.List;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
@@ -19,6 +21,7 @@ class InitSafetyIT {
 
     private static final String TEST_BRIDGE = "isx-it-testbr";
     private static final String TEST_GATEWAY = "10.254.254.1";
+    private static final String TEST_PROFILE = "isx-it-testprofile";
 
     private static IncusClient client;
 
@@ -33,6 +36,9 @@ class InitSafetyIT {
     @AfterAll
     static void tearDown() {
         if (client == null) return;
+        // Profile first: its NIC references TEST_BRIDGE, and Incus refuses to delete a network
+        // that is still in use — which would leak the bridge and fail the next run.
+        try { client.deleteProfile(TEST_PROFILE); } catch (Exception ignored) {}
         try { client.deleteNetwork(TEST_BRIDGE); } catch (Exception ignored) {}
     }
 
@@ -59,5 +65,59 @@ class InitSafetyIT {
         client.deleteNetwork(TEST_BRIDGE);
         assertTrue(client.createBridgeIfMissing(TEST_BRIDGE, TEST_GATEWAY),
                 "After deletion, creating again should return true");
+    }
+
+    /**
+     * Regression: a daemon with a storage pool but an unpopulated default profile made every
+     * instance creation fail with "Failed getting root disk: No root device could be found".
+     * 'incus admin init --minimal' is skipped once any pool exists, so init has to repair this
+     * itself. Runs against a scratch profile — breaking the real default profile would leave a
+     * developer's machine unable to create instances if the test aborted mid-run.
+     */
+    @Test @Order(5)
+    void ensureProfileDevicesRepairsEmptyProfile() {
+        // Delete first: a profile left behind by an aborted run would already have devices.
+        client.deleteProfile(TEST_PROFILE);
+        client.createProfile(TEST_PROFILE);
+        var pool = client.findCowPool();
+        Assumptions.assumeTrue(pool != null, "No CoW pool — skipping");
+
+        var added = client.ensureProfileDevices(TEST_PROFILE, pool, TEST_BRIDGE);
+        assertEquals(List.of("root", "eth0"), added,
+                "An empty profile should get both a root disk and a NIC");
+    }
+
+    @Test @Order(6)
+    void ensureProfileDevicesIsIdempotent() {
+        var pool = client.findCowPool();
+        Assumptions.assumeTrue(pool != null, "No CoW pool — skipping");
+        assertEquals(List.of(), client.ensureProfileDevices(TEST_PROFILE, pool, TEST_BRIDGE),
+                "A complete profile should be left untouched");
+    }
+
+    /**
+     * The repaired profile must actually satisfy Incus, not merely look right — this is the
+     * assertion that would have caught the original bug.
+     */
+    @Test @Order(7)
+    void repairedProfileHasUsableRootDisk() {
+        var devices = client.profileDevices(TEST_PROFILE);
+        assertEquals("disk", devices.path("root").path("type").asText());
+        assertEquals("/", devices.path("root").path("path").asText());
+        assertFalse(devices.path("root").path("pool").asText().isEmpty(),
+                "The root disk must name a storage pool");
+    }
+
+    /** A pre-existing device must never be rewritten — only genuinely missing ones are added. */
+    @Test @Order(8)
+    void ensureProfileDevicesPreservesExistingDevices() {
+        var pool = client.findCowPool();
+        Assumptions.assumeTrue(pool != null, "No CoW pool — skipping");
+        var before = client.profileDevices(TEST_PROFILE).path("root").deepCopy();
+
+        client.ensureProfileDevices(TEST_PROFILE, "some-other-pool", "some-other-bridge");
+
+        assertEquals(before, client.profileDevices(TEST_PROFILE).path("root"),
+                "An existing root disk must not be repointed at another pool");
     }
 }


### PR DESCRIPTION
Follow-up to b3ed08f, which fixed `isx init` skipping `incus admin init --minimal` on a fresh daemon. This fixes the state that bug left behind, and adds the coverage that would have caught it.

## The bug

`incus admin init --minimal` is what normally gives the default profile its root disk and NIC, but init skips it whenever a storage pool already exists. `checkStorageDriver()` and `createBridgeIfMissing()` then still produce a pool and a bridge, so `isx init` reported success against a profile with no root device, and every instance creation failed with:

```
Failed getting root disk: No root device could be found
```

It was self-latching — once a pool existed, later runs said "already initialized" and skipped the repair forever.

## The fix

`IncusClient.ensureDefaultProfileDevices`, called from init after the pool and bridge are known to exist. It PATCHes only the devices that are missing, so anything configured by hand survives, and it matches on device *type* rather than the conventional names `root`/`eth0`. If the repair itself fails, init prints the `incus profile device add` command to run manually rather than failing the whole setup.

## Why the existing tests missed it

Both harnesses were blind to this, and both are fixed here:

- **`isx-integration-tests`** runs `incus admin init --minimal` *before* `isx init`, which populates the profile itself — so it can never observe init failing to. The new **`fresh-daemon-init`** job creates only a storage pool, no `admin init`, reproducing the reported state exactly. It asserts a root disk and NIC are present, then launches a real instance: a profile that merely *looks* right can still name a bad pool.
- **The appliance smoke test** collapsed a rejected container creation into `SKIP: no network to fetch image`, so a broken profile still reported PASSED. The two failure modes are now separated — an unavailable image may SKIP, but a rejected creation fails and dumps the incus output.

`InitSafetyIT` gains four cases: repair, idempotence, a usable root disk, and that an existing device is never repointed. They run against a scratch profile — breaking the real default profile would leave a developer unable to create instances if a run aborted midway.

## Note for reviewers

The "default profile has a root disk and a NIC" invariant now exists **twice**: in `incus-spawn-vm-init` (shell, in-VM) and `IncusClient.ensureDefaultProfileDevices` (Java, host). That's because the appliance provisions Incus with its own script and never calls `isx init`. CLAUDE.md records that the two must be kept in sync, and why `isx init` can't be tested against the QEMU appliance on Linux (isx would connect to the runner's own daemon over `/run/incus/unix.socket` and report a misleading success).

## Testing

- Unit suite green (767 tests) — but it doesn't touch the new code.
- `InitSafetyIT` was **not** run locally; it needs a live Incus daemon. Relying on CI here.
- The new `fresh-daemon-init` job is first exercised by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
