### PR TITLE
Refresh proxy-start.sh when the isx binary moves

### DIFF
--- a/src/main/java/dev/incusspawn/proxy/ProxyService.java
+++ b/src/main/java/dev/incusspawn/proxy/ProxyService.java
@@ -250,7 +250,7 @@ public final class ProxyService {
         if (Platform.isMacOS()) {
             needsReinstall = needsMacOsPlistUpdate();
         } else {
-            needsReinstall = regenerateServiceFile();
+            needsReinstall = regenerateServiceFiles();
         }
 
         if (!needsReinstall) {
@@ -269,35 +269,66 @@ public final class ProxyService {
     }
 
     /**
-     * Bring the on-disk unit into line with {@link #serviceUnitContent()}, rewriting it whenever
-     * it differs. Returns true if the file was rewritten.
+     * Bring both on-disk service files — the systemd unit and the start script it execs — into
+     * line with what this build would write, rewriting whichever differs. Returns true if either
+     * was rewritten, meaning the caller must restart the service.
      * <p>
-     * The generated unit is fully deterministic — the only substitution is {@link #execStartLine()},
-     * a fixed path — so regenerating is equivalent to migrating, and it picks up every future
-     * change to the template for free. Patching individual directives instead meant a new helper
-     * per directive, in each of the places that knew the unit's shape, which is how
-     * {@code RestartPreventExitStatus} came to be missing from this path.
+     * The two files are checked independently because <b>they do not carry the same information</b>.
+     * {@link #execStartLine()} names the start script, at a fixed path, so the unit text is
+     * identical for every installation on every machine; the path to the {@code isx} binary
+     * appears only inside the start script. Comparing the unit alone therefore cannot detect a
+     * binary that moved, which is exactly what happens on an upgrade that changes where {@code isx}
+     * lives (a distro package landing in {@code /usr/bin} over a previous {@code ~/.local/bin}
+     * install, or the reverse). Before this checked the script too, the unit always compared equal,
+     * the script was never refreshed, and the service went on exec'ing a binary from the previous
+     * installation indefinitely — while version-drift detection dutifully restarted that same stale
+     * binary and reported success.
      * <p>
-     * Safe to overwrite: {@link #install()} already writes this file wholesale, and systemd's
+     * Regenerating rather than patching means each file picks up every future change to its
+     * template for free. Patching individual directives instead meant a new helper per directive,
+     * in each of the places that knew the unit's shape, which is how {@code RestartPreventExitStatus}
+     * came to be missing from this path.
+     * <p>
+     * Safe to overwrite: {@link #install()} already writes both files wholesale, and systemd's
      * supported customization mechanism is a drop-in ({@code <unit>.d/override.conf}), a separate
      * file this never touches.
      */
-    private static boolean regenerateServiceFile() {
+    private static boolean regenerateServiceFiles() {
         if (Platform.isMacOS() || !Files.exists(Environment.proxyServiceFile())) return false;
         var isxPath = resolveIsxPath();
         if (isxPath == null) return false;
         try {
-            var content = Files.readString(Environment.proxyServiceFile());
-            var expected = serviceUnitContent();
-            if (expected.equals(content)) return false;
-            writeProxyStartScript(proxyStartScript(), isxPath);
-            Files.writeString(Environment.proxyServiceFile(), expected);
-            runQuiet("systemctl", "--user", "daemon-reload");
-            return true;
+            var changed = false;
+
+            var script = proxyStartScript();
+            if (startScriptIsStale(script, isxPath)) {
+                writeProxyStartScript(script, isxPath);
+                changed = true;
+            }
+
+            var expectedUnit = serviceUnitContent();
+            if (!expectedUnit.equals(Files.readString(Environment.proxyServiceFile()))) {
+                Files.writeString(Environment.proxyServiceFile(), expectedUnit);
+                // Only the unit is systemd's to parse; a start script change needs a restart
+                // (handled by the caller) but not a reload.
+                runQuiet("systemctl", "--user", "daemon-reload");
+                changed = true;
+            }
+
+            return changed;
         } catch (IOException e) {
-            System.err.println("Warning: could not update proxy service file: " + e.getMessage());
+            System.err.println("Warning: could not update proxy service files: " + e.getMessage());
             return false;
         }
+    }
+
+    /**
+     * True when the start script is missing or does not exec {@code isxPath} — i.e. when the
+     * service would otherwise keep running a binary from a previous installation.
+     */
+    static boolean startScriptIsStale(Path script, String isxPath) throws IOException {
+        if (!Files.exists(script)) return true;
+        return !proxyStartScriptContent(isxPath).equals(Files.readString(script));
     }
 
     public static void upgradeIfNeeded() {
@@ -308,8 +339,8 @@ public final class ProxyService {
             }
             return;
         }
-        if (regenerateServiceFile()) {
-            System.out.println("Updated proxy service unit.");
+        if (regenerateServiceFiles()) {
+            System.out.println("Updated proxy service configuration.");
             runQuiet("systemctl", "--user", "restart", SERVICE_NAME);
         }
     }
@@ -439,9 +470,14 @@ public final class ProxyService {
         return Environment.configDir().resolve("proxy-start.sh");
     }
 
+    /** Single source of truth for the start script, so writing and staleness-checking cannot drift. */
+    static String proxyStartScriptContent(String isxPath) {
+        return "#!/bin/bash\nexec " + Container.shellQuote(isxPath) + " proxy start\n";
+    }
+
     static void writeProxyStartScript(Path script, String isxPath) throws IOException {
         Files.createDirectories(script.getParent());
-        Files.writeString(script, "#!/bin/bash\nexec " + Container.shellQuote(isxPath) + " proxy start\n");
+        Files.writeString(script, proxyStartScriptContent(isxPath));
         Files.setPosixFilePermissions(script, PosixFilePermissions.fromString("rwxr-xr-x"));
     }
 

--- a/src/test/java/dev/incusspawn/proxy/ProxyServiceTest.java
+++ b/src/test/java/dev/incusspawn/proxy/ProxyServiceTest.java
@@ -81,6 +81,47 @@ class ProxyServiceTest {
         assertFalse(content.contains("it's"), "unescaped single quote would break the shell script");
     }
 
+    // --- start script staleness -------------------------------------------------
+    //
+    // The isx binary path lives only in the start script, never in the unit, so an upgrade that
+    // moves the binary (a distro package landing in /usr/bin over a previous ~/.local/bin install,
+    // or the reverse) is invisible to a unit-text comparison. Checking the unit alone left the
+    // service exec'ing the previous installation's binary forever.
+
+    @Test
+    void startScriptIsStaleWhenMissing() throws IOException {
+        var script = tempDir.resolve("proxy-start.sh");
+        assertTrue(ProxyService.startScriptIsStale(script, "/home/user/.local/bin/isx"));
+    }
+
+    @Test
+    void startScriptIsNotStaleWhenItMatches() throws IOException {
+        var script = tempDir.resolve("proxy-start.sh");
+        ProxyService.writeProxyStartScript(script, "/home/user/.local/bin/isx");
+        assertFalse(ProxyService.startScriptIsStale(script, "/home/user/.local/bin/isx"));
+    }
+
+    @Test
+    void startScriptIsStaleWhenBinaryMoved() throws IOException {
+        var script = tempDir.resolve("proxy-start.sh");
+        ProxyService.writeProxyStartScript(script, "/usr/bin/isx");
+        assertTrue(ProxyService.startScriptIsStale(script, "/home/user/.local/bin/isx"),
+                "an upgrade that relocates the binary must be detected");
+    }
+
+    @Test
+    void unitTextCarriesNoBinaryPath() {
+        // Pins the reason the script must be checked separately: two installations pointing at
+        // different isx binaries produce byte-identical units, so comparing units can never
+        // notice the difference. If the unit ever does embed the binary path, this test fails
+        // and the staleness logic above should be revisited.
+        var unit = ProxyService.serviceUnitContent();
+        assertFalse(unit.contains("/usr/bin/isx"));
+        assertFalse(unit.contains(".local/bin/isx"));
+        assertTrue(unit.contains("proxy-start.sh"),
+                "the unit should exec the start script, which is what holds the binary path");
+    }
+
     // --- systemd restart policy -------------------------------------------------
     //
     // A misconfiguration the user must fix by hand (init not run, Vertex fields blank) exits


### PR DESCRIPTION
Found while diagnosing the 0.2.20 proxy failure: after upgrading, `isx proxy install` kept reporting success while the service went on running the *previous* installation's binary.

## The bug

`regenerateServiceFile()` compared only the systemd unit against what the current build would write, and rewrote `proxy-start.sh` solely as a side effect of the unit differing:

```java
var expected = serviceUnitContent();
if (expected.equals(content)) return false;   // ← bails before touching the script
writeProxyStartScript(proxyStartScript(), isxPath);
```

But **the unit never carries the isx binary path.** `execStartLine()` names `proxy-start.sh` at a fixed path, so the unit text is byte-identical for every installation on every machine. The path to `isx` lives only inside the start script.

So when an upgrade relocates the binary — a distro package landing in `/usr/bin` over a previous `~/.local/bin` install, or the reverse — the unit compares equal, the function returns `false`, and the start script is never refreshed. The service keeps exec'ing the old binary indefinitely.

Version-drift detection *did* notice the mismatch, but its only remedy is `restart()`, which re-runs the same stale script. The result is a confident false positive:

```
Proxy service restarted with updated binary.
```

...while nothing changed. That is what made this hard to spot from the outside — the upgrade path reported success on every invocation.

Observed on a real machine: `~/.config/incus-spawn/proxy-start.sh` still contained `exec '/usr/bin/isx' proxy start` and carried an mtime five days older than the current install, with the proxy's own log reporting the superseded version.

## The fix

Check the two files independently and rewrite whichever drifted, because they do not carry the same information. `daemon-reload` still runs only when the unit itself changed — a start script change needs a restart, which both callers (`reinstallIfChanged`, `upgradeIfNeeded`) already perform.

The script text moves into `proxyStartScriptContent(isxPath)` so writing and staleness-checking share one source of truth.

## Tests

`mvn test` — 847 pass. Four new cases in `ProxyServiceTest`:

- script missing → stale
- script matching the resolved path → not stale
- **script pointing at a different binary → stale** (the regression)
- `unitTextCarriesNoBinaryPath` — an invariant test pinning *why* the script needs a separate check. If the unit ever does embed the binary path, that test fails and points at the staleness logic.

The end-to-end path is not covered by CI, since the integration tests never install the service — see #486.

## Follow-ups, not in this PR

- `resolveIsxPath()` resolves via `which isx`, inheriting the calling process's PATH, so `/usr/bin/isx proxy install` can legitimately install `~/.local/bin/isx` and vice versa. On Linux the running executable (`/proc/self/exe` for the native image) would be a more truthful source, though it does not generalise to the JVM wrapper, which is why `which` is used today.
- `install.sh`'s post-upgrade hook only fires when the unit is already **active** (`systemctl --user is-active --quiet incus-spawn-proxy`). A service that is installed but stopped, or a proxy running as a bare process, silently skips the reinstall — which is how the stale script survived a fresh `./install.sh --native` in the case that prompted this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)