### PR TITLE
Upgrade GraalVM native toolchain to 25.3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,15 +46,15 @@ jobs:
           - runner: ubuntu-latest
             os: linux
             arch: amd64
-            graalvm-version: '25.2'
+            graalvm-version: '25.3'
           - runner: ubuntu-24.04-arm
             os: linux
             arch: aarch64
-            graalvm-version: '25.2'
+            graalvm-version: '25.3'
           - runner: macos-14
             os: macos
             arch: aarch64
-            graalvm-version: '25.2'
+            graalvm-version: '25.3'
           - runner: macos-15-intel
             os: macos
             arch: x86_64

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -30,10 +30,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Install Oracle GraalVM 25.2
+      - name: Install Oracle GraalVM 25.3
         uses: graalvm/setup-graalvm@v1
         with:
-          version: '25.2'
+          version: '25.3'
           java-version: '25'
           distribution: 'graalvm'
 
@@ -77,10 +77,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Install Oracle GraalVM 25.2
+      - name: Install Oracle GraalVM 25.3
         uses: graalvm/setup-graalvm@v1
         with:
-          version: '25.2'
+          version: '25.3'
           java-version: '25'
           distribution: 'graalvm'
 
@@ -107,10 +107,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Install Oracle GraalVM 25.2
+      - name: Install Oracle GraalVM 25.3
         uses: graalvm/setup-graalvm@v1
         with:
-          version: '25.2'
+          version: '25.3'
           java-version: '25'
           distribution: 'graalvm'
 

--- a/install.sh
+++ b/install.sh
@@ -39,7 +39,11 @@ if $NATIVE; then
             exit 1
         fi
         GRAALVM_BASE="container-registry.oracle.com/graalvm/native-image:latest"
-        BUILDER_TAG="incus-spawn-graalvm-builder:25.2"
+        # The tag is a local cache name, not a pull ref: the builder FROMs :latest.
+        # Bumping it here (25.2 -> 25.3) invalidates the cached builder so the next
+        # build re-pulls :latest and picks up the new GraalVM (25.3: Priority Inlining
+        # default, compressed references, Adaptive2 serial GC, loop vectorization).
+        BUILDER_TAG="incus-spawn-graalvm-builder:25.3"
         if ! $CTR image inspect "$BUILDER_TAG" >/dev/null 2>&1; then
             echo "Preparing GraalVM builder image (one-time)..."
             $CTR rmi "$GRAALVM_BASE" >/dev/null 2>&1 || true


### PR DESCRIPTION
Move the native-image toolchain from 25.2 to 25.3 to pick up the release's default Priority Inliner, compressed references, the Adaptive2 serial GC policy, and default loop vectorization.

## Changes
- **install.sh**: bump the builder cache tag (`25.2` → `25.3`). The tag `FROM`s `:latest`, so bumping it forces a re-pull of the current GraalVM builder image.
- **CI**: bump the `graalvm/setup-graalvm` pins in `release.yml` and `test-integration.yml` (macOS x86_64 stays on `25.0`, matching the existing intentional lag on that runner).

No source or build-arg changes: the existing native args build cleanly on GraalVM 25.3.

## Validation
Built locally under GraalVM 25.3:
- **CLI** at production flags (`-Os`, serial GC) — builds cleanly.
- **Proxy** — builds cleanly (validated with serial GC locally, since G1 is Oracle-GraalVM-only and unavailable in the local Community Edition; CI/release use the Oracle builder which provides G1).

Runtime benchmarking of the release's effects (proxy throughput 25.2 vs 25.3) is deferred to a follow-up.

> Note: the companion GraalVM tool in `incus-spawn-templates` (`tools/graalvm.yaml`) is bumped 25.2 → 25.3 separately, with verified Oracle GDS checksums.

🤖 Generated with [Claude Code](https://claude.com/claude-code)