### PR TITLE
Fix isx init silently failing to expand /etc/subuid range

### DIFF
--- a/cli/src/main/java/dev/incusspawn/command/InitCommand.java
+++ b/cli/src/main/java/dev/incusspawn/command/InitCommand.java
@@ -824,7 +824,7 @@ public class InitCommand extends BaseCommand {
         }
 
         if (oldEntry != null && content.lines().anyMatch(l -> l.equals(oldEntry))) {
-            runHost("sudo", "sed", "-i", "s/^" + Pattern.quote(oldEntry) + "$/" + entry + "/", path);
+            writeSubidFile(path, content.replaceAll("(?m)^" + Pattern.quote(oldEntry) + "$", entry));
             return true;
         }
 
@@ -833,7 +833,7 @@ public class InitCommand extends BaseCommand {
         var existing = content.lines().filter(l -> l.startsWith(prefix)).findFirst();
 
         if (existing.isEmpty()) {
-            runHost("sh", "-c", "echo '" + entry + "' | sudo tee -a " + path);
+            writeSubidFile(path, content.endsWith("\n") ? content + entry + "\n" : content + "\n" + entry + "\n");
             return true;
         }
 
@@ -850,12 +850,16 @@ public class InitCommand extends BaseCommand {
         var console = System.console();
         if (console != null) {
             if (askConfirmation(console, System.err, "  \u001B[1;33mReplace it?\u001B[0m", false)) {
-                runHost("sudo", "sed", "-i", "s/^" + Pattern.quote(existing.get()) + "$/" + entry + "/", path);
+                writeSubidFile(path, content.replaceAll("(?m)^" + Pattern.quote(existing.get()) + "$", entry));
                 return true;
             }
         }
         System.err.println("  Skipped — containers may not start correctly.");
         return false;
+    }
+
+    private void writeSubidFile(String path, String content) {
+        runHost("sh", "-c", "printf '%s' '" + content.replace("'", "'\\''") + "' | sudo tee " + path + " > /dev/null");
     }
 
     static boolean subidRangeCovers(String line, String user, long base, long count) {


### PR DESCRIPTION
## Summary

Fixes a silent failure in `isx init` introduced by #355.

- `ensureSubidEntry()` used `Pattern.quote()` to escape strings for `sed`, but `\Q...\E` is Java-only — `sed` silently matched nothing, leaving `/etc/subuid` at `root:1000000:65536`
- With the small host range, `security.idmap.size=165536` couldn't be honored — Incus allocated only 65536 UIDs, so container UIDs 65536–165535 didn't exist in the namespace
- `newuidmap` failed with EPERM when rootless podman tried to map the subordinate range (100000:65536), since those UIDs were unmapped
- Replaced all `sed` invocations with read-modify-write via `String.replace()` + `sudo tee`

## Test plan

- [x] `mvn test -pl cli -Dtest=InitCommandTest` passes
- [x] Full test suite passes (715/717, 2 pre-existing BridgeSubnetCheck flakes)
- [x] Manually verified: after fixing `/etc/subuid` on affected host, `incus restart` regenerated the idmap with `Maprange:164535`, and rootless podman works