### PR TITLE
Fix resolv.conf when gateway IP changes after isx init

### DIFF
--- a/cli/src/main/java/dev/incusspawn/command/BranchCommand.java
+++ b/cli/src/main/java/dev/incusspawn/command/BranchCommand.java
@@ -16,6 +16,7 @@ import dev.incusspawn.lifecycle.InstanceType;
 import dev.incusspawn.lifecycle.KvmPassthrough;
 import dev.incusspawn.proxy.CertificateAuthority;
 import dev.incusspawn.proxy.CertificateAuthority.CaStatus;
+import dev.incusspawn.proxy.ProxyConfig;
 import dev.incusspawn.proxy.ProxyHealthCheck;
 import org.aesh.command.CommandDefinition;
 import org.aesh.command.CommandResult;
@@ -176,6 +177,7 @@ public class BranchCommand extends BaseCommand {
 
         if (networkMode != NetworkMode.AIRGAP) {
             CertificateAuthority.fixContainerCaIfNeeded(incus, name);
+            ProxyConfig.fixResolvConfIfNeeded(incus, name);
         }
 
         System.out.println("Branch '" + name + "' is ready.\n");

--- a/cli/src/main/java/dev/incusspawn/command/BuildCommand.java
+++ b/cli/src/main/java/dev/incusspawn/command/BuildCommand.java
@@ -668,11 +668,10 @@ public class BuildCommand extends BaseCommand {
             waitForIpv4(container);
         }
 
-        var gatewayIp = ProxyConfig.resolveGatewayIp(incus);
         container.sh(
                 "sed -i 's/resolve \\[!UNAVAIL=return\\] //' /etc/nsswitch.conf; " +
                 "rm -f /etc/resolv.conf; " +
-                "echo 'nameserver " + gatewayIp + "' > /etc/resolv.conf")
+                "printf '%s' '" + ProxyConfig.resolvConfContent(incus) + "' > /etc/resolv.conf")
                 .assertSuccess("Failed to fix DNS after copy");
 
         // The copy carries the parent's trust store, which may predate a CA re-issue
@@ -838,11 +837,10 @@ public class BuildCommand extends BaseCommand {
         }
 
         System.out.println("Configuring DNS...");
-        var gatewayIp = ProxyConfig.resolveGatewayIp(incus);
         container.sh(
                 "sed -i 's/resolve \\[!UNAVAIL=return\\] //' /etc/nsswitch.conf; " +
                 "rm -f /etc/resolv.conf; " +
-                "echo 'nameserver " + gatewayIp + "' > /etc/resolv.conf")
+                "printf '%s' '" + ProxyConfig.resolvConfContent(incus) + "' > /etc/resolv.conf")
                 .assertSuccess("Failed to configure DNS");
 
         waitForNetwork(buildName);

--- a/cli/src/main/java/dev/incusspawn/command/InstancePrep.java
+++ b/cli/src/main/java/dev/incusspawn/command/InstancePrep.java
@@ -8,6 +8,7 @@ import dev.incusspawn.incus.IncusClient;
 import dev.incusspawn.incus.Metadata;
 import dev.incusspawn.lifecycle.GuiPassthrough;
 import dev.incusspawn.proxy.CertificateAuthority;
