### PR TITLE
Treat a newer init sentinel as initialized, and stop the proxy crash-looping

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,9 @@ mvn package -Dnative -Dquarkus.native.container-build=true  # GraalVM native bin
 
 `InitCommand` runs first-time setup (dependencies, Incus, firewall, CA, proxy service, etc.). Commands that need a working environment call `InitCommand.requireInit()`, which auto-launches init if it hasn't completed. Completion is tracked by a sentinel file `~/.config/incus-spawn/.init-complete` containing `INIT_VERSION` — a version integer defined in `InitCommand`. Every init step is idempotent, so re-running is safe.
 
-**When to bump `INIT_VERSION`**: increment it when adding a new infrastructure step to init that existing installations need (new dependency, firewall rule, systemd service, config field). A version mismatch causes `hasBeenInitialized()` to return false, triggering a re-run on the next command. Do NOT bump it for changes that don't affect host configuration (new template features, TUI changes, proxy logic changes).
+**When to bump `INIT_VERSION`**: increment it when adding a new infrastructure step to init that existing installations need (new dependency, firewall rule, systemd service, config field). A sentinel *older* than `INIT_VERSION` causes `hasBeenInitialized()` to return false, triggering a re-run on the next command. Do NOT bump it for changes that don't affect host configuration (new template features, TUI changes, proxy logic changes).
+
+The comparison is `>=`, not equality: the sentinel is a monotonic floor, so a binary that finds a *newer* sentinel treats itself as initialized rather than concluding init never ran. This matters when two isx builds are installed at once (e.g. `/usr/bin/isx` and `~/.local/bin/isx`) — under equality the older one both hard-failed the proxy service and re-ran init to write the sentinel back down, ping-ponging with the newer binary. Never renumber `INIT_VERSION` downward.
 
 ### Image Hierarchy and Build System
 

