### PR TITLE
Raise per-UID inotify limits in the appliance

### DIFF
--- a/appliance/root/etc/sysctl.d/99-incus-spawn.conf
+++ b/appliance/root/etc/sysctl.d/99-incus-spawn.conf
@@ -1,2 +1,11 @@
 net.ipv4.ip_forward=1
 net.ipv6.conf.all.forwarding=1
+
+# Every container shares one host UID range (idmap base 0 -> host uid 1000000),
+# so all of them draw on the *same* per-UID kernel budgets. The defaults are
+# sized for one interactive user, not a dozen systemd instances: at ~10 inotify
+# instances per container, the 128 default runs out around the tenth container
+# and the next one's PID 1 dies before it logs anything (the veth appears and
+# vanishes within 100ms, and exec then fails with "Failed to get init pid").
+fs.inotify.max_user_instances=8192
+fs.inotify.max_user_watches=524288

--- a/appliance/root/usr/local/sbin/incus-spawn-smoke-test
+++ b/appliance/root/usr/local/sbin/incus-spawn-smoke-test
@@ -62,6 +62,17 @@ incus profile device get default eth0 network > /dev/null 2>&1 \
     || fail "default profile has no NIC (incus-spawn-vm-init did not populate it)"
 echo "  PASS: default profile has a NIC"
 
+# Every container's root maps to the same host UID, so they all share one per-UID inotify
+# budget. At the 128 default it runs out around the tenth concurrent container and the next
+# one's systemd exits before it can log anything — a failure that surfaces only as an
+# unhelpful "Failed to get init pid" from lxc attach. rcS applies 99-incus-spawn.conf with
+# stderr discarded, so a typo or a knob the custom kernel lacks would fail silently; assert
+# the value actually took.
+INOTIFY_INSTANCES=$(cat /proc/sys/fs/inotify/max_user_instances 2>/dev/null || echo 0)
+[ "$INOTIFY_INSTANCES" -ge 1024 ] \
+    || fail "fs.inotify.max_user_instances is $INOTIFY_INSTANCES (99-incus-spawn.conf did not apply)"
+echo "  PASS: inotify instance limit raised ($INOTIFY_INSTANCES)"
+
 # Filter to CONTAINER images — picking a VIRTUAL-MACHINE image would fail creation spuriously.
 IMAGE=$(incus image list --format csv --columns ft 2>/dev/null \
     | grep -i ',container' | head -n1 | cut -d, -f1)

--- a/appliance/test-boot.sh
+++ b/appliance/test-boot.sh
@@ -317,6 +317,7 @@ else
     check "incus daemon responsive"             "incus API responsive"
     check "storage pool 'cow' exists"           "smoke test: storage pool"
     check "bridge 'incusbr0' exists"            "smoke test: bridge"
+    check "inotify instance limit raised"       "smoke test: per-UID inotify budget"
     check "SMOKE TEST PASSED"                    "smoke test passed"
 fi
 


### PR DESCRIPTION
## Summary

Template builds fail once about a dozen containers are running, with a message several steps removed from the actual cause:

```
Build failed for tpl-minimal: Failed to install MITM CA certificate:
  Container status: Running
  LXC log (last 5 lines):
    lxc tpl-minimal-rebuilding ... ERROR attach - Connection refused - Failed to get init pid
```

The container is not running — it started and its PID 1 exited about 60ms later, before writing anything to the console or to `lxc.log`.

**Cause:** every container's root maps to the same host UID (`volatile.idmap.base=0` → host uid 1000000; `BuildCommand` sets `security.idmap.size` but never `security.idmap.isolated`), so all containers draw on one shared per-UID inotify budget. The kernel default of 128 instances is sized for a single interactive user. At roughly ten instances per container it runs out around the twelfth concurrent container, and the next container's systemd cannot allocate one.

**Evidence** on a saturated VM (12 running containers):

- `inotify_init1()` returns `EMFILE` on the *first* call from inside an already-running container — the budget is completely consumed, with `/proc/sys/fs/inotify/max_user_instances = 128`.
- A fresh container from the same base image dies within seconds; the same container with `lxc.init.cmd = /usr/bin/sleep 600` stays up indefinitely. Storage, idmap and rootfs are fine — only systemd fails.
- The VM log shows the veth appear and disappear inside one tick:
  ```
  [24216.671708] incusbr0: port 13(veth023856bd) entered blocking state
  [24216.725795] incusbr0: port 13(veth023856bd) entered forwarding state
  [24216.786866] incusbr0: port 13(veth023856bd) entered disabled state
  ```

## Changes

- `99-incus-spawn.conf`: raise `fs.inotify.max_user_instances` to 8192 and `fs.inotify.max_user_watches` to 524288.
- `incus-spawn-smoke-test`: assert the limit actually took effect. `rcS` runs `sysctl -p ... 2>/dev/null`, so a typo or a knob the custom kernel lacks would fail silently in exactly the way this bug did.
- `test-boot.sh`: matching marker check.

`kernel.keys.maxkeys`/`maxbytes` are the same class of shared-UID budget, but the custom kernel has no `CONFIG_KEYS` and those sysctls do not exist in the appliance — verified against the running VM — so they are deliberately not set.

## Alternative considered

`security.idmap.isolated=true` would give each container its own host UID range and split the budgets, with better UID isolation as a bonus. The VM does advertise `idmapped_mounts_v2: true`, so it likely would not force a UID rewrite on every CoW branch — but that needs testing against the instant-branch property before betting on it. Raising a sysctl is one line and carries no such question.

## Test plan

- [x] `sh -n` / `bash -n` clean on both modified scripts.
- [x] Verified `fs.inotify.max_user_instances` and `max_user_watches` exist in the appliance kernel (`CONFIG_INOTIFY_USER=y`); confirmed `kernel.keys.*` do not, and dropped them.
- [x] Root cause reproduced and isolated on a live VM as described above.
- [ ] CI: the appliance cache key is `hashFiles('appliance/**')`, so this forces a rebuild, and `integration-tests` boots the result with `isx.smoke_test=1` and requires `SMOKE TEST PASSED` — the new assertion is exercised end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012WyQei7w3szxaUrpUtmcpp
