### PR TITLE
Make the benchmark harness measure the proxy, and measure it doing real work

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -5,7 +5,8 @@ Performance benchmarks for the native image build of the MITM proxy. Use these t
 ## Prerequisites
 
 - **Linux x86_64** (benchmarks read `/proc/<pid>/status` for RSS)
-- **Oracle GraalVM** with `native-image` on `PATH` — release builds use Oracle GraalVM (not Community Edition), so benchmarks should too for comparable results. Download from https://www.oracle.com/java/technologies/downloads/ or use sdkman: `sdk install java 25.0.4-oracle`
+- **Oracle GraalVM** with `native-image` on `PATH` — release builds use Oracle GraalVM (not Community Edition), so benchmarks should too for comparable results. Download from https://www.oracle.com/java/technologies/downloads/ or use sdkman: `sdk install java 25.0.4-oracle`. On Linux you can instead pass `--builder-image=<tag>`, which builds inside the same container image `install.sh` uses and so reproduces the release toolchain exactly.
+- **No proxy already running** — stop the service first (`systemctl --user stop incus-spawn-proxy`), otherwise the freshly built proxy cannot bind the port. The script refuses to run in that state rather than measure the wrong process.
 - **Running Incus daemon** with the default `incusbr0` bridge
 - **Working isx setup** — run `isx init` first so `~/.config/incus-spawn/config.yaml` and the CA cert exist. The proxy needs an API key configured (it doesn't make real API calls during benchmarks, but validates the config)
 - **Podman** — [Hyperfoil](https://hyperfoil.io/) runs inside a Podman container to work around a [CpuWatchdog bug](https://github.com/Hyperfoil/Hyperfoil/issues/833) on machines with non-contiguous CPU numbering in `/proc/stat`. The container virtualizes `/proc/stat` with contiguous numbering.
@@ -36,6 +37,38 @@ bench/run.sh --label "before"
 bench/run.sh --label "after"
 ```
 
+## Load Profiles
+
+`--load=constant` (the default) drives 5,000 req/s at the proxy. That is about **3% of
+capacity**, which makes it a cheap regression tripwire but structurally blind to throughput:
+both a faster and a slower proxy will report ~5,000 req/s at 100% success.
+
+`--load=saturate` runs a closed-loop concurrency ladder (16/64/128/256) that drives the proxy
+to its actual ceiling. Throughput plateaus while latency grows linearly with concurrency —
+that plateau is the capacity figure, and it is what to compare across builds or toolchains.
+
+```shell
+bench/run.sh --load=saturate --label=my-change
+```
+
+Results record `loadMode`, and the delta table only ever compares runs of the same mode.
+
+## Comparing Two Toolchains
+
+The same code built by two different GraalVM releases, on one host:
+
+```shell
+bench/run.sh --builder-image=incus-spawn-graalvm-builder:25.2 --label=25.2
+bench/run.sh --builder-image=incus-spawn-graalvm-builder:25.3 --label=25.3
+```
+
+Use `--graalvm=DIR` instead to point at an unpacked GraalVM (the only option on macOS).
+Either way the binaries self-report the toolchain that produced them (`org.graalvm.version`
+is baked in), and that is what lands in `proxyBuiltWith` / `cliBuiltWith` — so a result can
+never be mislabelled with a toolchain it wasn't built by.
+
+## Reading the Comparison
+
 The script automatically compares with the most recent previous result and prints a delta table:
 
 ```
@@ -56,7 +89,9 @@ Regressions of 1% or more are flagged with `!!!`; improvements with `(better)`.
 
 | Metric | How | Why |
 |---|---|---|
-| Binary size | `stat` on the native runner | Detects image bloat from dependency changes |
+| Proxy binary size | `stat` on `proxy/target/…-runner` | Detects image bloat from dependency changes |
+| CLI binary size | `stat` on `cli/target/…-runner` | The `-Os` vs `-O3` trade-off is a size question |
+| CLI startup | Median of 20 `isx --help` runs | The CLI is short-lived, so launch cost is its cost |
 | Startup time | Wall-clock to first healthy `/health` response | Native startup regression |
 | Idle RSS | `/proc/<pid>/status` VmRSS after 2s settle | Memory footprint at rest |
 | Peak RSS | VmRSS after the load test | Memory under pressure |
@@ -65,9 +100,9 @@ Regressions of 1% or more are flagged with `!!!`; improvements with `(better)`.
 
 ## How It Works
 
-1. Validates the environment (GraalVM, Podman, isx config, Incus bridge)
-2. Builds a native image (`mvnw package -Dnative -DskipTests`), skippable with `--skip-build`
-3. Starts the proxy against the Incus bridge gateway IP
+1. Validates the environment (GraalVM, Podman, isx config, Incus bridge, health port free)
+2. Builds the native images (`mvnw package -Dnative -DskipTests`), skippable with `--skip-build`
+3. Starts `proxy/target/…-runner` directly against the Incus bridge gateway IP
 4. Measures startup time (polling `/health` at 250ms intervals)
 5. Records idle RSS after a 2-second settle period
 6. Starts a Hyperfoil controller in a Podman container (`--network=host`)
@@ -77,6 +112,11 @@ Regressions of 1% or more are flagged with `!!!`; improvements with `(better)`.
 10. Records peak RSS after load
 11. Saves results as JSON to `bench/results/<git-sha>-<timestamp>.json`
 12. Prints summary and comparison with the previous run
+
+Step 3 runs the proxy binary itself rather than `isx proxy start`. Going through the CLI would
+exec whatever `isx-proxy` sits next to the installed `isx` (`ProxyService.resolveProxyBinaryPath`
+resolves it from `which isx`), so the run could silently measure a stale binary instead of the one
+just built — and RSS would be sampled from the CLI wrapper process rather than the proxy.
 
 ## Result Format
 
@@ -89,7 +129,11 @@ Results are JSON files in `bench/results/`:
   "gitSha": "831a617",
   "gitSubject": "Use Quarkus-managed Vert.x instance in MITM proxy",
   "graalvm": "native-image 25.0.3 2026-04-21",
-  "binarySizeBytes": 38210632,
+  "proxyBuiltWith": "native (GraalVM 25.3.4.1)",
+  "cliBuiltWith": "native (GraalVM 25.3.4.1)",
+  "binarySizeBytes": 89919144,
+  "cliBinarySizeBytes": 31525880,
+  "cliStartupUs": 3800,
   "startupMs": 1815,
   "idleRssKb": 152744,
   "peakRssKb": 160108,
@@ -115,7 +159,9 @@ Result files are git-ignored.
 
 ## Interpreting Results
 
-**Stable metrics:** Binary size is deterministic for a given commit — any change is real. Throughput at constant rate (5000 req/s) should show 100% success; a drop means the proxy can't keep up.
+**Binary size:** near-deterministic, but not byte-exact — the same commit and toolchain have produced binaries 65,536 bytes apart, because `git-commit-id` bakes build metadata into the image heap. Treat deltas under ~100 KB as noise and anything larger as real.
+
+**Throughput:** at constant rate (5000 req/s) this only confirms the proxy kept up — it is ~3% of capacity, so it cannot detect a throughput change in either direction. Use `--load=saturate` for that. Success below 100% in either mode means the proxy could not keep up.
 
 **Noisy metrics:** Startup time and RSS vary between runs due to OS scheduling, memory fragmentation, and background load. Run benchmarks on a quiet machine for reliable comparisons. Expect ~10% variance in startup time and ~5% in RSS.
 
@@ -127,8 +173,9 @@ Result files are git-ignored.
 
 ```
 bench/
-  run.sh                # Main benchmark script
-  proxy-health.hf.yaml  # Hyperfoil benchmark definition
-  README.md             # This file
-  results/              # JSON result files (git-ignored)
+  run.sh                  # Main benchmark script
+  proxy-health.hf.yaml    # Constant-rate profile (--load=constant, default)
+  proxy-saturate.hf.yaml  # Closed-loop capacity ladder (--load=saturate)
+  README.md               # This file
+  results/                # JSON result files (git-ignored)
 ```

--- a/bench/README.md
+++ b/bench/README.md
@@ -39,17 +39,36 @@ bench/run.sh --label "after"
 
 ## Load Profiles
 
-`--load=constant` (the default) drives 5,000 req/s at the proxy. That is about **3% of
-capacity**, which makes it a cheap regression tripwire but structurally blind to throughput:
-both a faster and a slower proxy will report ~5,000 req/s at 100% success.
+Three profiles, measuring genuinely different things. Picking the wrong one is how you get a
+confident number that answers no question you actually had.
 
-`--load=saturate` runs a closed-loop concurrency ladder (16/64/128/256) that drives the proxy
-to its actual ceiling. Throughput plateaus while latency grows linearly with concurrency —
-that plateau is the capacity figure, and it is what to compare across builds or toolchains.
+| Mode | Endpoint | What it tells you |
+|---|---|---|
+| `constant` (default) | `/health`, plain HTTP | Regression tripwire at 5,000 req/s |
+| `saturate` | `/health`, plain HTTP | HTTP server ceiling — no TLS, no body, no cache |
+| `maven` | intercepted HTTPS, cached artifact | **The workload containers actually generate** |
+
+`constant` drives 5,000 req/s, roughly 3% of what `/health` can serve. Cheap, but structurally
+blind to throughput: a faster and a slower proxy both report ~5,000 req/s at 100% success.
+
+`saturate` runs a closed-loop concurrency ladder (16/64/128/256) until throughput plateaus
+while latency grows linearly. That plateau is the ceiling of the Vert.x HTTP server — useful,
+but **it is not "the proxy's throughput"**, because `/health` returns a couple of hundred
+plaintext bytes and touches neither TLS nor the cache.
+
+`maven` fetches a real cached artifact over the intercepted HTTPS path: TLS terminated with a
+minted per-domain cert, SNI routing, domain classification, cache lookup, and a 642 KB body
+streamed back. This is the profile to use when comparing builds or toolchains, and the only
+one whose numbers describe the product.
 
 ```shell
-bench/run.sh --load=saturate --label=my-change
+bench/run.sh --load=maven --label=my-change
 ```
+
+It needs no extra setup — the harness builds a truststore from your isx CA, points
+`repo1.maven.org` at the gateway inside the Hyperfoil container, and warms the artifact cache
+before measuring so that every recorded request is a cache hit. Results carry `mbPerSec`
+alongside `meanReqPerSec`, computed from the artifact size actually fetched.
 
 Results record `loadMode`, and the delta table only ever compares runs of the same mode.
 
@@ -95,8 +114,9 @@ Regressions of 1% or more are flagged with `!!!`; improvements with `(better)`.
 | Startup time | Wall-clock to first healthy `/health` response | Native startup regression |
 | Idle RSS | `/proc/<pid>/status` VmRSS after 2s settle | Memory footprint at rest |
 | Peak RSS | VmRSS after the load test | Memory under pressure |
-| Throughput | Hyperfoil constant-rate at 5000 req/s | HTTP server efficiency |
-| Latency p50/p99/max | Hyperfoil steady phase stats | Per-request overhead |
+| Throughput | Hyperfoil, per `--load` profile | Best rung is the headline; all rungs in `ladder` |
+| MB/s | Throughput × artifact size (`maven` only) | The figure that describes cache serving |
+| Latency p50/p99/max | Hyperfoil phase stats | Per-request overhead |
 
 ## How It Works
 
@@ -106,9 +126,11 @@ Regressions of 1% or more are flagged with `!!!`; improvements with `(better)`.
 4. Measures startup time (polling `/health` at 250ms intervals)
 5. Records idle RSS after a 2-second settle period
 6. Starts a Hyperfoil controller in a Podman container (`--network=host`)
-7. Uploads `bench/proxy-health.hf.yaml` via the Hyperfoil REST API
-8. Runs a 5-second warmup at 1000 req/s (results discarded)
-9. Runs a 15-second steady-state benchmark at 5000 req/s with 50 connections
+7. Uploads the selected profile's YAML via the Hyperfoil REST API (and, for `maven`, warms
+   the artifact cache first so every measured request is a cache hit)
+8. Runs a warmup phase (results discarded)
+9. Runs the measured phase(s) — one steady phase for `constant`, a concurrency ladder for
+   `saturate` and `maven`
 10. Records peak RSS after load
 11. Saves results as JSON to `bench/results/<git-sha>-<timestamp>.json`
 12. Prints summary and comparison with the previous run
@@ -175,7 +197,8 @@ Result files are git-ignored.
 bench/
   run.sh                  # Main benchmark script
   proxy-health.hf.yaml    # Constant-rate profile (--load=constant, default)
-  proxy-saturate.hf.yaml  # Closed-loop capacity ladder (--load=saturate)
+  proxy-saturate.hf.yaml  # Closed-loop /health ladder (--load=saturate)
+  proxy-maven.hf.yaml     # Cached-artifact ladder over TLS (--load=maven)
   README.md               # This file
   results/                # JSON result files (git-ignored)
 ```

--- a/bench/proxy-maven.hf.yaml
+++ b/bench/proxy-maven.hf.yaml
@@ -1,0 +1,41 @@
+name: proxy-maven
+http:
+  host: https://repo1.maven.org:18443
+  sharedConnections: 64
+phases:
+- warmup:
+    always:
+      users: 8
+      duration: 5s
+      isWarmup: true
+      scenario:
+      - fetch:
+        - httpRequest:
+            GET: /maven2/org/apache/commons/commons-lang3/3.14.0/commons-lang3-3.14.0.jar
+- c008:
+    always:
+      users: 8
+      duration: 10s
+      startAfter: warmup
+      scenario:
+      - fetch:
+        - httpRequest:
+            GET: /maven2/org/apache/commons/commons-lang3/3.14.0/commons-lang3-3.14.0.jar
+- c032:
+    always:
+      users: 32
+      duration: 10s
+      startAfter: c008
+      scenario:
+      - fetch:
+        - httpRequest:
+            GET: /maven2/org/apache/commons/commons-lang3/3.14.0/commons-lang3-3.14.0.jar
+- c064:
+    always:
+      users: 64
+      duration: 10s
+      startAfter: c032
+      scenario:
+      - fetch:
+        - httpRequest:
+            GET: /maven2/org/apache/commons/commons-lang3/3.14.0/commons-lang3-3.14.0.jar

--- a/bench/proxy-saturate.hf.yaml
+++ b/bench/proxy-saturate.hf.yaml
@@ -1,0 +1,50 @@
+name: proxy-saturate
+http:
+  host: !param TARGET
+  sharedConnections: 256
+phases:
+- warmup:
+    always:
+      users: 32
+      duration: 5s
+      isWarmup: true
+      scenario:
+      - health:
+        - httpRequest:
+            GET: /health
+- c016:
+    always:
+      users: 16
+      duration: 10s
+      startAfter: warmup
+      scenario:
+      - health:
+        - httpRequest:
+            GET: /health
+- c064:
+    always:
+      users: 64
+      duration: 10s
+      startAfter: c016
+      scenario:
+      - health:
+        - httpRequest:
+            GET: /health
+- c128:
+    always:
+      users: 128
+      duration: 10s
+      startAfter: c064
+      scenario:
+      - health:
+        - httpRequest:
+            GET: /health
+- c256:
+    always:
+      users: 256
+      duration: 10s
+      startAfter: c128
+      scenario:
+      - health:
+        - httpRequest:
+            GET: /health

--- a/bench/run.sh
+++ b/bench/run.sh
@@ -37,7 +37,7 @@ while [ $# -gt 0 ]; do
         --load=*) LOAD_MODE="${1#--load=}" ;;
         --load) shift; LOAD_MODE="${1:-}" ;;
         --help|-h)
-            echo "Usage: bench/run.sh [--skip-build] [--label=NAME] [--graalvm=DIR|--builder-image=TAG]"
+            echo "Usage: bench/run.sh [--skip-build] [--label=NAME] [--load=MODE] [--graalvm=DIR|--builder-image=TAG]"
             echo ""
             echo "Benchmarks the native image build of the MITM proxy."
             echo "Measures: binary size, startup time, memory (RSS), throughput, latency."
@@ -45,10 +45,13 @@ while [ $# -gt 0 ]; do
             echo "Options:"
             echo "  --skip-build    Reuse existing native binaries in cli/target and proxy/target"
             echo "  --label=NAME    Tag results with a label (e.g. 'baseline')"
-            echo "  --load=MODE     constant (default): 5000 req/s, ~3% of capacity — a"
-            echo "                  regression tripwire, blind to throughput changes."
-            echo "                  saturate: closed-loop concurrency ladder that drives the"
-            echo "                  proxy to its actual ceiling. Use this to compare toolchains."
+            echo "  --load=MODE     constant (default): 5000 req/s at /health. ~3% of that"
+            echo "                  endpoint's capacity — a regression tripwire only."
+            echo "                  saturate: concurrency ladder against /health. Finds the"
+            echo "                  HTTP server ceiling; no TLS, no body, no cache."
+            echo "                  maven: fetches a real cached artifact over the intercepted"
+            echo "                  HTTPS path. The workload containers actually generate —"
+            echo "                  use this to compare builds or toolchains."
             echo "  --graalvm=DIR   Build with this GraalVM instead of whatever is on PATH."
             echo "  --builder-image=TAG"
             echo "                  Build in this container image — the path Linux releases"
@@ -157,7 +160,8 @@ fi
 case "$LOAD_MODE" in
     constant) BENCHMARK_YAML="$SCRIPT_DIR/proxy-health.hf.yaml" ;;
     saturate) BENCHMARK_YAML="$SCRIPT_DIR/proxy-saturate.hf.yaml" ;;
-    *) die "Unknown --load mode '$LOAD_MODE' (expected: constant, saturate)" ;;
+    maven)    BENCHMARK_YAML="$SCRIPT_DIR/proxy-maven.hf.yaml" ;;
+    *) die "Unknown --load mode '$LOAD_MODE' (expected: constant, saturate, maven)" ;;
 esac
 
 # Check benchmark definition
@@ -170,6 +174,15 @@ fi
 BENCHMARK_NAME=$(awk '/^name:/ { print $2; exit }' "$BENCHMARK_YAML")
 [ -n "$BENCHMARK_NAME" ] || die "No 'name:' in $BENCHMARK_YAML"
 echo "Load:     $LOAD_MODE ($BENCHMARK_NAME)"
+
+if [ "$LOAD_MODE" = maven ]; then
+    # e.g. "host: https://repo1.maven.org:18443" -> repo1.maven.org
+    MAVEN_HOST=$(awk '/^  host:/ { print $2; exit }' "$BENCHMARK_YAML" | sed -E 's#^https?://##; s#:[0-9]+$##')
+    MAVEN_PORT=$(awk '/^  host:/ { print $2; exit }' "$BENCHMARK_YAML" | sed -nE 's#.*:([0-9]+)$#\1#p')
+    MAVEN_PATH=$(awk '/GET:/ { print $2; exit }' "$BENCHMARK_YAML")
+    [ -n "$MAVEN_HOST" ] && [ -n "$MAVEN_PATH" ] || die "Could not parse host/GET path from $BENCHMARK_YAML"
+    echo "Artifact: $MAVEN_HOST$MAVEN_PATH"
+fi
 
 # Resolve gateway IP from Incus bridge
 GATEWAY_IP=$(incus network get incusbr0 ipv4.address 2>/dev/null | cut -d/ -f1) || true
@@ -282,6 +295,19 @@ sleep 2
 IDLE_RSS=$(get_rss_kb "$PROXY_PID")
 echo "Idle RSS:    ${IDLE_RSS} KB"
 
+ARTIFACT_BYTES=0
+if [ "$LOAD_MODE" = maven ]; then
+    # Prime the on-disk cache and prove the intercepted path works before handing
+    # it to the load generator; a cold first request would otherwise be measured
+    # as an upstream fetch and skew the whole run.
+    WARM=$(curl -s -o /dev/null -w "%{http_code}:%{size_download}" \
+        --resolve "$MAVEN_HOST:$MAVEN_PORT:$GATEWAY_IP" --cacert "$ISX_CONFIG_DIR/ca.crt" \
+        "https://$MAVEN_HOST:$MAVEN_PORT$MAVEN_PATH") || die "Artifact fetch through the proxy failed"
+    [ "${WARM%%:*}" = "200" ] || die "Artifact fetch returned HTTP ${WARM%%:*} (expected 200)"
+    ARTIFACT_BYTES="${WARM##*:}"
+    echo "Cache warm:  $ARTIFACT_BYTES bytes"
+fi
+
 # ── 6. Start Hyperfoil ──────────────────────────────────────────────────────
 
 echo ""
@@ -295,8 +321,28 @@ fi
 # Remove any leftover container from a previous run
 podman rm -f "$HYPERFOIL_CONTAINER" 2>/dev/null || true
 
+HF_RUN_ARGS=(-d --name "$HYPERFOIL_CONTAINER" --network=host)
+
+# The maven profile talks HTTPS to the proxy's MITM port as a real client would,
+# so the generator needs (a) repo1.maven.org pointed at the gateway instead of
+# the internet and (b) trust in the leaf cert the proxy mints, which is signed by
+# our own CA. Without the truststore every request fails the handshake.
+if [ "$LOAD_MODE" = maven ]; then
+    command -v keytool &>/dev/null || die "keytool not found; needed to build a truststore for --load=maven"
+    TRUSTSTORE="$(mktemp -d)/isx-truststore.p12"
+    keytool -importcert -noprompt -trustcacerts -alias isx-ca \
+        -file "$ISX_CONFIG_DIR/ca.crt" \
+        -keystore "$TRUSTSTORE" -storetype PKCS12 -storepass changeit &>/dev/null \
+        || die "Failed to build truststore from $ISX_CONFIG_DIR/ca.crt"
+    HF_RUN_ARGS+=(
+        --add-host "$MAVEN_HOST:$GATEWAY_IP"
+        -v "$TRUSTSTORE:/ca/truststore.p12:ro,Z"
+        -e JAVA_OPTS="-Djavax.net.ssl.trustStore=/ca/truststore.p12 -Djavax.net.ssl.trustStorePassword=changeit -Djavax.net.ssl.trustStoreType=PKCS12"
+    )
+fi
+
 echo "Starting Hyperfoil controller..."
-podman run -d --name "$HYPERFOIL_CONTAINER" --network=host "$HYPERFOIL_IMAGE" standalone >/dev/null 2>&1
+podman run "${HF_RUN_ARGS[@]}" "$HYPERFOIL_IMAGE" standalone >/dev/null 2>&1
 
 # Wait for controller to be ready
 HF_READY=false
@@ -327,7 +373,12 @@ curl -sf -X POST "http://localhost:$HYPERFOIL_PORT/benchmark" \
 TARGET_URL="http://$GATEWAY_IP:18080"
 
 # Start the benchmark run
-RESPONSE=$(curl -sf "http://localhost:$HYPERFOIL_PORT/benchmark/$BENCHMARK_NAME/start?templateParam=TARGET=$TARGET_URL")
+if grep -q '!param TARGET' "$BENCHMARK_YAML"; then
+    START_URL="http://localhost:$HYPERFOIL_PORT/benchmark/$BENCHMARK_NAME/start?templateParam=TARGET=$TARGET_URL"
+else
+    START_URL="http://localhost:$HYPERFOIL_PORT/benchmark/$BENCHMARK_NAME/start"
+fi
+RESPONSE=$(curl -sf "$START_URL")
 RUN_ID=$(echo "$RESPONSE" | python3 -c "import sys,json; print(json.load(sys.stdin)['id'])")
 echo "Run started: $RUN_ID"
 
@@ -354,7 +405,9 @@ STATS=$(curl -sf "http://localhost:$HYPERFOIL_PORT/run/$RUN_ID/stats/total")
 echo "$STATS" | python3 -c "
 import sys, json
 data = json.load(sys.stdin)
-print(f\"  {'phase':<8}{'req/s':>10}{'2xx%':>8}{'p50us':>9}{'p99us':>10}{'p99.9us':>10}{'maxus':>10}\")
+artifact_bytes = $ARTIFACT_BYTES
+hdr = f\"  {'phase':<8}{'req/s':>10}{'2xx%':>8}{'p50us':>9}{'p99us':>10}{'p99.9us':>10}{'maxus':>10}\"
+print(hdr + (f\"{'MB/s':>9}\" if artifact_bytes else ''))
 for s in data.get('statistics', []):
     name = s.get('phase') or s.get('name', '?')
     if s.get('isWarmup', False) or 'warmup' in name:
@@ -365,9 +418,12 @@ for s in data.get('statistics', []):
     dur = (summary['endTime'] - summary['startTime']) / 1000
     rate = summary['requestCount'] / dur if dur else 0
     ok = http.get('status_2xx', 0) / max(summary['requestCount'], 1) * 100
-    print(f\"  {name:<8}{rate:>10.0f}{ok:>8.1f}{pct.get('50.0',0)/1000:>9.1f}\"
-          f\"{pct.get('99.0',0)/1000:>10.1f}{pct.get('99.9',0)/1000:>10.1f}\"
-          f\"{summary['maxResponseTime']/1000:>10.1f}\")
+    row = (f\"  {name:<8}{rate:>10.0f}{ok:>8.1f}{pct.get('50.0',0)/1000:>9.1f}\"
+           f\"{pct.get('99.0',0)/1000:>10.1f}{pct.get('99.9',0)/1000:>10.1f}\"
+           f\"{summary['maxResponseTime']/1000:>10.1f}\")
+    if artifact_bytes:
+        row += f\"{rate * artifact_bytes / 1048576:>9.1f}\"
+    print(row)
 "
 
 # ── 8. Peak RSS ─────────────────────────────────────────────────────────────
@@ -405,6 +461,7 @@ for s in data.get('statistics', []):
         'p50Us': round(pct.get('50.0', 0) / 1000.0, 1),
         'p99Us': round(pct.get('99.0', 0) / 1000.0, 1),
         'p999Us': round(pct.get('99.9', 0) / 1000.0, 1),
+        'mbPerSec': round(summary['requestCount'] / duration_s * $ARTIFACT_BYTES / 1048576, 1) if duration_s and $ARTIFACT_BYTES else None,
     })
 # The headline is the best rung: under a saturating ladder that is the plateau,
 # i.e. the proxy's actual ceiling. Under the constant-rate profile there is only

--- a/bench/run.sh
+++ b/bench/run.sh
@@ -82,6 +82,7 @@ cleanup() {
     echo "Cleaning up..."
     [ -n "${PROXY_PID:-}" ] && kill "$PROXY_PID" 2>/dev/null && wait "$PROXY_PID" 2>/dev/null || true
     podman stop "$HYPERFOIL_CONTAINER" 2>/dev/null && podman rm "$HYPERFOIL_CONTAINER" 2>/dev/null || true
+    [ -n "${TRUSTSTORE_DIR:-}" ] && rm -rf "$TRUSTSTORE_DIR" || true
 }
 trap cleanup EXIT
 
@@ -98,6 +99,14 @@ epoch_ms() {
 
 echo "=== Benchmark: native image proxy ==="
 echo ""
+
+# The two toolchain flags are mutually exclusive: a container build ignores the
+# local GRAALVM_HOME entirely, so accepting both would silently measure the
+# builder image while the run is labelled with the --graalvm one. That is the
+# exact class of mislabelled A/B this harness exists to prevent.
+if [ -n "$GRAALVM_DIR" ] && [ -n "$BUILDER_IMAGE" ]; then
+    die "--graalvm and --builder-image are mutually exclusive: a container build ignores the local GraalVM, so the result would not reflect --graalvm. Pick one."
+fi
 
 # Pin a toolchain if asked. Quarkus picks native-image up from GRAALVM_HOME/JAVA_HOME
 # or PATH, so set all three: that is what makes a 25.2-vs-25.3 A/B on one host possible.
@@ -181,7 +190,8 @@ if [ "$LOAD_MODE" = maven ]; then
     MAVEN_PORT=$(awk '/^  host:/ { print $2; exit }' "$BENCHMARK_YAML" | sed -nE 's#.*:([0-9]+)$#\1#p')
     MAVEN_PATH=$(awk '/GET:/ { print $2; exit }' "$BENCHMARK_YAML")
     [ -n "$MAVEN_HOST" ] && [ -n "$MAVEN_PATH" ] || die "Could not parse host/GET path from $BENCHMARK_YAML"
-    echo "Artifact: $MAVEN_HOST$MAVEN_PATH"
+    MAVEN_URL="https://$MAVEN_HOST:$MAVEN_PORT$MAVEN_PATH"
+    echo "Artifact: $MAVEN_URL"
 fi
 
 # Resolve gateway IP from Incus bridge
@@ -302,7 +312,7 @@ if [ "$LOAD_MODE" = maven ]; then
     # as an upstream fetch and skew the whole run.
     WARM=$(curl -s -o /dev/null -w "%{http_code}:%{size_download}" \
         --resolve "$MAVEN_HOST:$MAVEN_PORT:$GATEWAY_IP" --cacert "$ISX_CONFIG_DIR/ca.crt" \
-        "https://$MAVEN_HOST:$MAVEN_PORT$MAVEN_PATH") || die "Artifact fetch through the proxy failed"
+        "$MAVEN_URL") || die "Artifact fetch through the proxy failed"
     [ "${WARM%%:*}" = "200" ] || die "Artifact fetch returned HTTP ${WARM%%:*} (expected 200)"
     ARTIFACT_BYTES="${WARM##*:}"
     echo "Cache warm:  $ARTIFACT_BYTES bytes"
@@ -329,7 +339,8 @@ HF_RUN_ARGS=(-d --name "$HYPERFOIL_CONTAINER" --network=host)
 # our own CA. Without the truststore every request fails the handshake.
 if [ "$LOAD_MODE" = maven ]; then
     command -v keytool &>/dev/null || die "keytool not found; needed to build a truststore for --load=maven"
-    TRUSTSTORE="$(mktemp -d)/isx-truststore.p12"
+    TRUSTSTORE_DIR="$(mktemp -d)"
+    TRUSTSTORE="$TRUSTSTORE_DIR/isx-truststore.p12"
     keytool -importcert -noprompt -trustcacerts -alias isx-ca \
         -file "$ISX_CONFIG_DIR/ca.crt" \
         -keystore "$TRUSTSTORE" -storetype PKCS12 -storepass changeit &>/dev/null \

--- a/bench/run.sh
+++ b/bench/run.sh
@@ -18,27 +18,49 @@ HYPERFOIL_IMAGE="quay.io/hyperfoil/hyperfoil:latest"
 HYPERFOIL_CONTAINER="isx-bench-hf"
 HYPERFOIL_PORT=8090
 BENCHMARK_YAML="$SCRIPT_DIR/proxy-health.hf.yaml"
+LOAD_MODE="constant"
 
 SKIP_BUILD=false
 LABEL=""
+GRAALVM_DIR=""
+BUILDER_IMAGE=""
 
 while [ $# -gt 0 ]; do
     case "$1" in
         --skip-build) SKIP_BUILD=true ;;
         --label=*) LABEL="${1#--label=}" ;;
         --label) shift; LABEL="${1:-}" ;;
+        --graalvm=*) GRAALVM_DIR="${1#--graalvm=}" ;;
+        --graalvm) shift; GRAALVM_DIR="${1:-}" ;;
+        --builder-image=*) BUILDER_IMAGE="${1#--builder-image=}" ;;
+        --builder-image) shift; BUILDER_IMAGE="${1:-}" ;;
+        --load=*) LOAD_MODE="${1#--load=}" ;;
+        --load) shift; LOAD_MODE="${1:-}" ;;
         --help|-h)
-            echo "Usage: bench/run.sh [--skip-build] [--label=NAME]"
+            echo "Usage: bench/run.sh [--skip-build] [--label=NAME] [--graalvm=DIR|--builder-image=TAG]"
             echo ""
             echo "Benchmarks the native image build of the MITM proxy."
             echo "Measures: binary size, startup time, memory (RSS), throughput, latency."
             echo ""
             echo "Options:"
-            echo "  --skip-build    Reuse existing native binary in target/"
+            echo "  --skip-build    Reuse existing native binaries in cli/target and proxy/target"
             echo "  --label=NAME    Tag results with a label (e.g. 'baseline')"
+            echo "  --load=MODE     constant (default): 5000 req/s, ~3% of capacity — a"
+            echo "                  regression tripwire, blind to throughput changes."
+            echo "                  saturate: closed-loop concurrency ladder that drives the"
+            echo "                  proxy to its actual ceiling. Use this to compare toolchains."
+            echo "  --graalvm=DIR   Build with this GraalVM instead of whatever is on PATH."
+            echo "  --builder-image=TAG"
+            echo "                  Build in this container image — the path Linux releases"
+            echo "                  actually use (see install.sh). Preferred over --graalvm on"
+            echo "                  Linux, since it reproduces the release toolchain exactly."
+            echo ""
+            echo "                  Either flag lets you A/B two toolchains on one host:"
+            echo "                    bench/run.sh --builder-image=incus-spawn-graalvm-builder:25.2 --label=25.2"
+            echo "                    bench/run.sh --builder-image=incus-spawn-graalvm-builder:25.3 --label=25.3"
             echo ""
             echo "Requirements:"
-            echo "  - Oracle GraalVM with native-image on PATH"
+            echo "  - Oracle GraalVM with native-image on PATH (or via --graalvm/--builder-image)"
             echo "  - Working isx setup (run 'isx init' first)"
             echo "  - Running Incus daemon"
             echo "  - Podman (for running Hyperfoil in a container)"
@@ -74,8 +96,33 @@ epoch_ms() {
 echo "=== Benchmark: native image proxy ==="
 echo ""
 
+# Pin a toolchain if asked. Quarkus picks native-image up from GRAALVM_HOME/JAVA_HOME
+# or PATH, so set all three: that is what makes a 25.2-vs-25.3 A/B on one host possible.
+if [ -n "$GRAALVM_DIR" ]; then
+    GRAALVM_DIR="${GRAALVM_DIR/#\~/$HOME}"
+    [ -x "$GRAALVM_DIR/bin/native-image" ] || die "No native-image at $GRAALVM_DIR/bin/native-image"
+    export GRAALVM_HOME="$GRAALVM_DIR"
+    export JAVA_HOME="$GRAALVM_DIR"
+    export PATH="$GRAALVM_DIR/bin:$PATH"
+fi
+
+MVN_TOOLCHAIN_ARGS=()
+if [ -n "$BUILDER_IMAGE" ]; then
+    podman image exists "$BUILDER_IMAGE" 2>/dev/null \
+        || die "Builder image '$BUILDER_IMAGE' not found locally. Build or pull it first."
+    MVN_TOOLCHAIN_ARGS=(
+        -Dquarkus.native.container-build=true
+        -Dquarkus.native.container-runtime=podman
+        -Dquarkus.native.builder-image="$BUILDER_IMAGE"
+        -Dquarkus.native.builder-image.pull=never
+    )
+fi
+
 # Check native-image
-if command -v native-image &>/dev/null; then
+if [ -n "$BUILDER_IMAGE" ]; then
+    GRAALVM_VERSION="$(podman run --rm "$BUILDER_IMAGE" native-image --version 2>&1 | head -1) (in $BUILDER_IMAGE)"
+    echo "GraalVM:  $GRAALVM_VERSION"
+elif command -v native-image &>/dev/null; then
     GRAALVM_VERSION="$(native-image --version 2>&1 | head -1)"
     GRAALVM_FULL="$(native-image --version 2>&1)"
     if ! echo "$GRAALVM_FULL" | grep -qi "oracle"; then
@@ -106,10 +153,23 @@ if [ ! -f "$ISX_CONFIG_DIR/ca.key" ]; then
     die "isx CA not initialized ($ISX_CONFIG_DIR/ca.key missing). Run 'isx init' first."
 fi
 
+# Select the load profile
+case "$LOAD_MODE" in
+    constant) BENCHMARK_YAML="$SCRIPT_DIR/proxy-health.hf.yaml" ;;
+    saturate) BENCHMARK_YAML="$SCRIPT_DIR/proxy-saturate.hf.yaml" ;;
+    *) die "Unknown --load mode '$LOAD_MODE' (expected: constant, saturate)" ;;
+esac
+
 # Check benchmark definition
 if [ ! -f "$BENCHMARK_YAML" ]; then
     die "Benchmark definition not found at $BENCHMARK_YAML"
 fi
+
+# The name in the YAML is what the REST API addresses the benchmark by, so read
+# it rather than hardcoding — otherwise adding a profile silently starts the wrong one.
+BENCHMARK_NAME=$(awk '/^name:/ { print $2; exit }' "$BENCHMARK_YAML")
+[ -n "$BENCHMARK_NAME" ] || die "No 'name:' in $BENCHMARK_YAML"
+echo "Load:     $LOAD_MODE ($BENCHMARK_NAME)"
 
 # Resolve gateway IP from Incus bridge
 GATEWAY_IP=$(incus network get incusbr0 ipv4.address 2>/dev/null | cut -d/ -f1) || true
@@ -118,6 +178,15 @@ if [ -z "$GATEWAY_IP" ]; then
 fi
 echo "Gateway:  $GATEWAY_IP"
 
+# A proxy already bound to the health port is the worst failure mode here: the
+# freshly built one loses the bind and exits, but /health still answers — from
+# the *old* process — so the run would report its startup, RSS and throughput.
+if curl -sf --max-time 2 "http://$GATEWAY_IP:18080/health" &>/dev/null; then
+    die "Something is already serving $GATEWAY_IP:18080 — results would come from that process, not the build under test.
+  Stop it first:  systemctl --user stop incus-spawn-proxy
+  Restart after:  systemctl --user start incus-spawn-proxy"
+fi
+
 GIT_SHA="$(git -C "$PROJECT_DIR" rev-parse --short HEAD 2>/dev/null || echo "unknown")"
 GIT_SUBJECT="$(git -C "$PROJECT_DIR" log -1 --format=%s 2>/dev/null || echo "")"
 echo "Git:      $GIT_SHA $GIT_SUBJECT"
@@ -125,36 +194,65 @@ echo ""
 
 # ── 2. Build native image ───────────────────────────────────────────────────
 
-RUNNER=$(ls -t "$PROJECT_DIR"/cli/target/incus-spawn-*-runner 2>/dev/null | head -1 || true)
+resolve_runner() {
+    # shellcheck disable=SC2012  # -t ordering is the point; names have no spaces
+    ls -t $1 2>/dev/null | head -1 || true
+}
+
+CLI_RUNNER=$(resolve_runner "$PROJECT_DIR/cli/target/incus-spawn-*-runner")
+PROXY_RUNNER=$(resolve_runner "$PROJECT_DIR/proxy/target/incus-spawn-proxy-*-runner")
 
 if $SKIP_BUILD; then
-    if [ -z "$RUNNER" ]; then
-        die "No native binary found in cli/target/. Run without --skip-build first."
-    fi
-    echo "Skipping build, using existing binary: $RUNNER"
+    [ -n "$PROXY_RUNNER" ] || die "No native proxy binary in proxy/target/. Run without --skip-build first."
+    [ -n "$CLI_RUNNER" ] || die "No native CLI binary in cli/target/. Run without --skip-build first."
+    echo "Skipping build, using existing binaries."
 else
-    echo "Building native image (this takes a few minutes)..."
+    echo "Building native images (this takes a few minutes)..."
     BUILD_START=$(epoch_ms)
-    "$PROJECT_DIR/mvnw" -f "$PROJECT_DIR/pom.xml" package -Dnative -DskipTests -q
+    "$PROJECT_DIR/mvnw" -f "$PROJECT_DIR/pom.xml" package -Dnative -DskipTests -q "${MVN_TOOLCHAIN_ARGS[@]}"
     BUILD_END=$(epoch_ms)
     BUILD_TIME_MS=$((BUILD_END - BUILD_START))
-    RUNNER=$(ls -t "$PROJECT_DIR"/cli/target/incus-spawn-*-runner 2>/dev/null | head -1)
-    [ -z "$RUNNER" ] && die "Native build succeeded but no runner binary found in cli/target/"
+    CLI_RUNNER=$(resolve_runner "$PROJECT_DIR/cli/target/incus-spawn-*-runner")
+    PROXY_RUNNER=$(resolve_runner "$PROJECT_DIR/proxy/target/incus-spawn-proxy-*-runner")
+    [ -z "$CLI_RUNNER" ] && die "Native build succeeded but no runner binary found in cli/target/"
+    [ -z "$PROXY_RUNNER" ] && die "Native build succeeded but no runner binary found in proxy/target/"
     echo "Build completed in $((BUILD_TIME_MS / 1000))s"
 fi
+echo "  proxy: $PROXY_RUNNER"
+echo "  cli:   $CLI_RUNNER"
+
+# The binaries bake org.graalvm.version in, so they report the toolchain that
+# actually produced them — the only trustworthy label for a 25.2-vs-25.3 run.
+PROXY_BUILT_WITH=$("$PROXY_RUNNER" --version 2>/dev/null | tail -1 || true)
+CLI_BUILT_WITH=$("$CLI_RUNNER" --version 2>/dev/null | tail -1 || true)
+echo "  built with: ${PROXY_BUILT_WITH:-unknown}"
 echo ""
 
-# ── 3. Binary size ──────────────────────────────────────────────────────────
+# ── 3. Binary size and CLI startup ──────────────────────────────────────────
 
-BINARY_SIZE=$(stat -c %s "$RUNNER")
+BINARY_SIZE=$(stat -c %s "$PROXY_RUNNER")
 BINARY_SIZE_MB=$(awk "BEGIN { printf \"%.1f\", $BINARY_SIZE / 1048576 }")
-echo "Binary size: $BINARY_SIZE_MB MB ($BINARY_SIZE bytes)"
+CLI_BINARY_SIZE=$(stat -c %s "$CLI_RUNNER")
+CLI_BINARY_SIZE_MB=$(awk "BEGIN { printf \"%.1f\", $CLI_BINARY_SIZE / 1048576 }")
+echo "Proxy binary: $BINARY_SIZE_MB MB ($BINARY_SIZE bytes)"
+echo "CLI binary:   $CLI_BINARY_SIZE_MB MB ($CLI_BINARY_SIZE bytes)"
+
+# The CLI is short-lived and startup-bound, so its cost is process launch, not
+# throughput. Take the median of 20 `--help` runs (--help touches no daemon).
+CLI_SAMPLES=$(for _ in $(seq 1 20); do
+    s=$(date +%s%N)
+    "$CLI_RUNNER" --help >/dev/null 2>&1 || true
+    e=$(date +%s%N)
+    echo $(( (e - s) / 1000 ))
+done | sort -n | tr '\n' ' ')
+CLI_STARTUP_US=$(echo "$CLI_SAMPLES" | awk '{ print $10 }')
+echo "CLI startup:  ${CLI_STARTUP_US} us (median of 20)"
 
 # ── 4. Start proxy and measure startup time ─────────────────────────────────
 
 echo "Starting proxy..."
 PROXY_START=$(epoch_ms)
-"$RUNNER" proxy start --gateway-ip "$GATEWAY_IP" &>/dev/null &
+"$PROXY_RUNNER" --gateway-ip "$GATEWAY_IP" &>/dev/null &
 PROXY_PID=$!
 
 HEALTH_URL="http://$GATEWAY_IP:18080/health"
@@ -229,7 +327,7 @@ curl -sf -X POST "http://localhost:$HYPERFOIL_PORT/benchmark" \
 TARGET_URL="http://$GATEWAY_IP:18080"
 
 # Start the benchmark run
-RESPONSE=$(curl -sf "http://localhost:$HYPERFOIL_PORT/benchmark/proxy-health/start?templateParam=TARGET=$TARGET_URL")
+RESPONSE=$(curl -sf "http://localhost:$HYPERFOIL_PORT/benchmark/$BENCHMARK_NAME/start?templateParam=TARGET=$TARGET_URL")
 RUN_ID=$(echo "$RESPONSE" | python3 -c "import sys,json; print(json.load(sys.stdin)['id'])")
 echo "Run started: $RUN_ID"
 
@@ -256,19 +354,20 @@ STATS=$(curl -sf "http://localhost:$HYPERFOIL_PORT/run/$RUN_ID/stats/total")
 echo "$STATS" | python3 -c "
 import sys, json
 data = json.load(sys.stdin)
+print(f\"  {'phase':<8}{'req/s':>10}{'2xx%':>8}{'p50us':>9}{'p99us':>10}{'p99.9us':>10}{'maxus':>10}\")
 for s in data.get('statistics', []):
-    if s.get('isWarmup', False):
+    name = s.get('phase') or s.get('name', '?')
+    if s.get('isWarmup', False) or 'warmup' in name:
         continue
     summary = s['summary']
     pct = summary.get('percentileResponseTime', {})
     http = summary.get('extensions', {}).get('http', {})
-    print(f\"  Requests:   {summary['requestCount']}\")
-    rate = summary['requestCount'] / ((summary['endTime'] - summary['startTime']) / 1000)
-    print(f\"  Throughput: {rate:.1f} req/s\")
-    print(f\"  Success:    {http.get('status_2xx', 0) / max(summary['requestCount'], 1) * 100:.1f}%\")
-    print(f\"  Latency p50: {pct.get('50.0', 0)/1000:.1f} us\")
-    print(f\"  Latency p99: {pct.get('99.0', 0)/1000:.1f} us\")
-    print(f\"  Latency max: {summary['maxResponseTime']/1000:.1f} us\")
+    dur = (summary['endTime'] - summary['startTime']) / 1000
+    rate = summary['requestCount'] / dur if dur else 0
+    ok = http.get('status_2xx', 0) / max(summary['requestCount'], 1) * 100
+    print(f\"  {name:<8}{rate:>10.0f}{ok:>8.1f}{pct.get('50.0',0)/1000:>9.1f}\"
+          f\"{pct.get('99.0',0)/1000:>10.1f}{pct.get('99.9',0)/1000:>10.1f}\"
+          f\"{summary['maxResponseTime']/1000:>10.1f}\")
 "
 
 # ── 8. Peak RSS ─────────────────────────────────────────────────────────────
@@ -289,21 +388,32 @@ podman stop "$HYPERFOIL_CONTAINER" 2>/dev/null && podman rm "$HYPERFOIL_CONTAINE
 THROUGHPUT_DATA=$(echo "$STATS" | python3 -c "
 import sys, json
 data = json.load(sys.stdin)
+rungs = []
 for s in data.get('statistics', []):
-    if s.get('isWarmup', False):
+    name = s.get('phase') or s.get('name', '?')
+    if s.get('isWarmup', False) or 'warmup' in name:
         continue
     summary = s['summary']
     pct = summary.get('percentileResponseTime', {})
+    http = summary.get('extensions', {}).get('http', {})
     duration_s = (summary['endTime'] - summary['startTime']) / 1000
-    print(json.dumps({
+    rungs.append({
+        'phase': name,
         'requestCount': summary['requestCount'],
-        'meanReqPerSec': round(summary['requestCount'] / duration_s, 1),
+        'meanReqPerSec': round(summary['requestCount'] / duration_s, 1) if duration_s else 0,
+        'success2xxPct': round(http.get('status_2xx', 0) / max(summary['requestCount'], 1) * 100, 1),
         'p50Us': round(pct.get('50.0', 0) / 1000.0, 1),
         'p99Us': round(pct.get('99.0', 0) / 1000.0, 1),
         'p999Us': round(pct.get('99.9', 0) / 1000.0, 1),
-    }))
-    break
-" 2>/dev/null) || THROUGHPUT_DATA='{"requestCount":0,"meanReqPerSec":0,"p50Us":0,"p99Us":0,"p999Us":0}'
+    })
+# The headline is the best rung: under a saturating ladder that is the plateau,
+# i.e. the proxy's actual ceiling. Under the constant-rate profile there is only
+# one rung, so this stays identical to what the harness has always reported.
+best = max(rungs, key=lambda r: r['meanReqPerSec']) if rungs else {}
+out = dict(best)
+out['ladder'] = rungs
+print(json.dumps(out))
+" 2>/dev/null) || THROUGHPUT_DATA='{"requestCount":0,"meanReqPerSec":0,"p50Us":0,"p99Us":0,"p999Us":0,"ladder":[]}'
 
 # ── 11. Save results ────────────────────────────────────────────────────────
 
@@ -320,18 +430,24 @@ result = {
     'gitSha': '$GIT_SHA',
     'gitSubject': '''$GIT_SUBJECT''',
     'graalvm': '''$GRAALVM_VERSION''',
+    'proxyBuiltWith': '''$PROXY_BUILT_WITH''',
+    'cliBuiltWith': '''$CLI_BUILT_WITH''',
     'binarySizeBytes': $BINARY_SIZE,
+    'cliBinarySizeBytes': $CLI_BINARY_SIZE,
+    'cliStartupUs': $CLI_STARTUP_US,
     'startupMs': $STARTUP_MS,
     'idleRssKb': $IDLE_RSS,
     'peakRssKb': $PEAK_RSS,
     'throughput': throughput,
     'loadTool': 'hyperfoil',
+    'loadMode': '''$LOAD_MODE''',
+    'benchmarkName': '''$BENCHMARK_NAME''',
+    # Read the shape of the load off the definition that actually ran; the old
+    # hardcoded block described proxy-health and silently mislabelled any other profile.
     'hyperfoilConfig': {
         'image': '$HYPERFOIL_IMAGE',
-        'connections': 50,
-        'warmupDuration': '5s',
-        'steadyDuration': '15s',
-        'targetRate': 5000,
+        'definition': '''$(basename "$BENCHMARK_YAML")''',
+        'connections': $(awk '/sharedConnections:/ { print $2; exit }' "$BENCHMARK_YAML"),
     },
 }
 with open('$RESULT_FILE', 'w') as f:
@@ -347,7 +463,10 @@ echo "Results saved to: $RESULT_FILE"
 
 echo ""
 echo "=== Results ==="
-printf "%-20s %s\n" "Binary size:" "$BINARY_SIZE_MB MB"
+printf "%-20s %s\n" "Built with:" "${PROXY_BUILT_WITH:-unknown}"
+printf "%-20s %s\n" "Proxy binary:" "$BINARY_SIZE_MB MB"
+printf "%-20s %s\n" "CLI binary:" "$CLI_BINARY_SIZE_MB MB"
+printf "%-20s %s\n" "CLI startup:" "${CLI_STARTUP_US} us"
 printf "%-20s %s\n" "Startup time:" "${STARTUP_MS} ms"
 printf "%-20s %s\n" "Idle RSS:" "${IDLE_RSS} KB"
 printf "%-20s %s\n" "Peak RSS:" "${PEAK_RSS} KB"
@@ -363,7 +482,28 @@ printf "%-20s %s\n" "Latency p99:" "${P99} us"
 printf "%-20s %s\n" "Latency p99.9:" "${P999} us"
 
 # Compare with most recent previous result
-PREV_RESULT=$(ls -t "$RESULTS_DIR"/*.json 2>/dev/null | grep -v "$(basename "$RESULT_FILE")" | head -1 || true)
+# Only compare against a run of the same load profile. A constant-rate result and
+# a saturating one differ by two orders of magnitude, so a cross-mode delta table
+# is not a regression signal — it is noise dressed up as a 3000% improvement.
+PREV_RESULT=$(python3 - "$RESULTS_DIR" "$RESULT_FILE" "$LOAD_MODE" <<'PY' || true
+import json, os, sys
+results_dir, current, mode = sys.argv[1], sys.argv[2], sys.argv[3]
+candidates = []
+for name in os.listdir(results_dir):
+    path = os.path.join(results_dir, name)
+    if not name.endswith('.json') or os.path.samefile(path, current):
+        continue
+    try:
+        with open(path) as f:
+            # Results written before loadMode existed were all constant-rate.
+            if json.load(f).get('loadMode', 'constant') == mode:
+                candidates.append((os.path.getmtime(path), path))
+    except Exception:
+        continue
+if candidates:
+    print(max(candidates)[1])
+PY
+)
 if [ -n "$PREV_RESULT" ]; then
     echo ""
     echo "=== Comparison with previous run ==="
@@ -397,7 +537,9 @@ def delta(name, curr_val, prev_val, unit, lower_is_better=True):
 ct = curr.get('throughput', {})
 pt = prev.get('throughput', {})
 
-delta('Binary size', curr['binarySizeBytes'], prev['binarySizeBytes'], 'B')
+delta('Proxy binary', curr['binarySizeBytes'], prev.get('binarySizeBytes', 0), 'B')
+delta('CLI binary', curr.get('cliBinarySizeBytes', 0), prev.get('cliBinarySizeBytes', 0), 'B')
+delta('CLI startup', curr.get('cliStartupUs', 0), prev.get('cliStartupUs', 0), 'us')
 delta('Startup time', curr['startupMs'], prev['startupMs'], 'ms')
 delta('Idle RSS', curr['idleRssKb'], prev['idleRssKb'], 'KB')
 delta('Peak RSS', curr['peakRssKb'], prev['peakRssKb'], 'KB')

--- a/docs/PERFORMANCE-NOTES.md
+++ b/docs/PERFORMANCE-NOTES.md
@@ -1,0 +1,102 @@
+# Performance Notes
+
+Running notes on measured performance, kept as raw material for a future landing page.
+Add to it whenever a benchmark produces a number worth quoting. Every figure here must
+be reproducible with `bench/run.sh` and carry the conditions it was measured under —
+a marketing claim we cannot re-measure on demand is a liability, not an asset.
+
+## Read this before quoting any number below
+
+**The load test hits `/health` over plain HTTP on port 18080. It does not exercise TLS
+termination, certificate minting, credential injection, or upstream forwarding.** What it
+characterises is the proxy's Vert.x HTTP server path — the floor under everything else, not
+the MITM work itself. "The proxy sustains 166k req/s" is therefore true of the server
+core and *not* a statement about intercepted HTTPS throughput, which nobody has measured
+yet. See "Open questions" below.
+
+Latency figures are also load-dependent by construction: a closed-loop benchmark trades
+latency for concurrency, so p50 at 256 concurrent (1.5 ms) and p50 at 16 concurrent (90 µs)
+describe the same server at the same throughput. Quote the pair, never the flattering half.
+
+## Headline figures
+
+Measured 2026-08-28 on commit `fbb10d9`, Linux x86_64, 32 logical cores, quiet host.
+Oracle GraalVM 25.3.4.1, native image, `-O3` + G1 (the release configuration).
+
+| What | Figure | Conditions |
+|---|---|---|
+| Proxy HTTP capacity | **~166,000 req/s** | closed-loop, 16–256 concurrent, 100% 2xx |
+| Latency at capacity | **90 µs p50**, 184 µs p99 | 16 concurrent, saturated |
+| Latency at realistic load | **15 µs p50**, 33 µs p99 | 5,000 req/s (3% of capacity) |
+| Proxy idle memory | **~82 MB RSS** | after 2s settle |
+| Proxy startup | **~514 ms** | to first healthy `/health` |
+| CLI startup | **~3.8 ms** | median of 20 `isx --help` |
+| CLI binary | **30.1 MB** | `-Os`, serial GC |
+| Proxy binary | **85.8 MB** | `-O3`, G1 |
+
+The capacity number is worth understanding before it gets used: the proxy is deliberately
+confined to **2 Vert.x event loops** (`quarkus.vertx.event-loops-pool-size=2`,
+`-R:ActiveProcessorCount=4`). It reaches ~166k req/s on two event loops while the other 30
+cores on the box run the load generator. The honest framing is efficiency-per-core, not raw
+throughput — it is a background service for a handful of agent containers that costs almost
+nothing to keep running.
+
+## Behaviour above capacity
+
+Driven open-loop at 200,000 req/s (25.3 proxy):
+
+- delivered 168,360 req/s — the ceiling, reproduced by a second, independent load model
+- **100% 2xx** — nothing failed
+- p50 collapsed to 21.5 ms, p99 to 167.8 ms, max 220.2 ms
+
+The proxy degrades by queueing, not by shedding. Latency is the early-warning signal;
+errors never appear. Useful for an honest "what happens under overload" section.
+
+## GraalVM 25.2 → 25.3 (issue #590)
+
+Same commit, same host, both toolchains from the release builder images.
+
+- **Throughput: 25.3 ahead in 8/8 rungs across two counterbalanced rounds, +0.6% to +3.8%.**
+  Direction is credible; magnitude is soft. Roughly +1–2%.
+- **Binary size: proxy −1.0%, CLI −2.6%** under 25.3.
+- **Startup: flat** (515 ms → 514 ms).
+- **RSS: no signal.** −5.2% in round 1, +21% in round 2. G1's adaptive sizing under a
+  10-second burst is not a stable measurement. Do not quote RSS deltas between toolchains.
+
+Not a marketing story on its own — a ~1–2% throughput drift is invisible next to the
+efficiency-per-core framing above. Recorded so the next upgrade has a baseline.
+
+## CLI `-Os` vs `-O3` (GraalVM 25.3)
+
+Interleaved A/B/A/B, 60 pairs, so drift hits both variants equally:
+
+| | `-Os` | `-O3` |
+|---|---|---|
+| Binary | 31,525,880 B | 72,682,488 B (**+131%**) |
+| Startup median | 3,952 µs | 3,736 µs (**−5.5%**) |
+
+`-O3` buys ~216 µs of startup for +41 MB. Verdict: **keep `-Os`.** A CLI invocation cannot
+perceive 216 µs, and 41 MB is a real download and disk cost for users.
+
+## Measurement caveats worth remembering
+
+- **Native builds are not byte-reproducible here.** The same commit and toolchain produced
+  proxy binaries 65,536 bytes apart (the `git-commit-id` plugin bakes build metadata into
+  the image heap). Treat size deltas below ~100 KB as noise.
+- **Startup drifts ~8% between sessions.** Cross-session startup comparisons are worthless;
+  only interleaved A/B within one session is trustworthy.
+- **Single-run RSS and tail latency are noise.** Anything under ~5% needs repetition with
+  the run order counterbalanced.
+
+## Open questions before a landing page
+
+1. **Throughput through the actual MITM path** — TLS termination + credential injection +
+   upstream forward. This is the number a landing page would really want, and it does not
+   exist yet. It needs a benchmark with an upstream stub, not `/health`.
+2. **Cache effectiveness** — the OCI blob / Maven artifact / npm tarball caches are a
+   strong story (bandwidth and latency saved on repeat container builds) and are entirely
+   unmeasured.
+3. **Container branch time** — CoW branching is a headline feature; "new environment in
+   N seconds" would be the most compelling figure on the page, and it is not measured here.
+4. **Comparison baseline** — every figure above is absolute. A landing page needs a
+   reference point (a plain HTTPS forward proxy? no proxy at all?) for any of it to land.

--- a/docs/PERFORMANCE-NOTES.md
+++ b/docs/PERFORMANCE-NOTES.md
@@ -5,66 +5,87 @@ Add to it whenever a benchmark produces a number worth quoting. Every figure her
 be reproducible with `bench/run.sh` and carry the conditions it was measured under —
 a marketing claim we cannot re-measure on demand is a liability, not an asset.
 
-## Read this before quoting any number below
+## Which number describes what
 
-**The load test hits `/health` over plain HTTP on port 18080. It does not exercise TLS
-termination, certificate minting, credential injection, or upstream forwarding.** What it
-characterises is the proxy's Vert.x HTTP server path — the floor under everything else, not
-the MITM work itself. "The proxy sustains 166k req/s" is therefore true of the server
-core and *not* a statement about intercepted HTTPS throughput, which nobody has measured
-yet. See "Open questions" below.
+The harness has three load profiles, and they measure genuinely different things. Quoting
+one as if it were the other is the easiest way to publish something false.
 
-Latency figures are also load-dependent by construction: a closed-loop benchmark trades
-latency for concurrency, so p50 at 256 concurrent (1.5 ms) and p50 at 16 concurrent (90 µs)
-describe the same server at the same throughput. Quote the pair, never the flattering half.
+| Profile | Path exercised | Result |
+|---|---|---|
+| `--load=constant` | `/health`, plain HTTP | 5,000 req/s tripwire; ~3% of that endpoint's capacity |
+| `--load=saturate` | `/health`, plain HTTP | ~166,000 req/s — **HTTP server core only** |
+| `--load=maven` | intercepted HTTPS, TLS + cached 642 KB artifact | **~116 req/s, ~73 MB/s** |
+
+**`--load=maven` is the one that describes the product.** It terminates TLS with a minted
+per-domain cert, routes by SNI, classifies the domain, hits the artifact cache and streams a
+real body back — the work a container build actually causes. The `/health` figures describe
+the Vert.x server underneath and must never be quoted as "the proxy's throughput".
 
 ## Headline figures
 
-Measured 2026-08-28 on commit `fbb10d9`, Linux x86_64, 32 logical cores, quiet host.
-Oracle GraalVM 25.3.4.1, native image, `-O3` + G1 (the release configuration).
+Measured 2026-08-28, Linux x86_64, 32 logical cores, quiet host. Oracle GraalVM 25.3.4.1,
+native image, `-O3` + G1 (the release configuration).
 
 | What | Figure | Conditions |
 |---|---|---|
-| Proxy HTTP capacity | **~166,000 req/s** | closed-loop, 16–256 concurrent, 100% 2xx |
-| Latency at capacity | **90 µs p50**, 184 µs p99 | 16 concurrent, saturated |
-| Latency at realistic load | **15 µs p50**, 33 µs p99 | 5,000 req/s (3% of capacity) |
+| Cached artifact serving | **~73 MB/s** (116 req/s × 642 KB) | 8–64 concurrent, 100% 2xx |
+| Cached artifact latency | **~11 ms** single client | 642 KB over TLS, cache hit |
+| Cold artifact (upstream) | **~177 ms** | first fetch, network-bound |
+| HTTP server core | ~166,000 req/s, 90 µs p50 | `/health`, no TLS, no body |
 | Proxy idle memory | **~82 MB RSS** | after 2s settle |
 | Proxy startup | **~514 ms** | to first healthy `/health` |
 | CLI startup | **~3.8 ms** | median of 20 `isx --help` |
 | CLI binary | **30.1 MB** | `-Os`, serial GC |
 | Proxy binary | **85.8 MB** | `-O3`, G1 |
 
-The capacity number is worth understanding before it gets used: the proxy is deliberately
-confined to **2 Vert.x event loops** (`quarkus.vertx.event-loops-pool-size=2`,
-`-R:ActiveProcessorCount=4`). It reaches ~166k req/s on two event loops while the other 30
-cores on the box run the load generator. The honest framing is efficiency-per-core, not raw
-throughput — it is a background service for a handful of agent containers that costs almost
-nothing to keep running.
+The cache-hit story is the strongest honest claim available today: **a 642 KB dependency
+served in ~11 ms from local cache instead of ~177 ms from Maven Central** — a 16× latency
+improvement on repeat builds, which is what agent containers do constantly.
 
-## Behaviour above capacity
+The proxy is also deliberately confined to **2 Vert.x event loops**
+(`quarkus.vertx.event-loops-pool-size=2`, `-R:ActiveProcessorCount=4`), so all of the above
+is achieved on two cores of a 32-core box. Efficiency-per-core is the framing, not raw
+throughput.
 
-Driven open-loop at 200,000 req/s (25.3 proxy):
+## Known bottleneck: cached artifact throughput caps at ~70 MB/s
 
-- delivered 168,360 req/s — the ceiling, reproduced by a second, independent load model
-- **100% 2xx** — nothing failed
-- p50 collapsed to 21.5 ms, p99 to 167.8 ms, max 220.2 ms
+Confirmed three independent ways, all flat across concurrency:
 
-The proxy degrades by queueing, not by shedding. Latency is the early-warning signal;
-errors never appear. Useful for an honest "what happens under overload" section.
+- single `curl`: 58 MB/s
+- parallel `curl` (OpenSSL), 8 and 32 concurrent: 65 MB/s — **identical at both**
+- Hyperfoil, 8/32/64 concurrent: 73 / 72 / 72 MB/s
+
+Throughput stays pinned while latency scales linearly (p50 60 ms at 8 concurrent → 545 ms at
+64), which is the signature of a hard serialisation point. For AES-GCM on hardware with
+AES-NI this is roughly an order of magnitude low, and the load generator is ruled out (curl
+with OpenSSL hits the same wall). The suspect is how `serveCachedFile` streams from disk.
+
+Practical impact: a build pulling 500 MB of cached dependencies spends ~7 s minimum on proxy
+egress. Worth its own issue; not a #590 concern.
 
 ## GraalVM 25.2 → 25.3 (issue #590)
 
 Same commit, same host, both toolchains from the release builder images.
 
-- **Throughput: 25.3 ahead in 8/8 rungs across two counterbalanced rounds, +0.6% to +3.8%.**
-  Direction is credible; magnitude is soft. Roughly +1–2%.
-- **Binary size: proxy −1.0%, CLI −2.6%** under 25.3.
-- **Startup: flat** (515 ms → 514 ms).
-- **RSS: no signal.** −5.2% in round 1, +21% in round 2. G1's adaptive sizing under a
-  10-second burst is not a stable measurement. Do not quote RSS deltas between toolchains.
+**On the real path (`--load=maven`): no measurable difference.** Four runs with the order
+counterbalanced, 100% 2xx throughout:
 
-Not a marketing story on its own — a ~1–2% throughput drift is invisible next to the
-efficiency-per-core framing above. Recorded so the next upgrade has a baseline.
+| Rung | 25.2 | 25.2b | 25.3 | 25.3b |
+|---|---|---|---|---|
+| 8 | 116 | 116 | 116 | 116 |
+| 32 | 115 | 115 | 114 | 116 |
+| 64 | 114 | 114 | 114 | 114 |
+
+Differences of 0–2 req/s, under 1%. Expected, given the ~70 MB/s bottleneck above: the path
+is not bound by compiled-code speed, so a better inliner has nothing to bite on.
+
+**On `/health` (`--load=saturate`): 25.3 ahead in 8/8 rungs, +0.6% to +3.8%.** Real for that
+path, but it does not transfer to the workload above. Treat as a curiosity.
+
+**Binary size: proxy −1.0%, CLI −2.6%** under 25.3. **Startup: flat** (515 → 514 ms).
+
+**RSS: no signal.** −5.2% in one round, +21% in the next. G1's adaptive sizing under a
+10-second burst is not a stable measurement. Do not quote RSS deltas between toolchains.
 
 ## CLI `-Os` vs `-O3` (GraalVM 25.3)
 
@@ -87,16 +108,18 @@ perceive 216 µs, and 41 MB is a real download and disk cost for users.
   only interleaved A/B within one session is trustworthy.
 - **Single-run RSS and tail latency are noise.** Anything under ~5% needs repetition with
   the run order counterbalanced.
+- **Closed-loop latency is a function of concurrency.** p50 at 64 concurrent and p50 at 8
+  concurrent describe the same server at the same throughput. Quote the pair, never the
+  flattering half.
 
 ## Open questions before a landing page
 
-1. **Throughput through the actual MITM path** — TLS termination + credential injection +
-   upstream forward. This is the number a landing page would really want, and it does not
-   exist yet. It needs a benchmark with an upstream stub, not `/health`.
-2. **Cache effectiveness** — the OCI blob / Maven artifact / npm tarball caches are a
-   strong story (bandwidth and latency saved on repeat container builds) and are entirely
-   unmeasured.
-3. **Container branch time** — CoW branching is a headline feature; "new environment in
-   N seconds" would be the most compelling figure on the page, and it is not measured here.
-4. **Comparison baseline** — every figure above is absolute. A landing page needs a
-   reference point (a plain HTTPS forward proxy? no proxy at all?) for any of it to land.
+1. **Credential injection overhead** — the Anthropic/OpenAI paths rewrite headers and, for
+   Vertex, translate request bodies. Unmeasured, and closer to the product's core claim than
+   artifact caching is.
+2. **Cache effectiveness in aggregate** — the 16× per-artifact figure is good; bandwidth and
+   wall-clock saved across a realistic full build would be better.
+3. **Container branch time** — CoW branching is a headline feature; "new environment in N
+   seconds" would likely be the most compelling number on the page, and it is not measured.
+4. **Comparison baseline** — every figure here is absolute. A landing page needs a reference
+   point (a plain forward proxy? no proxy at all?) for any of it to land.


### PR DESCRIPTION
Groundwork for #590. Benchmarking GraalVM 25.2 vs 25.3 turned out to be blocked on the harness measuring the wrong binary, in the wrong process, on the wrong code path — so this fixes those first. The #590 results are posted on the issue.

## The harness could not have produced a valid comparison

Three defects, each of which silently measured something other than what it claimed:

- **Wrong binary.** It launched `"$CLI_RUNNER" proxy start`, and `isx proxy start` execs whatever `isx-proxy` sits beside the *installed* `isx` — `ProxyService.resolveProxyBinaryPath()` resolves it via `which isx`. The freshly built proxy was never run. This is the gotcha called out in #590.
- **Wrong process.** `PROXY_PID` was therefore the CLI wrapper blocked in `waitFor()`, so idle and peak RSS described the wrapper, not the proxy.
- **Wrong instance.** With a proxy service already bound to the health port, the new proxy loses the bind and exits — but `/health` still answers, from the old process. The run would report the old binary's startup, RSS and throughput. Now refused up front with the command to stop the service.

## The default profile cannot detect a throughput change

`proxy-health.hf.yaml` drives a constant 5,000 req/s. That endpoint serves ~166,000 req/s, so the benchmark runs at ~3% of capacity and a faster and a slower proxy both report ~5,000 req/s at 100% success.

`--load=saturate` adds a closed-loop concurrency ladder that finds the actual ceiling.

## But `/health` is not the proxy

Plain HTTP, ~200 bytes, no TLS, no cache, no upstream. It measures the Vert.x server underneath the proxy. `--load=maven` measures the path a container build actually generates — TLS terminated with a minted per-domain cert, SNI routing, domain classification, Maven cache lookup, 642 KB body streamed back.

The two are not comparable: **~166,000 req/s on `/health` vs ~116 req/s (~73 MB/s) serving a cached artifact.**

`--load=maven` needs no setup from the user: the harness builds a truststore from the isx CA (Hyperfoil is a JVM client and won't trust our leaf), points `repo1.maven.org` at the gateway inside the container, and warms the cache so no measured request is a cold upstream pull.

## Also

- `--builder-image=TAG` / `--graalvm=DIR` to pin a toolchain. On Linux the container path reproduces the release build exactly (same image `install.sh` uses), which is what makes a same-host A/B possible.
- Separate proxy and CLI binary sizes; the old single figure was the CLI's while the load test measured the proxy.
- A CLI startup metric (median of 20 `isx --help`), since `-Os` vs `-O3` is a startup question.
- `proxyBuiltWith` / `cliBuiltWith` read from the binaries' baked-in `org.graalvm.version`, so a result cannot be mislabelled with a toolchain it wasn't built by.
- Results record `loadMode`; the delta table only compares runs of the same mode, instead of reporting a cross-profile "+3205% throughput".
- `hyperfoilConfig` is read from the definition that ran, rather than hardcoded to `proxy-health`'s values.
- README corrected: binary size is *not* byte-exact — the same commit and toolchain produced binaries 65,536 bytes apart, because `git-commit-id` bakes build metadata into the image heap.

## docs/PERFORMANCE-NOTES.md

Collects the measured figures as raw material for a future landing page, with conditions and caveats attached, and an explicit table of which profile's numbers may be quoted as what. It also records a bottleneck found along the way: **cached artifact serving caps at ~70 MB/s** regardless of concurrency, confirmed three independent ways (single curl 58 MB/s, parallel curl 65 MB/s flat 8→32, Hyperfoil 72 MB/s flat 8→64). That is roughly an order of magnitude below AES-GCM on this hardware and the load generator is ruled out. Worth its own issue.

## Testing

All three profiles run end-to-end on Linux x86_64 against a live Incus daemon; `--load=maven` verified to serve cache hits (proxy logs `Maven cache hit` for every request, 100% 2xx).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013CZ7v6giZGfaNaE3CV8gfN