--- a/src/main/java/dev/incusspawn/command/InitCommand.java
+++ b/src/main/java/dev/incusspawn/command/InitCommand.java
@@ -174,13 +174,22 @@ public class InitCommand extends BaseCommand {
 
     /**
      * Check whether init has run to completion at the current version.
+     * <p>
+     * The comparison is deliberately {@code >=}, not equality. A sentinel newer than this
+     * binary's {@link #INIT_VERSION} means some other (newer) install already ran a superset
+     * of the steps we need — init steps are idempotent and additive, so that install satisfies
+     * us. Requiring equality made an older binary treat a newer install as uninitialized, which
+     * hard-failed the proxy service and made two co-installed binaries re-run init in a loop,
+     * each rewriting the sentinel to its own version.
+     * <p>
+     * An absent or unparseable sentinel counts as not initialized, so init re-runs and rewrites it.
      */
     public static boolean hasBeenInitialized() {
         var marker = Environment.initCompleteMarker();
         if (!Files.exists(marker)) return false;
         try {
-            return Files.readString(marker).strip().equals(String.valueOf(INIT_VERSION));
-        } catch (IOException e) {
+            return Integer.parseInt(Files.readString(marker).strip()) >= INIT_VERSION;
+        } catch (IOException | NumberFormatException e) {
             return false;
         }
     }

--- a/src/main/java/dev/incusspawn/command/ProxyCommand.java
+++ b/src/main/java/dev/incusspawn/command/ProxyCommand.java
@@ -74,7 +74,7 @@ public class ProxyCommand extends BaseCommand {
             var incus = RuntimeServices.incus();
             if (!InitCommand.hasBeenInitialized()) {
                 System.err.println("Error: incus-spawn has not been initialized. Run 'isx init' first.");
-                return CommandResult.valueOf(1);
+                return CommandResult.valueOf(ProxyService.EXIT_CONFIG);
             }
             var config = dev.incusspawn.config.SpawnConfig.load();
             var claude = config.getClaude();
@@ -86,7 +86,7 @@ public class ProxyCommand extends BaseCommand {
             if (claude.isUseVertex()) {
                 if (claude.getCloudMlRegion().isBlank() || claude.getVertexProjectId().isBlank()) {
                     System.err.println("Error: Vertex AI enabled but region or project ID not configured. Run 'isx init' first.");
-                    return CommandResult.valueOf(1);
+                    return CommandResult.valueOf(ProxyService.EXIT_CONFIG);
                 }
             }
 

--- a/src/main/java/dev/incusspawn/proxy/ProxyHealthCheck.java
+++ b/src/main/java/dev/incusspawn/proxy/ProxyHealthCheck.java
@@ -3,6 +3,7 @@ package dev.incusspawn.proxy;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.incusspawn.BuildInfo;
+import dev.incusspawn.Environment;
 import dev.incusspawn.incus.IncusClient;
 
 import java.net.HttpURLConnection;
@@ -243,7 +244,13 @@ public final class ProxyHealthCheck {
                 return true;
             }
         }
-        log.accept("Proxy service did not become healthy after restart.");
+        if (ProxyService.failedWithConfigError()) {
+            log.accept("Proxy service failed to start due to a configuration problem "
+                    + "(exit " + ProxyService.EXIT_CONFIG + ").");
+            log.accept("  systemctl --user status " + Environment.PROXY_SERVICE_NAME);
+        } else {
+            log.accept("Proxy service did not become healthy after restart.");
+        }
         return false;
     }
 

--- a/src/main/java/dev/incusspawn/proxy/ProxyService.java
+++ b/src/main/java/dev/incusspawn/proxy/ProxyService.java
@@ -8,17 +8,93 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.PosixFilePermissions;
-import java.util.regex.Matcher;
+import java.util.ArrayList;
+import java.util.List;
 
 public final class ProxyService {
 
     private static final String SERVICE_NAME = Environment.PROXY_SERVICE_NAME;
 
+    /**
+     * Exit code for a fatal misconfiguration — a condition no amount of retrying can fix,
+     * because it needs a human to change something (run init, fill in a config field).
+     * {@code isx proxy start} returns it; the systemd unit below names it in
+     * {@code RestartPreventExitStatus} so such a failure stops immediately instead of
+     * crash-looping with the reason buried in the journal. Transient failures — Incus or the VM
+     * not up yet — must keep returning 1 so the restart loop can do its job.
+     * <p>
+     * Value is {@code EX_CONFIG} from sysexits.h; it does not collide with the 1 and 2 returned
+     * by other {@code isx proxy} subcommands.
+     */
+    public static final int EXIT_CONFIG = 78;
+
+    /** The unit directive that makes {@link #EXIT_CONFIG} non-restartable. */
+    static final String RESTART_PREVENT_LINE = "RestartPreventExitStatus=" + EXIT_CONFIG;
+
     private ProxyService() {}
+
+    /** The systemd unit written by {@link #install()}. Package-private so tests can assert on it. */
+    static String serviceUnitContent() {
+        return """
+                [Unit]
+                Description=incus-spawn MITM authentication proxy
+                After=incus.service
+
+                [Service]
+                Type=simple
+                %s
+                Restart=on-failure
+                %s
+                RestartSec=5
+
+                [Install]
+                WantedBy=default.target
+                """.formatted(execStartLine(), RESTART_PREVENT_LINE);
+    }
 
     public static boolean isInstalled() {
         if (Environment.isMacOS()) return isMacOsServiceInstalled();
         return Files.exists(Environment.proxyServiceFile());
+    }
+
+    /**
+     * True when the service gave up because of a misconfiguration rather than a transient
+     * failure — it exited {@link #EXIT_CONFIG} and systemd declined to restart it. Callers use
+     * this to report the actual cause instead of a generic "did not become healthy", which
+     * points at the network and hides the real problem.
+     * <p>
+     * Always false on macOS: launchd's {@code KeepAlive} cannot express a per-exit-code restart
+     * policy, so the condition this detects does not arise there.
+     */
+    public static boolean failedWithConfigError() {
+        if (Environment.isMacOS()) return false;
+        // Both properties in one invocation. Without --value the output is self-describing
+        // ("ActiveState=failed\nExecMainStatus=78"), so neither value is read positionally.
+        var shown = showProperties("ActiveState", "ExecMainStatus");
+        return shown != null
+                && shown.contains("ActiveState=failed")
+                && shown.contains("ExecMainStatus=" + EXIT_CONFIG);
+    }
+
+    /** Read systemd unit properties as {@code key=value} lines, or null if unavailable. */
+    private static String showProperties(String... properties) {
+        var command = new ArrayList<>(List.of("systemctl", "--user", "show", SERVICE_NAME));
+        for (var property : properties) {
+            command.add("-p");
+            command.add(property);
+        }
+        try {
+            var pb = new ProcessBuilder(command);
+            pb.redirectError(ProcessBuilder.Redirect.DISCARD);
+            var process = pb.start();
+            var output = new String(process.getInputStream().readAllBytes()).strip();
+            return process.waitFor() == 0 ? output : null;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return null;
+        } catch (Exception e) {
+            return null;
+        }
     }
 
     public static boolean isActive() {
@@ -54,20 +130,7 @@ public final class ProxyService {
             return false;
         }
 
-        var serviceContent = """
-                [Unit]
-                Description=incus-spawn MITM authentication proxy
-                After=incus.service
-
-                [Service]
-                Type=simple
-                %s
-                Restart=on-failure
-                RestartSec=5
-
-                [Install]
-                WantedBy=default.target
-                """.formatted(execStartLine());
+        var serviceContent = serviceUnitContent();
 
         try {
             writeProxyStartScript(proxyStartScript(), isxPath);
@@ -136,6 +199,13 @@ public final class ProxyService {
             waitForProxyExit();
             runQuiet("launchctl", "bootstrap", "gui/" + uid, proxyPlistFile().toString());
         } else {
+            // Clear any prior failure before starting. A unit halted by RestartPreventExitStatus
+            // sits in 'failed' state, and repeated restart attempts can trip systemd's start rate
+            // limit (StartLimitBurst), after which even a valid start is refused until the state
+            // is reset. 'restart' alone recovers from plain 'failed', but not from a tripped rate
+            // limit — this makes recovery unconditional once the user has fixed the config.
+            // No-op when the unit is healthy.
+            runQuiet("systemctl", "--user", "reset-failed", SERVICE_NAME);
             runQuiet("systemctl", "--user", "restart", SERVICE_NAME);
         }
         if (isActive()) {
@@ -179,7 +249,7 @@ public final class ProxyService {
         if (Environment.isMacOS()) {
             needsReinstall = needsMacOsPlistUpdate();
         } else {
-            needsReinstall = updateSystemdServiceFile();
+            needsReinstall = regenerateServiceFile();
         }
 
         if (!needsReinstall) {
@@ -197,20 +267,30 @@ public final class ProxyService {
         return false;
     }
 
-    private static boolean updateSystemdServiceFile() {
+    /**
+     * Bring the on-disk unit into line with {@link #serviceUnitContent()}, rewriting it whenever
+     * it differs. Returns true if the file was rewritten.
+     * <p>
+     * The generated unit is fully deterministic — the only substitution is {@link #execStartLine()},
+     * a fixed path — so regenerating is equivalent to migrating, and it picks up every future
+     * change to the template for free. Patching individual directives instead meant a new helper
+     * per directive, in each of the places that knew the unit's shape, which is how
+     * {@code RestartPreventExitStatus} came to be missing from this path.
+     * <p>
+     * Safe to overwrite: {@link #install()} already writes this file wholesale, and systemd's
+     * supported customization mechanism is a drop-in ({@code <unit>.d/override.conf}), a separate
+     * file this never touches.
+     */
+    private static boolean regenerateServiceFile() {
         if (Environment.isMacOS() || !Files.exists(Environment.proxyServiceFile())) return false;
         var isxPath = resolveIsxPath();
         if (isxPath == null) return false;
         try {
             var content = Files.readString(Environment.proxyServiceFile());
-            var expected = execStartLine();
-            if (content.contains(expected)) return false;
-            var updated = content.replaceFirst(
-                    "(?m)^ExecStart=.*",
-                    Matcher.quoteReplacement(expected));
-            if (updated.equals(content)) return false;
+            var expected = serviceUnitContent();
+            if (expected.equals(content)) return false;
             writeProxyStartScript(proxyStartScript(), isxPath);
-            Files.writeString(Environment.proxyServiceFile(), updated);
+            Files.writeString(Environment.proxyServiceFile(), expected);
             runQuiet("systemctl", "--user", "daemon-reload");
             return true;
         } catch (IOException e) {
@@ -227,23 +307,9 @@ public final class ProxyService {
             }
             return;
         }
-        if (!Files.exists(Environment.proxyServiceFile())) return;
-        var isxPath = resolveIsxPath();
-        if (isxPath == null) return;
-        try {
-            var content = Files.readString(Environment.proxyServiceFile());
-            if (!content.contains("ExecStart=")) return;
-            var expected = execStartLine();
-            if (content.contains(expected)) return;
-            var updated = content.replaceFirst("(?m)^ExecStart=.*", Matcher.quoteReplacement(expected));
-            if (updated.equals(content)) return;
-            writeProxyStartScript(proxyStartScript(), isxPath);
-            Files.writeString(Environment.proxyServiceFile(), updated);
-            System.out.println("Updated proxy service ExecStart.");
-            runQuiet("systemctl", "--user", "daemon-reload");
+        if (regenerateServiceFile()) {
+            System.out.println("Updated proxy service unit.");
             runQuiet("systemctl", "--user", "restart", SERVICE_NAME);
-        } catch (IOException e) {
-            System.err.println("Warning: could not check proxy service file: " + e.getMessage());
         }
     }
 

--- a/src/test/java/dev/incusspawn/command/InitCommandTest.java
+++ b/src/test/java/dev/incusspawn/command/InitCommandTest.java
@@ -1,6 +1,13 @@
 package dev.incusspawn.command;
 
+import dev.incusspawn.Environment;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -147,5 +154,76 @@ class InitCommandTest {
         assertNotNull(result);
         assertEquals(java.util.List.of("any-order@example.com"), result.verified());
         assertEquals("any-order@example.com", result.primary());
+    }
+
+    /**
+     * Runs {@code body} with {@code user.home} pointed at {@code home}, so the tests below
+     * exercise the real {@link Environment#initCompleteMarker()} path.
+     */
+    private static void withHome(Path home, Runnable body) {
+        var original = System.getProperty("user.home");
+        System.setProperty("user.home", home.toString());
+        try {
+            body.run();
+        } finally {
+            if (original == null) {
+                System.clearProperty("user.home");
+            } else {
+                System.setProperty("user.home", original);
+            }
+        }
+    }
+
+    /** Writes the sentinel at whatever path the production code reads it from. */
+    private static void writeSentinel(Path home, String contents) {
+        withHome(home, () -> {
+            try {
+                var marker = Environment.initCompleteMarker();
+                Files.createDirectories(marker.getParent());
+                Files.writeString(marker, contents);
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        });
+    }
+
+    @Test
+    void notInitializedWhenSentinelAbsent(@TempDir Path home) {
+        withHome(home, () -> assertFalse(InitCommand.hasBeenInitialized()));
+    }
+
+    @Test
+    void initializedAtCurrentVersion(@TempDir Path home) {
+        writeSentinel(home, String.valueOf(InitCommand.INIT_VERSION));
+        withHome(home, () -> assertTrue(InitCommand.hasBeenInitialized()));
+    }
+
+    @Test
+    void notInitializedWhenSentinelIsOlder(@TempDir Path home) {
+        writeSentinel(home, String.valueOf(InitCommand.INIT_VERSION - 1));
+        withHome(home, () -> assertFalse(InitCommand.hasBeenInitialized()));
+    }
+
+    /**
+     * The regression: an older binary reading a sentinel written by a newer install must not
+     * conclude it was never initialized. Equality here crash-looped the proxy service and made
+     * two co-installed binaries re-run init in a loop.
+     */
+    @Test
+    void initializedWhenSentinelIsNewer(@TempDir Path home) {
+        writeSentinel(home, String.valueOf(InitCommand.INIT_VERSION + 1));
+        withHome(home, () -> assertTrue(InitCommand.hasBeenInitialized()));
+    }
+
+    @Test
+    void notInitializedWhenSentinelIsUnparseable(@TempDir Path home) {
+        writeSentinel(home, "garbage");
+        withHome(home, () -> assertFalse(InitCommand.hasBeenInitialized()));
+    }
+
+    @Test
+    void sentinelToleratesSurroundingWhitespace(@TempDir Path home) {
+        writeSentinel(home, "  " + InitCommand.INIT_VERSION + "\n");
+        withHome(home, () -> assertTrue(InitCommand.hasBeenInitialized()));
     }
 }

--- a/src/test/java/dev/incusspawn/proxy/ProxyServiceTest.java
+++ b/src/test/java/dev/incusspawn/proxy/ProxyServiceTest.java
@@ -80,4 +80,34 @@ class ProxyServiceTest {
         assertTrue(content.contains("s here"));
         assertFalse(content.contains("it's"), "unescaped single quote would break the shell script");
     }
+
+    // --- systemd restart policy -------------------------------------------------
+    //
+    // A misconfiguration the user must fix by hand (init not run, Vertex fields blank) exits
+    // EXIT_CONFIG. RestartPreventExitStatus stops systemd retrying it forever and burying the
+    // reason in the journal. Transient failures still exit 1 and are still retried.
+
+    @Test
+    void generatedUnitPreventsRestartOnConfigError() {
+        var unit = ProxyService.serviceUnitContent();
+        assertTrue(unit.contains("Restart=on-failure"),
+                "transient failures must still be retried");
+        assertTrue(unit.contains(ProxyService.RESTART_PREVENT_LINE),
+                "config errors must not crash-loop");
+        // The directive is derived from EXIT_CONFIG, so this also pins the unit text to the
+        // exit code the proxy actually returns — the two cannot drift apart.
+        assertEquals("RestartPreventExitStatus=78", ProxyService.RESTART_PREVENT_LINE);
+    }
+
+    @Test
+    void generatedUnitIsStructurallyWellFormed() {
+        var unit = ProxyService.serviceUnitContent();
+        assertTrue(unit.contains("[Unit]"));
+        assertTrue(unit.contains("[Service]"));
+        assertTrue(unit.contains("[Install]"));
+        assertTrue(unit.contains("ExecStart="));
+        assertFalse(unit.contains("%s"), "format placeholder left unsubstituted");
+        // The restart policy lines belong together.
+        assertTrue(unit.contains("Restart=on-failure\nRestartPreventExitStatus=78\nRestartSec=5"));
+    }
 }


### PR DESCRIPTION

Two failures with one root cause, both surfaced by the first ever bump of INIT_VERSION (1 -> 2 in 6ffd6ff). The versioning mechanism had never been exercised, so neither had been hit before.

hasBeenInitialized() compared the sentinel to INIT_VERSION for equality, which is only correct in one direction. A binary reading a sentinel *newer* than its own INIT_VERSION concluded init had never run. With two isx builds installed at once (/usr/bin/isx and ~/.local/bin/isx) that hard-failed the proxy service and made the two binaries re-run init in a loop, each rewriting the sentinel to its own version. Compare with >= instead: init steps are idempotent and additive, so an install that has had more init done than this binary requires already satisfies it. A corrupt sentinel still means "re-run init".

The proxy then made that failure much harder to diagnose. 'isx proxy start' exited 1 on a condition no retry can fix, and Restart=on-failure retried it 110 times, leaving the real error only in the journal while 'isx build' reported "proxy did not become healthy" — pointing at the network. Fatal misconfiguration now exits EXIT_CONFIG (78, EX_CONFIG), named in the unit's RestartPreventExitStatus so it fails once and stays failed with the reason in 'systemctl status'. Transient failures still exit 1 and are still retried. Verified against systemd: exit 78 gives NRestarts=0, exit 1 still loops, and recovery after a config fix restores normal supervision.

restart() now runs reset-failed first, so recovery is unconditional even if systemd's start rate limit was tripped, and ProxyHealthCheck reports the config failure instead of the misleading health message.

The unit file is now regenerated from serviceUnitContent() rather than patched directive-by-directive. There were two independent patchers, and the one reached via 'isx doctor' did not learn about RestartPreventExitStatus — an install repaired that way would have kept the crash-looping unit. Regenerating collapses both and needs no new code for future unit changes; the generated unit is deterministic, and systemd customization lives in drop-ins, which this never touches.

Not addressed here: ProxyCommand's bind-failure path returns SUCCESS, so a genuinely held port exits 0 and the restart loop never fires.