### PR TITLE
Add sshd to template skeleton

### DIFF
--- a/cli/src/main/java/dev/incusspawn/command/TemplatesCommand.java
+++ b/cli/src/main/java/dev/incusspawn/command/TemplatesCommand.java
@@ -323,7 +323,7 @@ public class TemplatesCommand extends BaseCommand {
             #   - ripgrep
 
             # Tool definitions to set up
-            # Built-in tools: podman, maven-3, gh, claude
+            # Built-in tools: podman, maven-3, gh, claude, sshd
             # tools:
             #   - podman
 


### PR DESCRIPTION
For discoverability, add sshd to the built-in tools comment of the template skeleton.

Fixes: #523