+import dev.incusspawn.proxy.ProxyConfig;
 import dev.incusspawn.proxy.ProxyHealthCheck;
 
 /**
@@ -50,6 +51,7 @@ public class InstancePrep {
             BridgeSubnetCheck.warnIfConflict(incus);
             FirewallDetector.warnIfNotRunning();
             fixCaMismatch(incus, name);
+            fixResolvConfMismatch(incus, name);
         }
 
         // Start if stopped, or restart VMs with unresponsive agent
@@ -68,6 +70,19 @@ public class InstancePrep {
         GuiPassthrough.checkGuiHealth(incus, name);
 
         return templateName;
+    }
+
+    private static void fixResolvConfMismatch(IncusClient incus, String name) {
+        if ("Stopped".equalsIgnoreCase(incus.getInstanceStatus(name))) return;
+        try {
+            if (ProxyConfig.fixResolvConfIfNeeded(incus, name)) {
+                var sep = "\033[33m" + "─".repeat(60) + "\033[0m";
+                System.err.println(sep);
+                System.err.println("\033[1;33mDNS configuration mismatch\033[0m — updated /etc/resolv.conf automatically.");
+                System.err.println(sep);
+            }
+        } catch (Exception ignored) {
+        }
     }
 
     private static void fixCaMismatch(IncusClient incus, String container) {

--- a/cli/src/main/java/dev/incusspawn/command/ListCommand.java
+++ b/cli/src/main/java/dev/incusspawn/command/ListCommand.java
@@ -3863,6 +3863,7 @@ public class ListCommand extends BaseCommand {
             if (showProxyError()) return true;
             showSubnetWarning();
             fixCaMismatchIfNeeded(containerName);
+            fixResolvConfIfNeeded(containerName);
             return false;
         } catch (IncusException e) {
             errorMessage = "Cannot reach Incus: " + e.getMessage();
@@ -3877,6 +3878,14 @@ public class ListCommand extends BaseCommand {
             if (diagnostic != null) {
                 statusMessage = "Bridge subnet conflict detected — run 'isx init' to fix";
             }
+        } catch (Exception ignored) {
+        }
+    }
+
+    private void fixResolvConfIfNeeded(String name) {
+        if ("Stopped".equalsIgnoreCase(incus.getInstanceStatus(name))) return;
+        try {
+            ProxyConfig.fixResolvConfIfNeeded(incus, name);
         } catch (Exception ignored) {
         }
     }

--- a/common/src/main/java/dev/incusspawn/proxy/ProxyConfig.java
+++ b/common/src/main/java/dev/incusspawn/proxy/ProxyConfig.java
@@ -103,6 +103,22 @@ public final class ProxyConfig {
         throw new IncusException("Bridge incusbr0 has no ipv4.address configured");
     }
 
+    public static String resolvConfContent(IncusClient incus) {
+        return "nameserver " + resolveGatewayIp(incus) + "\n";
+    }
+
+    /**
+     * @return true if resolv.conf was updated
+     */
+    public static boolean fixResolvConfIfNeeded(IncusClient incus, String name) {
+        var expected = resolvConfContent(incus);
+        var result = incus.shellExec(name, "cat", "/etc/resolv.conf");
+        if (!result.success() || result.stdout().contains(expected.strip())) return false;
+        incus.shellExec(name, "sh", "-c",
+                "rm -f /etc/resolv.conf; printf '%s' '" + expected + "' > /etc/resolv.conf");
+        return true;
+    }
+
     public static void configureBridgeDns(IncusClient incus) {
         writeBridgeDns(incus);
         System.out.println("  DNS overrides: " + interceptedDomains().size() +

--- a/common/src/main/java/dev/incusspawn/proxy/ProxyConfig.java
+++ b/common/src/main/java/dev/incusspawn/proxy/ProxyConfig.java
@@ -113,10 +113,10 @@ public final class ProxyConfig {
     public static boolean fixResolvConfIfNeeded(IncusClient incus, String name) {
         var expected = resolvConfContent(incus);
         var result = incus.shellExec(name, "cat", "/etc/resolv.conf");
-        if (!result.success() || result.stdout().contains(expected.strip())) return false;
-        incus.shellExec(name, "sh", "-c",
+        if (result.success() && result.stdout().contains(expected.strip())) return false;
+        var write = incus.shellExec(name, "sh", "-c",
                 "rm -f /etc/resolv.conf; printf '%s' '" + expected + "' > /etc/resolv.conf");
-        return true;
+        return write.success();
     }
 
     public static void configureBridgeDns(IncusClient incus) {


### PR DESCRIPTION
## Summary

- When `isx init` reconfigures the bridge, existing containers retain the old gateway IP in `/etc/resolv.conf`, breaking all DNS resolution (and therefore all proxied HTTPS, including Claude)
- Add `ProxyConfig.fixResolvConfIfNeeded()` to detect and rewrite a stale resolv.conf on instance startup (shell, run, TUI, branch)
- Extract `ProxyConfig.resolvConfContent()` as a single source of truth for the file content, shared by both the build-time write and the startup fix

## Test plan

- [ ] Run `isx init` with a changed bridge subnet, then `isx shell` into an existing container — resolv.conf should be auto-fixed with a warning banner
- [ ] Branch from a template built with the old gateway — resolv.conf should be silently corrected
- [ ] Container with correct resolv.conf — no change, no warning
- [ ] CI unit tests pass