### PR TITLE
get-isx: Fix git-remote-isx URL

### DIFF
--- a/get-isx.sh
+++ b/get-isx.sh
@@ -29,7 +29,7 @@ curl -fsSL "https://github.com/$REPO/releases/download/$VERSION/$ASSET" -o "$INS
 chmod +x "$INSTALL_DIR/isx"
 
 # Install git remote helper shim for isx:// URLs
-curl -fsSL "https://raw.githubusercontent.com/$REPO/$VERSION/src/main/resources/git-remote-isx" -o "$INSTALL_DIR/git-remote-isx"
+curl -fsSL "https://github.com/$REPO/releases/download/$VERSION/git-remote-isx" -o "$INSTALL_DIR/git-remote-isx"
 chmod +x "$INSTALL_DIR/git-remote-isx"
 
 echo "Installed incus-spawn $VERSION to $INSTALL_DIR/isx"


### PR DESCRIPTION
Installation is failing with a 404 error. Fix the URL for git-remote-isx.