### PR TITLE
Raise native image MaxRAM from 128m to 512m

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -257,7 +257,7 @@
                 </property>
             </activation>
             <properties>
-                <quarkus.native.additional-build-args>--initialize-at-run-time=dev.incusspawn.Environment\,dev.incusspawn.RuntimeServices\,dev.tamboui.tui\,dev.tamboui.toolkit\,dev.tamboui.terminal\,dev.tamboui.capability\,dev.tamboui.error\,dev.tamboui.widget\,dev.tamboui.backend.panama,-H:+UnlockExperimentalVMOptions,-H:+SharedArenaSupport,--enable-native-access=ALL-UNNAMED,-Os,--gc=serial,--initialize-at-build-time=dev.tamboui.backend.panama.unix.PlatformConstants,-H:-ParseRuntimeOptions,-H:-UseContainerSupport,-R:MaxRAM=128m,-R:ActiveProcessorCount=2,-H:NativeLinkerOption=-sectcreate,-H:NativeLinkerOption=__TEXT,-H:NativeLinkerOption=__info_plist,-H:NativeLinkerOption=${macos.info.plist}</quarkus.native.additional-build-args>
+                <quarkus.native.additional-build-args>--initialize-at-run-time=dev.incusspawn.Environment\,dev.incusspawn.RuntimeServices\,dev.tamboui.tui\,dev.tamboui.toolkit\,dev.tamboui.terminal\,dev.tamboui.capability\,dev.tamboui.error\,dev.tamboui.widget\,dev.tamboui.backend.panama,-H:+UnlockExperimentalVMOptions,-H:+SharedArenaSupport,--enable-native-access=ALL-UNNAMED,-Os,--gc=serial,--initialize-at-build-time=dev.tamboui.backend.panama.unix.PlatformConstants,-H:-ParseRuntimeOptions,-H:-UseContainerSupport,-R:MaxRAM=512m,-R:ActiveProcessorCount=2,-H:NativeLinkerOption=-sectcreate,-H:NativeLinkerOption=__TEXT,-H:NativeLinkerOption=__info_plist,-H:NativeLinkerOption=${macos.info.plist}</quarkus.native.additional-build-args>
             </properties>
         </profile>
     </profiles>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -15,4 +15,4 @@ quarkus.native.additional-build-args=--initialize-at-run-time=dev.incusspawn.Env
   -Os,--gc=serial,\
   --initialize-at-build-time=dev.tamboui.backend.panama.unix.PlatformConstants,\
   -H:-ParseRuntimeOptions,-H:-UseContainerSupport,\
-  -R:MaxRAM=128m,-R:ActiveProcessorCount=2
+  -R:MaxRAM=512m,-R:ActiveProcessorCount=2


### PR DESCRIPTION
## Problem

`0.2.20` shipped with `-R:MaxRAM=128m`, and the proxy started dying of `OutOfMemoryError` in normal use within a day of release.

The cap was introduced in 2743797 with the rationale *"MaxRAM=128m: cap heap sizing (proxy peak RSS ~30MB)"*. That 30MB came from `bench/run.sh`, which drives `bench/proxy-health.hf.yaml` — a profile that only hammers the `/health` endpoint with small JSON responses. It never touches TLS termination, per-domain cert minting, the Maven/OCI blob caches, or Vertex request translation, so the number that set the ceiling was measured on a workload that skips every memory-heavy path in the proxy. That is why it looked sufficient in testing.

Measured against real usage, the estimate was off by roughly 4×:

| measurement | value |
|---|---|
| bench "peak RSS" (health endpoint only) | ~30 MB |
| proxy idle, one minute after start | ~74 MB |
| service cgroup peak over a 19 h run | ~113 MB |
| heap ceiling at `MaxRAM=128m` (80% of MaxRAM) | ~102 MB |

The ceiling sat *below* real-world peak RSS.

## Change

`-R:MaxRAM=128m` → `-R:MaxRAM=512m`, putting the heap ceiling near 410 MB.

The margin is deliberately generous rather than snug. `-H:-ParseRuntimeOptions` leaves no runtime escape hatch — `-XX:MaxHeapSize` cannot be passed to a deployed binary — so the two directions are asymmetric: too low is a field-broken release fixable only by rebuild and re-release (what happened here), while too high merely catches a runaway at 410 MB instead of 240 MB.

Keeping an explicit cap still matters: with `-H:-UseContainerSupport`, dropping `MaxRAM` falls back to 80% of *physical* RAM, which loses the deterministic sizing the flag was added for.

## Verification

Startup and idle footprint are unaffected — `--version`, 5 runs each, comparing the released 128m binary against a locally built raised-ceiling binary:

```
/usr/bin/isx (128m)          ~28.1 MB maxRSS, <10 ms
~/.local/bin/isx (raised)    ~28.2 MB maxRSS, <10 ms
```

Note this measures the CLI, which exits before the heap grows. SubstrateVM's serial GC does size young-gen relative to max heap, so a long-lived proxy may idle somewhat higher at a larger ceiling; on the hosts this runs on that is not a meaningful cost.

## Follow-up (not in this PR)

The durable fix is to make `bench/` exercise the MITM path — a cert-minting and cache-populating scenario alongside `proxy-health.hf.yaml` — so this ceiling is measured rather than inferred from the cheapest possible request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)