### PR TITLE
Trim pasted secrets in isx init, and say why a token was rejected

### DIFF
--- a/cli/src/main/java/dev/incusspawn/command/BuildCommand.java
+++ b/cli/src/main/java/dev/incusspawn/command/BuildCommand.java
@@ -1838,11 +1838,11 @@ public class BuildCommand extends BaseCommand {
         for (var branch : List.of("main", "master")) {
             var treeUrl = "https://api.github.com/repos/" + ownerRepo + "/git/trees/"
                     + branch + "?recursive=1";
-            var token = System.getenv("GITHUB_TOKEN");
+            var token = Environment.strippedEnv("GITHUB_TOKEN");
             var reqBuilder = HttpRequest.newBuilder(URI.create(treeUrl))
                     .timeout(Duration.ofSeconds(15))
                     .header("Accept", "application/vnd.github+json");
-            if (token != null && !token.isBlank()) {
+            if (!token.isBlank()) {
                 reqBuilder.header("Authorization", "Bearer " + token);
             }
             var response = http.send(reqBuilder.build(), HttpResponse.BodyHandlers.ofString());

--- a/cli/src/main/java/dev/incusspawn/command/InitCommand.java
+++ b/cli/src/main/java/dev/incusspawn/command/InitCommand.java
@@ -47,6 +47,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 )
 public class InitCommand extends BaseCommand {
 
+    private static final ObjectMapper JSON = new ObjectMapper();
+
     private IncusClient incus;
     private boolean useUfw;
 
@@ -1184,8 +1186,8 @@ public class InitCommand extends BaseCommand {
         var envOauthToken = strippedEnv("CLAUDE_CODE_OAUTH_TOKEN");
 
         if ("1".equals(envVertex)) {
-            var region = System.getenv().getOrDefault("CLOUD_ML_REGION", "");
-            var projectId = System.getenv().getOrDefault("ANTHROPIC_VERTEX_PROJECT_ID", "");
+            var region = strippedEnv("CLOUD_ML_REGION");
+            var projectId = strippedEnv("ANTHROPIC_VERTEX_PROJECT_ID");
             System.out.println("  Detected Vertex AI configuration from environment:");
             System.out.println("    Region:  " + (region.isBlank() ? "(not set)" : region));
             System.out.println("    Project: " + (projectId.isBlank() ? "(not set)" : projectId));
@@ -1213,7 +1215,7 @@ public class InitCommand extends BaseCommand {
                     }
                 }
             }
-        } else if (envOauthToken != null && !envOauthToken.isBlank()) {
+        } else if (!envOauthToken.isBlank()) {
             System.out.println("  Detected CLAUDE_CODE_OAUTH_TOKEN from environment.");
             System.out.println("  Verifying OAuth token...");
             var oauthResult = verifyOauthToken(envOauthToken);
@@ -1229,7 +1231,7 @@ public class InitCommand extends BaseCommand {
                 System.out.println("  " + oauthResult.message());
                 System.out.println("  Continuing with manual setup...");
             }
-        } else if (envApiKey != null && !envApiKey.isBlank()) {
+        } else if (!envApiKey.isBlank()) {
             System.out.println("  Detected ANTHROPIC_API_KEY from environment.");
             System.out.println("  Verifying API key...");
             var result = verifyAnthropicApiKey(envApiKey);
@@ -1320,7 +1322,7 @@ public class InitCommand extends BaseCommand {
         } else if (authChoice.equals("1")) {
             while (true) {
                 System.out.print("  ANTHROPIC_API_KEY (or press Enter to skip): ");
-                var key = readSecret(console);
+                var key = readSecret(console.readPassword());
                 if (key.isBlank()) {
                     System.out.println("  Skipped Claude setup. Configure later with 'isx init'.");
                     break;
@@ -1380,48 +1382,31 @@ public class InitCommand extends BaseCommand {
         };
     }
 
-    /**
-     * Read a secret from the console, trimming surrounding whitespace.
-     *
-     * Every {@code readLine()} prompt in this class strips its input; secrets must do
-     * the same or a paste that picks up a stray leading/trailing space silently becomes
-     * a different credential and is reported as rejected by the remote API.
-     */
+    /** Environment variable, stripped like every other credential this class reads. */
     private static String strippedEnv(String name) {
         var value = System.getenv(name);
-        return value == null ? null : value.strip();
+        return value == null ? "" : value.strip();
     }
 
-    private static String readSecret(Console console) {
-        return normalizeSecret(console.readPassword());
-    }
-
-    /** {@link #readSecret} without the console, so the trimming is testable. */
-    static String normalizeSecret(char[] chars) {
+    /**
+     * Every {@code readLine()} prompt in this class strips its input; secrets must do the
+     * same or a paste that picks up a stray leading/trailing space silently becomes a
+     * different credential and is reported as rejected by the remote API.
+     */
+    static String readSecret(char[] chars) {
         return chars == null ? "" : new String(chars).strip();
     }
 
-    private static final String OAUTH_TOKEN_PREFIX = "sk-ant-oat01-";
-
-    /**
-     * Tokens from 'claude setup-token' run to about 108 characters. Anything much
-     * shorter is almost always a paste truncated where the terminal wrapped the line
-     * (readPassword() stops at the first newline), which is worth naming rather than
-     * letting the API report it as an expired credential.
-     */
+    /** Real 'claude setup-token' output runs to ~108 chars; much shorter means a paste cut at a line wrap. */
     private static final int OAUTH_TOKEN_MIN_PLAUSIBLE_LENGTH = 90;
 
-    /**
-     * Non-fatal sanity check on a pasted OAuth token. Anthropic may change the format
-     * at any time, so a mismatch only warns — verification against the API remains the
-     * authority.
-     */
+    /** Non-fatal shape check; verification against the API remains the authority. */
     static Optional<String> oauthTokenShapeWarning(String token) {
         if (token == null || token.isBlank()) {
             return Optional.empty();
         }
-        if (!token.startsWith(OAUTH_TOKEN_PREFIX)) {
-            return Optional.of("Note: token does not start with '" + OAUTH_TOKEN_PREFIX
+        if (!token.startsWith(SpawnConfig.ClaudeConfig.OAUTH_TOKEN_PREFIX)) {
+            return Optional.of("Note: token does not start with '" + SpawnConfig.ClaudeConfig.OAUTH_TOKEN_PREFIX
                     + "' (unexpected format for 'claude setup-token' output).");
         }
         if (token.length() < OAUTH_TOKEN_MIN_PLAUSIBLE_LENGTH) {
@@ -1431,27 +1416,29 @@ public class InitCommand extends BaseCommand {
         return Optional.empty();
     }
 
+    private static final Pattern WHITESPACE_RUN = Pattern.compile("\\s+");
+
     /**
-     * Extract {@code error.message} from an Anthropic error body so a failure says what
-     * the API objected to. Remote input: a malformed, empty, or oversized body must
-     * yield no detail rather than throwing or flooding the terminal.
+     * " API said: ..." from an Anthropic error body, or "" when it carries no usable
+     * message. Remote input: a malformed or oversized body must yield nothing rather
+     * than throwing or flooding the terminal.
      */
-    static Optional<String> apiErrorDetail(String body) {
+    static String apiErrorSuffix(String body) {
         if (body == null || body.isBlank()) {
-            return Optional.empty();
+            return "";
         }
         try {
-            var message = new ObjectMapper().readTree(body).path("error").path("message");
+            var message = JSON.readTree(body).path("error").path("message");
             if (!message.isTextual()) {
-                return Optional.empty();
+                return "";
             }
-            var text = message.asText().replaceAll("\\s+", " ").strip();
+            var text = WHITESPACE_RUN.matcher(message.asText()).replaceAll(" ").strip();
             if (text.isEmpty()) {
-                return Optional.empty();
+                return "";
             }
-            return Optional.of(text.length() > 200 ? text.substring(0, 200) + "\u2026" : text);
+            return " API said: " + (text.length() > 200 ? text.substring(0, 200) + "\u2026" : text);
         } catch (Exception e) {
-            return Optional.empty();
+            return "";
         }
     }
 
@@ -1515,13 +1502,14 @@ public class InitCommand extends BaseCommand {
                     .POST(HttpRequest.BodyPublishers.ofString("{}"))
                     .build();
             var response = client.send(request, HttpResponse.BodyHandlers.ofString());
-            var detail = apiErrorDetail(response.body()).map(d -> " API said: " + d).orElse("");
 
             return switch (response.statusCode()) {
                 case 400 -> new AuthResult(true, label + " verified.");
-                case 401 -> new AuthResult(false, label + " rejected (HTTP 401). It may be expired or invalid." + detail);
+                case 401 -> new AuthResult(false, label + " rejected (HTTP 401). It may be expired or invalid."
+                        + apiErrorSuffix(response.body()));
                 case 403 -> new AuthResult(true, label + " accepted (HTTP 403). It may have restricted permissions.");
-                default -> new AuthResult(false, "Unexpected response (HTTP " + response.statusCode() + "). The " + label.toLowerCase() + " may be invalid." + detail);
+                default -> new AuthResult(false, "Unexpected response (HTTP " + response.statusCode() + "). The "
+                        + label.toLowerCase() + " may be invalid." + apiErrorSuffix(response.body()));
             };
         } catch (Exception e) {
             return new AuthResult(false, "Could not reach api.anthropic.com: " + e.getMessage());
@@ -1529,9 +1517,22 @@ public class InitCommand extends BaseCommand {
     }
 
     private void setupClaudeOauth(SpawnConfig config, java.io.Console console) {
+        System.out.println("  A Pro/Max subscription does not come with an API key. What it can");
+        System.out.println("  produce is a long-lived OAuth token (valid about a year):");
+        System.out.println();
+        System.out.println("    1. Install Claude Code: https://claude.com/claude-code");
+        System.out.println("    2. Sign in with the subscription account: run " + BOLD + "claude" + RESET
+                + ", then " + BOLD + "/login" + RESET);
+        System.out.println("    3. Run " + BOLD + "claude setup-token" + RESET);
+        System.out.println("    4. Copy the token it prints (it starts with '"
+                + SpawnConfig.ClaudeConfig.OAUTH_TOKEN_PREFIX + "')");
+        System.out.println();
+        System.out.println("  Re-run 'isx init' to paste a fresh token once this one expires.");
+        System.out.println();
+
         if (commandExists("claude")) {
-            System.out.println("  Found 'claude' CLI on this host.");
-            if (askConfirmation(console, "  Run 'claude setup-token' to generate an OAuth token?", true)) {
+            System.out.println("  Found 'claude' CLI on this host — steps 1 and 2 are already done.");
+            if (askConfirmation(console, "  Run 'claude setup-token' now?", true)) {
                 try {
                     var pb = new ProcessBuilder("claude", "setup-token");
                     pb.inheritIO();
@@ -1549,13 +1550,13 @@ public class InitCommand extends BaseCommand {
                 }
             }
         } else {
-            System.out.println("  'claude' CLI not found on this host.");
-            System.out.println("  To generate a token, install Claude Code and run: claude setup-token");
+            System.out.println("  'claude' CLI not found on this host — follow the steps above on any");
+            System.out.println("  machine where it is installed, then paste the token here.");
         }
 
         while (true) {
             System.out.print("  Paste your OAuth token (or press Enter to skip): ");
-            var token = readSecret(console);
+            var token = readSecret(console.readPassword());
             if (token.isBlank()) {
                 System.out.println("  Skipped Claude setup. Configure later with 'isx init'.");
                 break;
@@ -1679,7 +1680,7 @@ public class InitCommand extends BaseCommand {
 
         while (true) {
             System.out.print("  GitHub PAT (or press Enter to skip): ");
-            var token = readSecret(console);
+            var token = readSecret(console.readPassword());
             if (token.isBlank()) {
                 System.out.println("  Skipped GitHub setup. You can configure it later by re-running 'isx init'.");
                 break;
@@ -1708,7 +1709,7 @@ public class InitCommand extends BaseCommand {
             System.out.println("      " + patSettingsUrl(token));
             System.out.println("    • Or make your email public at https://github.com/settings/profile");
             System.out.print("  Enter new PAT with email permission, or press Enter to continue without: ");
-            var newToken = readSecret(console);
+            var newToken = readSecret(console.readPassword());
             if (newToken.isBlank()) {
                 config.getGithub().setToken(token);
                 config.save();
@@ -1757,7 +1758,7 @@ public class InitCommand extends BaseCommand {
                 return null;
             }
 
-            var json = new ObjectMapper().readTree(response.body());
+            var json = JSON.readTree(response.body());
             var login = json.has("login") ? json.get("login").asText(null) : null;
             var email = json.has("email") && !json.get("email").isNull() ? json.get("email").asText(null) : null;
             if (email == null) {
@@ -1831,7 +1832,7 @@ public class InitCommand extends BaseCommand {
 
     static EmailParseResult parseGitHubEmails(String json) {
         try {
-            var emails = new ObjectMapper().readTree(json);
+            var emails = JSON.readTree(json);
             var verifiedEmails = new ArrayList<String>();
             String primaryEmail = null;
             String noreplyEmail = null;
@@ -1900,7 +1901,7 @@ public class InitCommand extends BaseCommand {
         System.out.println("    4. Copy the generated key");
         System.out.println();
         System.out.print("  Bob API key (or press Enter to skip): ");
-        var apiKey = readSecret(console);
+        var apiKey = readSecret(console.readPassword());
         if (apiKey.isBlank()) {
             System.out.println("  Skipped Bob setup. You can configure it later by re-running 'isx init'.");
             return;
@@ -1951,7 +1952,7 @@ public class InitCommand extends BaseCommand {
         System.out.println("  Add credits at https://platform.openai.com/settings/organization/billing");
         System.out.println();
         System.out.print("  OpenAI API key (or press Enter to skip): ");
-        var apiKey = readSecret(console);
+        var apiKey = readSecret(console.readPassword());
         if (apiKey.isBlank()) {
             System.out.println("  Skipped OpenAI setup. You can configure it later by re-running 'isx init'.");
             return;

--- a/cli/src/main/java/dev/incusspawn/command/InitCommand.java
+++ b/cli/src/main/java/dev/incusspawn/command/InitCommand.java
@@ -1182,12 +1182,12 @@ public class InitCommand extends BaseCommand {
 
         // Detect existing env vars
         var envVertex = System.getenv("CLAUDE_CODE_USE_VERTEX");
-        var envApiKey = strippedEnv("ANTHROPIC_API_KEY");
-        var envOauthToken = strippedEnv("CLAUDE_CODE_OAUTH_TOKEN");
+        var envApiKey = Environment.strippedEnv("ANTHROPIC_API_KEY");
+        var envOauthToken = Environment.strippedEnv("CLAUDE_CODE_OAUTH_TOKEN");
 
         if ("1".equals(envVertex)) {
-            var region = strippedEnv("CLOUD_ML_REGION");
-            var projectId = strippedEnv("ANTHROPIC_VERTEX_PROJECT_ID");
+            var region = Environment.strippedEnv("CLOUD_ML_REGION");
+            var projectId = Environment.strippedEnv("ANTHROPIC_VERTEX_PROJECT_ID");
             System.out.println("  Detected Vertex AI configuration from environment:");
             System.out.println("    Region:  " + (region.isBlank() ? "(not set)" : region));
             System.out.println("    Project: " + (projectId.isBlank() ? "(not set)" : projectId));
@@ -1380,12 +1380,6 @@ public class InitCommand extends BaseCommand {
             case "s" -> VerificationFailureAction.SAVE_UNVERIFIED;
             default -> null;
         };
-    }
-
-    /** Environment variable, stripped like every other credential this class reads. */
-    private static String strippedEnv(String name) {
-        var value = System.getenv(name);
-        return value == null ? "" : value.strip();
     }
 
     /**

--- a/cli/src/main/java/dev/incusspawn/command/InitCommand.java
+++ b/cli/src/main/java/dev/incusspawn/command/InitCommand.java
@@ -32,6 +32,7 @@ import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
@@ -1179,8 +1180,8 @@ public class InitCommand extends BaseCommand {
 
         // Detect existing env vars
         var envVertex = System.getenv("CLAUDE_CODE_USE_VERTEX");
-        var envApiKey = System.getenv("ANTHROPIC_API_KEY");
-        var envOauthToken = System.getenv("CLAUDE_CODE_OAUTH_TOKEN");
+        var envApiKey = strippedEnv("ANTHROPIC_API_KEY");
+        var envOauthToken = strippedEnv("CLAUDE_CODE_OAUTH_TOKEN");
 
         if ("1".equals(envVertex)) {
             var region = System.getenv().getOrDefault("CLOUD_ML_REGION", "");
@@ -1319,7 +1320,7 @@ public class InitCommand extends BaseCommand {
         } else if (authChoice.equals("1")) {
             while (true) {
                 System.out.print("  ANTHROPIC_API_KEY (or press Enter to skip): ");
-                var key = new String(console.readPassword());
+                var key = readSecret(console);
                 if (key.isBlank()) {
                     System.out.println("  Skipped Claude setup. Configure later with 'isx init'.");
                     break;
@@ -1379,6 +1380,81 @@ public class InitCommand extends BaseCommand {
         };
     }
 
+    /**
+     * Read a secret from the console, trimming surrounding whitespace.
+     *
+     * Every {@code readLine()} prompt in this class strips its input; secrets must do
+     * the same or a paste that picks up a stray leading/trailing space silently becomes
+     * a different credential and is reported as rejected by the remote API.
+     */
+    private static String strippedEnv(String name) {
+        var value = System.getenv(name);
+        return value == null ? null : value.strip();
+    }
+
+    private static String readSecret(Console console) {
+        return normalizeSecret(console.readPassword());
+    }
+
+    /** {@link #readSecret} without the console, so the trimming is testable. */
+    static String normalizeSecret(char[] chars) {
+        return chars == null ? "" : new String(chars).strip();
+    }
+
+    private static final String OAUTH_TOKEN_PREFIX = "sk-ant-oat01-";
+
+    /**
+     * Tokens from 'claude setup-token' run to about 108 characters. Anything much
+     * shorter is almost always a paste truncated where the terminal wrapped the line
+     * (readPassword() stops at the first newline), which is worth naming rather than
+     * letting the API report it as an expired credential.
+     */
+    private static final int OAUTH_TOKEN_MIN_PLAUSIBLE_LENGTH = 90;
+
+    /**
+     * Non-fatal sanity check on a pasted OAuth token. Anthropic may change the format
+     * at any time, so a mismatch only warns — verification against the API remains the
+     * authority.
+     */
+    static Optional<String> oauthTokenShapeWarning(String token) {
+        if (token == null || token.isBlank()) {
+            return Optional.empty();
+        }
+        if (!token.startsWith(OAUTH_TOKEN_PREFIX)) {
+            return Optional.of("Note: token does not start with '" + OAUTH_TOKEN_PREFIX
+                    + "' (unexpected format for 'claude setup-token' output).");
+        }
+        if (token.length() < OAUTH_TOKEN_MIN_PLAUSIBLE_LENGTH) {
+            return Optional.of("Note: token is " + token.length() + " characters, shorter than expected."
+                    + " If your terminal wrapped the token, the paste may have been cut short.");
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Extract {@code error.message} from an Anthropic error body so a failure says what
+     * the API objected to. Remote input: a malformed, empty, or oversized body must
+     * yield no detail rather than throwing or flooding the terminal.
+     */
+    static Optional<String> apiErrorDetail(String body) {
+        if (body == null || body.isBlank()) {
+            return Optional.empty();
+        }
+        try {
+            var message = new ObjectMapper().readTree(body).path("error").path("message");
+            if (!message.isTextual()) {
+                return Optional.empty();
+            }
+            var text = message.asText().replaceAll("\\s+", " ").strip();
+            if (text.isEmpty()) {
+                return Optional.empty();
+            }
+            return Optional.of(text.length() > 200 ? text.substring(0, 200) + "\u2026" : text);
+        } catch (Exception e) {
+            return Optional.empty();
+        }
+    }
+
     private static final String[] KNOWN_PREFIXES = {"github_pat_", "sk-ant-", "ghp_"};
 
     static String maskSecret(String secret) {
@@ -1423,6 +1499,7 @@ public class InitCommand extends BaseCommand {
     }
 
     private AuthResult verifyOauthToken(String token) {
+        oauthTokenShapeWarning(token).ifPresent(warning -> System.out.println("  " + warning));
         return verifyAnthropicCredential("Authorization", "Bearer " + token, "OAuth token");
     }
 
@@ -1438,12 +1515,13 @@ public class InitCommand extends BaseCommand {
                     .POST(HttpRequest.BodyPublishers.ofString("{}"))
                     .build();
             var response = client.send(request, HttpResponse.BodyHandlers.ofString());
+            var detail = apiErrorDetail(response.body()).map(d -> " API said: " + d).orElse("");
 
             return switch (response.statusCode()) {
                 case 400 -> new AuthResult(true, label + " verified.");
-                case 401 -> new AuthResult(false, label + " rejected (HTTP 401). It may be expired or invalid.");
+                case 401 -> new AuthResult(false, label + " rejected (HTTP 401). It may be expired or invalid." + detail);
                 case 403 -> new AuthResult(true, label + " accepted (HTTP 403). It may have restricted permissions.");
-                default -> new AuthResult(false, "Unexpected response (HTTP " + response.statusCode() + "). The " + label.toLowerCase() + " may be invalid.");
+                default -> new AuthResult(false, "Unexpected response (HTTP " + response.statusCode() + "). The " + label.toLowerCase() + " may be invalid." + detail);
             };
         } catch (Exception e) {
             return new AuthResult(false, "Could not reach api.anthropic.com: " + e.getMessage());
@@ -1477,7 +1555,7 @@ public class InitCommand extends BaseCommand {
 
         while (true) {
             System.out.print("  Paste your OAuth token (or press Enter to skip): ");
-            var token = new String(console.readPassword());
+            var token = readSecret(console);
             if (token.isBlank()) {
                 System.out.println("  Skipped Claude setup. Configure later with 'isx init'.");
                 break;
@@ -1601,7 +1679,7 @@ public class InitCommand extends BaseCommand {
 
         while (true) {
             System.out.print("  GitHub PAT (or press Enter to skip): ");
-            var token = new String(console.readPassword());
+            var token = readSecret(console);
             if (token.isBlank()) {
                 System.out.println("  Skipped GitHub setup. You can configure it later by re-running 'isx init'.");
                 break;
@@ -1630,7 +1708,7 @@ public class InitCommand extends BaseCommand {
             System.out.println("      " + patSettingsUrl(token));
             System.out.println("    • Or make your email public at https://github.com/settings/profile");
             System.out.print("  Enter new PAT with email permission, or press Enter to continue without: ");
-            var newToken = new String(console.readPassword());
+            var newToken = readSecret(console);
             if (newToken.isBlank()) {
                 config.getGithub().setToken(token);
                 config.save();
@@ -1822,8 +1900,7 @@ public class InitCommand extends BaseCommand {
         System.out.println("    4. Copy the generated key");
         System.out.println();
         System.out.print("  Bob API key (or press Enter to skip): ");
-        var passwordChars = console.readPassword();
-        var apiKey = passwordChars != null ? new String(passwordChars) : "";
+        var apiKey = readSecret(console);
         if (apiKey.isBlank()) {
             System.out.println("  Skipped Bob setup. You can configure it later by re-running 'isx init'.");
             return;
@@ -1874,8 +1951,7 @@ public class InitCommand extends BaseCommand {
         System.out.println("  Add credits at https://platform.openai.com/settings/organization/billing");
         System.out.println();
         System.out.print("  OpenAI API key (or press Enter to skip): ");
-        var passwordChars = console.readPassword();
-        var apiKey = passwordChars != null ? new String(passwordChars) : "";
+        var apiKey = readSecret(console);
         if (apiKey.isBlank()) {
             System.out.println("  Skipped OpenAI setup. You can configure it later by re-running 'isx init'.");
             return;

--- a/cli/src/main/java/dev/incusspawn/command/UpdateBaseCommand.java
+++ b/cli/src/main/java/dev/incusspawn/command/UpdateBaseCommand.java
@@ -1,6 +1,7 @@
 package dev.incusspawn.command;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.incusspawn.Environment;
 import dev.incusspawn.config.ImageDef;
 import org.aesh.command.CommandDefinition;
 import org.aesh.command.CommandResult;
@@ -265,8 +266,8 @@ public class UpdateBaseCommand extends BaseCommand {
 
     private static HttpRequest.Builder githubRequest(String url) {
         var builder = HttpRequest.newBuilder(URI.create(url)).GET();
-        var token = System.getenv("GITHUB_TOKEN");
-        if (token != null && !token.isBlank()) {
+        var token = Environment.strippedEnv("GITHUB_TOKEN");
+        if (!token.isBlank()) {
             builder.header("Authorization", "Bearer " + token);
         }
         return builder;

--- a/cli/src/test/java/dev/incusspawn/command/InitCommandTest.java
+++ b/cli/src/test/java/dev/incusspawn/command/InitCommandTest.java
@@ -375,4 +375,90 @@ class InitCommandTest {
         assertTrue(InitCommand.hasExistingTemplatesSearchPath(
                 java.util.List.of("/home/user/other-templates", "/home/user/incus-spawn-templates")));
     }
+
+    // --- pasted-secret handling -------------------------------------------
+
+    @Test
+    void normalizeSecretTrimsSurroundingWhitespace() {
+        assertEquals("sk-ant-oat01-abc", InitCommand.normalizeSecret("  sk-ant-oat01-abc\t".toCharArray()));
+    }
+
+    @Test
+    void normalizeSecretPreservesInteriorCharacters() {
+        assertEquals("sk-ant-oat01-a_b-c", InitCommand.normalizeSecret("sk-ant-oat01-a_b-c".toCharArray()));
+    }
+
+    @Test
+    void normalizeSecretHandlesNullInput() {
+        assertEquals("", InitCommand.normalizeSecret(null));
+    }
+
+    // --- OAuth token shape check ------------------------------------------
+
+    private static String oauthToken(int length) {
+        var prefix = "sk-ant-oat01-";
+        return prefix + "a".repeat(length - prefix.length());
+    }
+
+    @Test
+    void wellFormedOauthTokenProducesNoWarning() {
+        assertTrue(InitCommand.oauthTokenShapeWarning(oauthToken(108)).isEmpty());
+    }
+
+    @Test
+    void truncatedOauthTokenWarnsWithItsLength() {
+        var warning = InitCommand.oauthTokenShapeWarning(oauthToken(73));
+        assertTrue(warning.isPresent());
+        assertTrue(warning.get().contains("73"), warning.get());
+        assertTrue(warning.get().contains("wrapped"), warning.get());
+    }
+
+    @Test
+    void unexpectedPrefixWarns() {
+        var warning = InitCommand.oauthTokenShapeWarning("sk-ant-api03-" + "a".repeat(95));
+        assertTrue(warning.isPresent());
+        assertTrue(warning.get().contains("sk-ant-oat01-"), warning.get());
+    }
+
+    @Test
+    void blankOauthTokenProducesNoWarning() {
+        assertTrue(InitCommand.oauthTokenShapeWarning("   ").isEmpty());
+        assertTrue(InitCommand.oauthTokenShapeWarning(null).isEmpty());
+    }
+
+    // --- API error detail extraction --------------------------------------
+
+    @Test
+    void apiErrorDetailExtractsMessage() {
+        assertEquals("model: Field required", InitCommand.apiErrorDetail(
+                "{\"type\":\"error\",\"error\":{\"type\":\"invalid_request_error\","
+                        + "\"message\":\"model: Field required\"}}").orElseThrow());
+    }
+
+    @Test
+    void apiErrorDetailCollapsesWhitespaceToOneLine() {
+        assertEquals("first second", InitCommand.apiErrorDetail(
+                "{\"error\":{\"message\":\"first\\n  second\"}}").orElseThrow());
+    }
+
+    @Test
+    void apiErrorDetailTruncatesOverlongMessage() {
+        var detail = InitCommand.apiErrorDetail(
+                "{\"error\":{\"message\":\"" + "x".repeat(500) + "\"}}").orElseThrow();
+        assertEquals(201, detail.length());
+        assertTrue(detail.endsWith("\u2026"), detail);
+    }
+
+    @Test
+    void apiErrorDetailIgnoresMalformedBody() {
+        assertTrue(InitCommand.apiErrorDetail("not json at all").isEmpty());
+        assertTrue(InitCommand.apiErrorDetail("").isEmpty());
+        assertTrue(InitCommand.apiErrorDetail(null).isEmpty());
+    }
+
+    @Test
+    void apiErrorDetailIgnoresNonTextualMessage() {
+        assertTrue(InitCommand.apiErrorDetail("{\"error\":{\"message\":{\"nested\":1}}}").isEmpty());
+        assertTrue(InitCommand.apiErrorDetail("{\"error\":{\"message\":\"  \"}}").isEmpty());
+    }
 }

--- a/cli/src/test/java/dev/incusspawn/command/InitCommandTest.java
+++ b/cli/src/test/java/dev/incusspawn/command/InitCommandTest.java
@@ -376,24 +376,15 @@ class InitCommandTest {
                 java.util.List.of("/home/user/other-templates", "/home/user/incus-spawn-templates")));
     }
 
-    // --- pasted-secret handling -------------------------------------------
+    // --- pasted secrets ---
 
     @Test
-    void normalizeSecretTrimsSurroundingWhitespace() {
-        assertEquals("sk-ant-oat01-abc", InitCommand.normalizeSecret("  sk-ant-oat01-abc\t".toCharArray()));
+    void readSecretStripsSurroundingWhitespaceAndToleratesNull() {
+        assertEquals("sk-ant-oat01-abc", InitCommand.readSecret("  sk-ant-oat01-abc\t".toCharArray()));
+        assertEquals("", InitCommand.readSecret(null));
     }
 
-    @Test
-    void normalizeSecretPreservesInteriorCharacters() {
-        assertEquals("sk-ant-oat01-a_b-c", InitCommand.normalizeSecret("sk-ant-oat01-a_b-c".toCharArray()));
-    }
-
-    @Test
-    void normalizeSecretHandlesNullInput() {
-        assertEquals("", InitCommand.normalizeSecret(null));
-    }
-
-    // --- OAuth token shape check ------------------------------------------
+    // --- OAuth token shape check ---
 
     private static String oauthToken(int length) {
         var prefix = "sk-ant-oat01-";
@@ -426,39 +417,39 @@ class InitCommandTest {
         assertTrue(InitCommand.oauthTokenShapeWarning(null).isEmpty());
     }
 
-    // --- API error detail extraction --------------------------------------
+    // --- API error detail ---
 
     @Test
-    void apiErrorDetailExtractsMessage() {
-        assertEquals("model: Field required", InitCommand.apiErrorDetail(
+    void apiErrorSuffixExtractsMessage() {
+        assertEquals(" API said: model: Field required", InitCommand.apiErrorSuffix(
                 "{\"type\":\"error\",\"error\":{\"type\":\"invalid_request_error\","
-                        + "\"message\":\"model: Field required\"}}").orElseThrow());
+                        + "\"message\":\"model: Field required\"}}"));
     }
 
     @Test
-    void apiErrorDetailCollapsesWhitespaceToOneLine() {
-        assertEquals("first second", InitCommand.apiErrorDetail(
-                "{\"error\":{\"message\":\"first\\n  second\"}}").orElseThrow());
+    void apiErrorSuffixCollapsesWhitespaceToOneLine() {
+        assertEquals(" API said: first second", InitCommand.apiErrorSuffix(
+                "{\"error\":{\"message\":\"first\\n  second\"}}"));
     }
 
     @Test
-    void apiErrorDetailTruncatesOverlongMessage() {
-        var detail = InitCommand.apiErrorDetail(
-                "{\"error\":{\"message\":\"" + "x".repeat(500) + "\"}}").orElseThrow();
-        assertEquals(201, detail.length());
-        assertTrue(detail.endsWith("\u2026"), detail);
+    void apiErrorSuffixTruncatesOverlongMessage() {
+        var suffix = InitCommand.apiErrorSuffix(
+                "{\"error\":{\"message\":\"" + "x".repeat(500) + "\"}}");
+        assertTrue(suffix.endsWith("\u2026"), suffix);
+        assertEquals(" API said: ".length() + 201, suffix.length());
     }
 
     @Test
-    void apiErrorDetailIgnoresMalformedBody() {
-        assertTrue(InitCommand.apiErrorDetail("not json at all").isEmpty());
-        assertTrue(InitCommand.apiErrorDetail("").isEmpty());
-        assertTrue(InitCommand.apiErrorDetail(null).isEmpty());
+    void apiErrorSuffixIgnoresMalformedBody() {
+        assertEquals("", InitCommand.apiErrorSuffix("not json at all"));
+        assertEquals("", InitCommand.apiErrorSuffix(""));
+        assertEquals("", InitCommand.apiErrorSuffix(null));
     }
 
     @Test
-    void apiErrorDetailIgnoresNonTextualMessage() {
-        assertTrue(InitCommand.apiErrorDetail("{\"error\":{\"message\":{\"nested\":1}}}").isEmpty());
-        assertTrue(InitCommand.apiErrorDetail("{\"error\":{\"message\":\"  \"}}").isEmpty());
+    void apiErrorSuffixIgnoresNonTextualMessage() {
+        assertEquals("", InitCommand.apiErrorSuffix("{\"error\":{\"message\":{\"nested\":1}}}"));
+        assertEquals("", InitCommand.apiErrorSuffix("{\"error\":{\"message\":\"  \"}}"));
     }
 }

--- a/common/src/main/java/dev/incusspawn/Environment.java
+++ b/common/src/main/java/dev/incusspawn/Environment.java
@@ -17,6 +17,17 @@ import java.util.List;
 public final class Environment {
     private Environment() {}
 
+    /**
+     * An environment variable, stripped. Credentials arrive from shells, CI files and
+     * copy-paste with stray whitespace attached; a padded token concatenated into an
+     * {@code Authorization} header is rejected as if it were the wrong credential.
+     * Returns "" when unset, so callers need only an {@code isBlank()} check.
+     */
+    public static String strippedEnv(String name) {
+        var value = System.getenv(name);
+        return value == null ? "" : value.strip();
+    }
+
     public static Path home() {
         return Path.of(System.getProperty("user.home"));
     }

--- a/common/src/main/java/dev/incusspawn/config/SpawnConfig.java
+++ b/common/src/main/java/dev/incusspawn/config/SpawnConfig.java
@@ -41,7 +41,9 @@ public class SpawnConfig {
 
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static class ClaudeConfig {
-        public static final String PLACEHOLDER_OAUTH_TOKEN = "sk-ant-oat01-placeholder";
+        /** Prefix of tokens minted by 'claude setup-token'. */
+        public static final String OAUTH_TOKEN_PREFIX = "sk-ant-oat01-";
+        public static final String PLACEHOLDER_OAUTH_TOKEN = OAUTH_TOKEN_PREFIX + "placeholder";
 
         private boolean useVertex;
         private String cloudMlRegion = "";
@@ -52,13 +54,13 @@ public class SpawnConfig {
         public boolean isUseVertex() { return useVertex; }
         public void setUseVertex(boolean useVertex) { this.useVertex = useVertex; }
         public String getCloudMlRegion() { return cloudMlRegion; }
-        public void setCloudMlRegion(String cloudMlRegion) { this.cloudMlRegion = cloudMlRegion == null ? "" : cloudMlRegion; }
+        public void setCloudMlRegion(String cloudMlRegion) { this.cloudMlRegion = cloudMlRegion == null ? "" : cloudMlRegion.strip(); }
         public String getVertexProjectId() { return vertexProjectId; }
-        public void setVertexProjectId(String vertexProjectId) { this.vertexProjectId = vertexProjectId == null ? "" : vertexProjectId; }
+        public void setVertexProjectId(String vertexProjectId) { this.vertexProjectId = vertexProjectId == null ? "" : vertexProjectId.strip(); }
         public String getApiKey() { return apiKey; }
-        public void setApiKey(String apiKey) { this.apiKey = apiKey == null ? "" : apiKey; }
+        public void setApiKey(String apiKey) { this.apiKey = apiKey == null ? "" : apiKey.strip(); }
         public String getOauthToken() { return oauthToken; }
-        public void setOauthToken(String oauthToken) { this.oauthToken = oauthToken == null ? "" : oauthToken; }
+        public void setOauthToken(String oauthToken) { this.oauthToken = oauthToken == null ? "" : oauthToken.strip(); }
 
         public boolean hasAuth() { return useVertex || !oauthToken.isBlank() || !apiKey.isBlank(); }
 
@@ -80,7 +82,7 @@ public class SpawnConfig {
         private String email = "";
 
         public String getToken() { return token; }
-        public void setToken(String token) { this.token = token == null ? "" : token; }
+        public void setToken(String token) { this.token = token == null ? "" : token.strip(); }
         public String getEmail() { return email; }
         public void setEmail(String email) { this.email = email == null ? "" : email; }
     }
@@ -91,7 +93,7 @@ public class SpawnConfig {
         private boolean licenseConsent;
 
         public String getApiKey() { return apiKey; }
-        public void setApiKey(String apiKey) { this.apiKey = apiKey == null ? "" : apiKey; }
+        public void setApiKey(String apiKey) { this.apiKey = apiKey == null ? "" : apiKey.strip(); }
         public boolean hasAuth() { return !apiKey.isBlank(); }
         public boolean isLicenseConsent() { return licenseConsent; }
         public void setLicenseConsent(boolean licenseConsent) { this.licenseConsent = licenseConsent; }
@@ -102,7 +104,7 @@ public class SpawnConfig {
         private String apiKey = "";
 
         public String getApiKey() { return apiKey; }
-        public void setApiKey(String apiKey) { this.apiKey = apiKey == null ? "" : apiKey; }
+        public void setApiKey(String apiKey) { this.apiKey = apiKey == null ? "" : apiKey.strip(); }
         public boolean hasAuth() { return !apiKey.isBlank(); }
     }
 

--- a/common/src/test/java/dev/incusspawn/config/SpawnConfigTest.java
+++ b/common/src/test/java/dev/incusspawn/config/SpawnConfigTest.java
@@ -175,4 +175,31 @@ class SpawnConfigTest {
         assertEquals("~/my-templates", paths.get(0));
         assertEquals("/absolute/path", paths.get(1));
     }
+
+    @Test
+    void credentialSettersStripWhitespace() {
+        var config = new SpawnConfig();
+        config.getClaude().setOauthToken("  sk-ant-oat01-abc\n");
+        config.getGithub().setToken("\tghp_abc ");
+        assertEquals("sk-ant-oat01-abc", config.getClaude().getOauthToken());
+        assertEquals("ghp_abc", config.getGithub().getToken());
+    }
+
+    @Test
+    void deserializeRepairsPaddedCredential() throws Exception {
+        // A config.yaml written by an isx that did not trim pasted secrets is healed on load,
+        // so the proxy never injects a credential with stray whitespace.
+        var yaml = """
+                claude:
+                  oauthToken: "sk-ant-oat01-abc "
+                """;
+        var config = YAML.readValue(yaml, SpawnConfig.class);
+        assertEquals("sk-ant-oat01-abc", config.getClaude().getOauthToken());
+    }
+
+    @Test
+    void placeholderOauthTokenCarriesThePrefix() {
+        assertTrue(SpawnConfig.ClaudeConfig.PLACEHOLDER_OAUTH_TOKEN
+                .startsWith(SpawnConfig.ClaudeConfig.OAUTH_TOKEN_PREFIX));
+    }
 }


### PR DESCRIPTION
## Problem

`isx init` reported a **valid** Claude Pro OAuth token as:

```
OAuth token rejected (HTTP 401). It may be expired or invalid.
```

Replaying the wizard's exact verification request against the same token read from disk returns:

```
HTTP 400  {"type":"error","error":{"type":"invalid_request_error","message":"model: Field required"}}
```

That 400 is precisely what `verifyAnthropicCredential` treats as verified, so the token was good and the check itself is sound — no missing `anthropic-beta` header, nothing wrong with the request. The string that reached the API simply wasn't the string that was pasted.

## Cause

Every `console.readLine()` prompt in `InitCommand` strips its input. None of the six `console.readPassword()` prompts did. A paste that picks up a stray leading or trailing space silently becomes a different credential.

Worse, `readPassword()` stops at the first newline. An OAuth token runs to ~108 characters, so a paste wrapped by the terminal is truncated *and* leaves its tail on stdin for the next prompt (the retry/skip/save question) to swallow — which also makes the wizard look like it skipped a step.

The failure message then blamed the credential rather than the paste.

## Changes

- **Strip every pasted secret.** All six `readPassword()` sites go through a new `readSecret()`; the two credentials read from the environment (`ANTHROPIC_API_KEY`, `CLAUDE_CODE_OAUTH_TOKEN`) are stripped too. The two input paths now behave the same way.
- **Shape-check OAuth tokens before verifying.** A non-fatal warning when the token lacks the `sk-ant-oat01-` prefix, or is materially shorter than expected — reporting the observed length and naming terminal wrapping as the likely cause. Mirrors the existing prefix note for API keys; the API remains the authority, so a format change on Anthropic's side only warns.
- **Surface the API's own message.** `verifyAnthropicCredential` parsed the response body and discarded it. `error.message` is now appended to the 401 and unexpected-status messages, whitespace-collapsed and length-capped, with malformed bodies yielding no detail rather than throwing.

No token or header value is ever echoed.

`INIT_VERSION` is deliberately **not** bumped — this touches no host configuration, only prompt handling.

## Tests

12 new cases in `InitCommandTest` covering the trimming (`normalizeSecret`), the shape check (well-formed / truncated / wrong-prefix / blank), and error-body extraction (message, whitespace collapsing, truncation, malformed and non-textual bodies).

`mvn package` is green. Two pre-existing failures on my macOS host — `GhSetupTest` (2) and `TemplateBuildIT` (6) — are environment-dependent and reproduce identically on unmodified `main`; they are untouched by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PPZZtQfjnYH22pS5ZrR9X9

---

## Follow-up (3b07198)

Review pass. The main change of substance: trimming now also happens in the `SpawnConfig` credential setters. Jackson calls those on load, so a `config.yaml` already holding a padded token is repaired on next read rather than staying broken until the user re-pastes — and any future writer that doesn't go through the wizard is covered too.

The wizard's OAuth step also now spells out how to obtain a token (a Pro/Max subscription yields no API key, only `claude setup-token` output), which was not discoverable from the prompt.

Smaller: `normalizeSecret` folded into `readSecret`; `strippedEnv` returns `""` instead of `null` and now covers `CLOUD_ML_REGION`/`ANTHROPIC_VERTEX_PROJECT_ID`; `apiErrorDetail` became `apiErrorSuffix` returning `String`, parsed lazily so the success path no longer builds a value it discards; `OAUTH_TOKEN_PREFIX` hoisted into `SpawnConfig.ClaudeConfig` so it can't drift from `PLACEHOLDER_OAUTH_TOKEN`; one static `ObjectMapper` per the convention in every sibling class; javadoc trimmed to the file's density.

Note for whoever next touches `MitmProxy`'s Anthropic 401 path (MitmProxy.java:756) — it currently *guesses* that the token expired. `apiErrorSuffix` is a tested parser for that body; lifting it to `common` would be the way to make that message say what the API actually objected to. Not done here because the proxy streams the response and doesn't buffer the body.


## Follow-up (9d6f668)

`GITHUB_TOKEN` was read straight from the environment and concatenated into `"Bearer " + token` at `UpdateBaseCommand.java:269` and `BuildCommand.java:1841`. Padded values — routine from CI env files and copy-paste — build a malformed header and come back as a 401 that looks exactly like a wrong or expired token: the same failure mode this branch fixes for the wizard's prompts.

The accessor now lives in `Environment.strippedEnv`, so the rule has one home instead of a third private copy; both GitHub sites and the four credential env vars `InitCommand` reads go through it, and returning `""` for unset lets callers drop their null guards.
