### PR TITLE
Fix headroom tool verification running as wrong user

### DIFF
--- a/src/main/resources/tools/headroom.yaml
+++ b/src/main/resources/tools/headroom.yaml
@@ -38,6 +38,6 @@ env:
   - name: ANTHROPIC_BASE_URL
     value: "http://localhost:8787"
 
-verify: /home/agentuser/.local/bin/headroom --version
+verify: runuser -u agentuser -- /home/agentuser/.local/bin/headroom --version
 
 ready: curl -sf http://localhost:8787/livez


### PR DESCRIPTION
## Summary
- The `verify` command in the headroom tool ran as root via `container.exec()`, but headroom is pip-installed as agentuser (`pip install --user`), so Python couldn't find the `headroom` module and verification always failed with a warning
- Changed to `runuser -u agentuser -- ...` so the verify runs as the correct user

## Test plan
- [x] Built `tpl-test-headroom` (parent: `tpl-dev`) with only the built-in headroom tool
- [x] Verified build now prints `headroom, version 0.33.0` instead of `Warning: verification failed for headroom`
- [x] Branched an instance and confirmed `claude mcp list` shows headroom connected
- [x] Confirmed headroom proxy is healthy (`curl -sf http://localhost:8787/livez`)
- [x] All unit tests pass (`mvnd test`)