### PR TITLE
Build the proxy with -march=skylake on x86_64 (5.6x TLS throughput)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,8 @@ Three Maven modules under a parent POM:
 - **`proxy`** (`incus-spawn-proxy`): the standalone MITM proxy binary (`isx-proxy`). Depends on common. Native image: G1 GC, `-O3` (throughput-optimized, enables ML-inferred PGO), and on x86_64 `-march=skylake`.
   The `-march` value is set by arch-gated Maven profiles in `proxy/pom.xml` (empty on aarch64, where an x86 `-march` would fail the build).
   GraalVM's default `-march=x86-64-v3` omits AES and CLMUL, so the image cannot use AES-NI/GHASH intrinsics and TLS falls back to software AES —
-  measured 65 MB/s vs 363 MB/s serving a cached Maven artifact. Do not "upgrade" this to `x86-64-v4`: the numbered levels never include AES,
+  measured 65 MB/s vs 363 MB/s serving a cached Maven artifact. AES/CLMUL cost no reach (AES-NI predates v3 by three years); ADX does move the
+  floor to Broadwell (2014) / Zen (2017), which is accepted deliberately. Do not "upgrade" this to `x86-64-v4`: the numbered levels never include AES,
   so v4 measures identically to v3 while dropping non-AVX-512 hardware.
 
 Both `cli` and `proxy` are independent Quarkus applications that produce separate native binaries. When `isx-proxy` is not installed, `isx proxy start` falls back to running the proxy inline within the CLI process.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,11 @@ Three Maven modules under a parent POM:
 
 - **`common`** (`incus-spawn-common`): shared code — Incus client, proxy config, image/tool definitions, configuration loading. Not a Quarkus app; uses the Jandex Maven plugin to produce a `META-INF/jandex.idx` so Quarkus discovers its CDI beans and `@RegisterForReflection` annotations from dependent modules.
 - **`cli`** (`incus-spawn`): the main CLI/TUI binary (`isx`). Depends on common. Native image: serial GC, `-Os` (size-optimized), `-H:-AllowVMInternalThreads`.
-- **`proxy`** (`incus-spawn-proxy`): the standalone MITM proxy binary (`isx-proxy`). Depends on common. Native image: G1 GC, `-O3` (throughput-optimized, enables ML-inferred PGO).
+- **`proxy`** (`incus-spawn-proxy`): the standalone MITM proxy binary (`isx-proxy`). Depends on common. Native image: G1 GC, `-O3` (throughput-optimized, enables ML-inferred PGO), and on x86_64 `-march=skylake`.
+  The `-march` value is set by arch-gated Maven profiles in `proxy/pom.xml` (empty on aarch64, where an x86 `-march` would fail the build).
+  GraalVM's default `-march=x86-64-v3` omits AES and CLMUL, so the image cannot use AES-NI/GHASH intrinsics and TLS falls back to software AES —
+  measured 65 MB/s vs 363 MB/s serving a cached Maven artifact. Do not "upgrade" this to `x86-64-v4`: the numbered levels never include AES,
+  so v4 measures identically to v3 while dropping non-AVX-512 hardware.
 
 Both `cli` and `proxy` are independent Quarkus applications that produce separate native binaries. When `isx-proxy` is not installed, `isx proxy start` falls back to running the proxy inline within the CLI process.
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -38,7 +38,7 @@ Three Maven modules under a parent POM:
 
 - **`common`** (`incus-spawn-common`): shared code — Incus client, proxy config, image/tool definitions, configuration loading. Not a Quarkus app; uses the Jandex Maven plugin to produce a bean index so Quarkus discovers its CDI beans from dependent modules.
 - **`cli`** (`incus-spawn`): the main CLI/TUI binary (`isx`). Depends on common. Native image: serial GC, `-Os` (size-optimized).
-- **`proxy`** (`incus-spawn-proxy`): the standalone MITM proxy binary (`isx-proxy`). Depends on common. Native image: G1 GC, `-O3` (throughput-optimized). When `isx-proxy` is not installed, `isx proxy start` falls back to running the proxy inline within the CLI process.
+- **`proxy`** (`incus-spawn-proxy`): the standalone MITM proxy binary (`isx-proxy`). Depends on common. Native image: G1 GC, `-O3` (throughput-optimized), and on x86_64 `-march=skylake` — see "Native image CPU baseline" below. When `isx-proxy` is not installed, `isx proxy start` falls back to running the proxy inline within the CLI process.
 
 ## Architecture
 
@@ -492,6 +492,45 @@ The removal is stateless — rather than tracking which remotes were added, we s
 **Protocol-lenient URL matching**
 
 Host repos may use SSH URLs (`git@github.com:org/repo.git`) while container repos use HTTPS (`https://github.com/org/repo.git`). The URL matcher normalizes both formats by stripping the scheme, `user@` prefix, SSH `:` separator, trailing `.git`, `www.` prefix, and lowercasing. The result is a canonical form like `github.com/org/repo` that matches regardless of protocol.
+
+### Native image CPU baseline
+
+The proxy is built with `-march=skylake` on x86_64, set by arch-gated Maven profiles in
+`proxy/pom.xml` so aarch64 builds (Linux arm64, Apple Silicon) pass no `-march` at all —
+an x86 value there is a hard build failure.
+
+GraalVM's default is `-march=x86-64-v3`, and the numbered psABI levels **do not include AES
+or CLMUL**. Without those the image cannot emit AES-NI/GHASH intrinsics, so TLS bulk
+encryption runs as software AES. Every byte through this proxy is AES-GCM encrypted on both
+legs — once to the client on a cache hit, twice on a miss (decrypt from upstream, re-encrypt
+to the client) — so that fallback dominates. Serving a cached 642 KB Maven artifact,
+measured on one host, same commit, Oracle GraalVM 25.3:
+
+| `-march` | Throughput | Note |
+|---|---|---|
+| `x86-64-v3` (GraalVM default) | 65 MB/s | no AES/CLMUL |
+| `x86-64-v4` | 65 MB/s | AVX-512 but still no AES — a trap |
+| `haswell` | 349 MB/s | v3 + AES + CLMUL |
+| **`skylake`** | **363 MB/s** | + ADX; what we ship |
+| `skylake-avx512` | 363 MB/s | no gain, +524 KB, excludes Zen 1–3 |
+| `native` | 383 MB/s | not portable |
+
+`skylake` costs almost nothing in reach: AES-NI shipped in 2010, three years *before* the
+AVX2/BMI2 that `x86-64-v3` already demands, so requiring it excludes no CPU that could run
+the previous binary. ADX (Broadwell, 2014) is the only real narrowing. Binary size is
+unchanged. It is chosen as a deliberately stable floor rather than something to revisit each
+release.
+
+Two things that look like they should help and do not, both measured:
+
+- **`-H:RuntimeCheckedCPUFeatures` does not cover the crypto intrinsics.** Adding
+  `AES,CLMUL` to a v3 build left throughput at 65 MB/s, and adding `AVX512_VAES` to a
+  skylake build changed nothing. The AES-GCM intrinsic is selected at build time from
+  `-march`; runtime dispatch applies to a narrower set of operations. The ~5% that `native`
+  holds over `skylake` therefore cannot be captured portably.
+- **Raising to `x86-64-v4`** buys nothing and costs all non-AVX-512 hardware.
+
+Reproduce with `bench/run.sh --load=maven`.
 
 ## Testing
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -515,11 +515,18 @@ measured on one host, same commit, Oracle GraalVM 25.3:
 | `skylake-avx512` | 363 MB/s | no gain, +524 KB, excludes Zen 1–3 |
 | `native` | 383 MB/s | not portable |
 
-`skylake` costs almost nothing in reach: AES-NI shipped in 2010, three years *before* the
-AVX2/BMI2 that `x86-64-v3` already demands, so requiring it excludes no CPU that could run
-the previous binary. ADX (Broadwell, 2014) is the only real narrowing. Binary size is
-unchanged. It is chosen as a deliberately stable floor rather than something to revisit each
-release.
+`skylake` is `x86-64-v3` + AES + CLMUL + ADX, and the two halves differ in what they cost:
+
+- **AES and CLMUL cost no reach at all.** AES-NI shipped in 2010, three years *before* the
+  AVX2/BMI2 that `x86-64-v3` already demands, so every CPU able to run the previous binary
+  already has them.
+- **ADX does narrow the baseline.** It arrives with Intel Broadwell (2014) and AMD Zen
+  (2017), so Intel Haswell (2013-14) and AMD Excavator can run `x86-64-v3` code but not
+  this build.
+
+That narrowing is accepted deliberately, as a stable floor rather than something to
+re-evaluate each release. `haswell` would avoid it entirely and measures ~4% slower
+(349 MB/s vs 363 MB/s). Binary size is unchanged either way.
 
 Two things that look like they should help and do not, both measured:
 

--- a/proxy/pom.xml
+++ b/proxy/pom.xml
@@ -160,12 +160,15 @@
           native image cannot use AES-NI/GHASH intrinsics and TLS bulk encryption
           falls back to software AES. Since every byte through this proxy is
           AES-GCM encrypted on both legs, that costs ~5x: measured 65 MB/s at v3
-          vs 351 MB/s at skylake serving a cached Maven artifact.
+          vs 363 MB/s at skylake serving a cached Maven artifact.
 
-          skylake is v3 + AES + CLMUL + ADX. AES-NI shipped in 2010, three years
-          before the AVX2/BMI2 that v3 already requires, so this excludes nothing
-          v3 did not; ADX (Broadwell, 2014) is the only real narrowing. Chosen
-          over haswell as a deliberately stable floor we do not want to revisit.
+          skylake is v3 + AES + CLMUL + ADX. The AES and CLMUL half costs no reach
+          at all: AES-NI shipped in 2010, three years before the AVX2/BMI2 that v3
+          already requires. ADX does narrow the baseline — it arrives with Broadwell
+          (2014) and AMD Zen (2017), so Intel Haswell (2013-14) and AMD Excavator
+          run v3 code but not this. That narrowing is accepted deliberately, as a
+          stable floor we do not want to revisit; haswell would avoid it and
+          measures ~4% slower (349 MB/s).
 
           Do NOT "upgrade" this to x86-64-v4: the numbered levels never include
           AES, so v4 measures identically to v3 (65 MB/s) while dropping all

--- a/proxy/pom.xml
+++ b/proxy/pom.xml
@@ -15,6 +15,8 @@
         <proxy.native.gc>serial</proxy.native.gc>
 <!-- Bake os.name at build time to avoid a uname() syscall; macOS doesn't need this (already a build-time constant in GraalVM) -->
         <svm.target.name.args/>
+<!-- Empty by default: -march values are architecture-specific, and passing an x86 one to an aarch64 build fails. Set only by the x86_64 profiles below. -->
+        <native.march.args/>
     </properties>
 
     <dependencies>
@@ -153,6 +155,41 @@
         </plugins>
     </build>
     <profiles>
+        <!--
+          GraalVM's default -march=x86-64-v3 does NOT include AES or CLMUL, so the
+          native image cannot use AES-NI/GHASH intrinsics and TLS bulk encryption
+          falls back to software AES. Since every byte through this proxy is
+          AES-GCM encrypted on both legs, that costs ~5x: measured 65 MB/s at v3
+          vs 351 MB/s at skylake serving a cached Maven artifact.
+
+          skylake is v3 + AES + CLMUL + ADX. AES-NI shipped in 2010, three years
+          before the AVX2/BMI2 that v3 already requires, so this excludes nothing
+          v3 did not; ADX (Broadwell, 2014) is the only real narrowing. Chosen
+          over haswell as a deliberately stable floor we do not want to revisit.
+
+          Do NOT "upgrade" this to x86-64-v4: the numbered levels never include
+          AES, so v4 measures identically to v3 (65 MB/s) while dropping all
+          non-AVX-512 hardware.
+        -->
+        <profile>
+            <id>x86-march-amd64</id>
+            <activation>
+                <os><arch>amd64</arch></os>
+            </activation>
+            <properties>
+                <native.march.args>,-march=skylake</native.march.args>
+            </properties>
+        </profile>
+        <profile>
+            <!-- Same, for JVMs reporting os.arch as x86_64 (macOS Intel). -->
+            <id>x86-march-x86_64</id>
+            <activation>
+                <os><arch>x86_64</arch></os>
+            </activation>
+            <properties>
+                <native.march.args>,-march=skylake</native.march.args>
+            </properties>
+        </profile>
         <profile>
             <id>linux-g1</id>
             <activation>

--- a/proxy/src/main/resources-filtered/application.properties
+++ b/proxy/src/main/resources-filtered/application.properties
@@ -11,7 +11,7 @@ quarkus.vertx.classpath-resolving=false
 quarkus.ssl.native=true
 quarkus.native.auto-service-loader-registration=false
 quarkus.native.additional-build-args=--initialize-at-run-time=dev.incusspawn.Environment,\
-  -O3,--gc=${proxy.native.gc},\
+  -O3,--gc=${proxy.native.gc}${native.march.args},\
   -H:-ParseRuntimeOptions,-H:-UseContainerSupport,-H:-JNIExportSymbols,\
   -R:MaxRAM=256m,-R:ActiveProcessorCount=4${svm.target.name.args},\
   --features=dev.incusspawn.graal.SyscallReachabilityFeature


### PR DESCRIPTION
Found while investigating the ~70 MB/s cached-artifact ceiling reported in #590. It is not an I/O problem — the native image was doing AES in software.

## The bug

GraalVM's default `-march=x86-64-v3` **does not include AES or CLMUL**. Without them the image cannot emit AES-NI/GHASH intrinsics, so TLS bulk encryption falls back to a software implementation. Every byte through this proxy is AES-GCM encrypted on both legs — once to the client on a cache hit, twice on a miss (decrypt from upstream, re-encrypt to the client) — so this dominates everything the proxy does: Maven artifacts, OCI blobs, npm tarballs, GitHub clones, API traffic.

## Measurements

Serving a cached 642 KB Maven artifact, same commit, same host, Oracle GraalVM 25.3, `-O3` + G1:

| `-march` | Throughput | Binary size | Note |
|---|---|---|---|
| `x86-64-v3` (default) | 65 MB/s | 89,984,680 | no AES/CLMUL |
| `x86-64-v4` | 65 MB/s | — | AVX-512 but still no AES — a trap |
| `haswell` | 349 MB/s | 89,984,680 | v3 + AES + CLMUL |
| **`skylake`** | **363 MB/s** | **89,984,680** | **+ ADX — this PR** |
| `skylake-avx512` | 363 MB/s | 90,508,968 | no gain, +524 KB, excludes Zen 1–3 |
| `native` | 383 MB/s | 90,377,896 | not portable |

**5.6× at byte-identical binary size.** For reference the same code on HotSpot does 257 MB/s — the native image was running at a quarter of JVM speed.

## What this costs in hardware support

`skylake` is `x86-64-v3` + AES + CLMUL + ADX, and the two halves are not equivalent:

- **AES and CLMUL cost no reach at all.** AES-NI shipped in 2010, three years *before* the AVX2/BMI2 that `x86-64-v3` already demands. Every CPU able to run the current binary already has them.
- **ADX genuinely narrows the baseline.** It arrives with Intel Broadwell (2014) and AMD Zen (2017), so Intel Haswell (2013–14) and AMD Excavator can run `x86-64-v3` code but *not* this build.

That narrowing is a deliberate choice, not a free lunch — it buys ~4% (349 → 363 MB/s) in exchange for dropping 2013–14 Intel hardware, taken as a stable floor rather than something to re-evaluate each release. **`haswell` is the escape hatch** if that trade is unwanted: it captures 349 of the 363 MB/s and excludes nothing `x86-64-v3` didn't already.

## Why arch-gated

`-march` values are architecture-specific and an x86 value passed to an aarch64 build is a **hard build failure**, which would break the `linux-aarch64` and `macos-14` jobs in `release.yml`. So it is set by arch-gated Maven profiles (`amd64` and `x86_64`, covering Linux and macOS Intel) and `native.march.args` stays empty on aarch64 — those builds are byte-for-byte unaffected.

## Rejected alternatives, both measured

- **`-H:RuntimeCheckedCPUFeatures`** looked like the ideal answer — runtime dispatch, no compatibility floor — but **does not cover the crypto intrinsics**. Adding `AES,CLMUL` to a v3 build left it at 65 MB/s; adding the AVX-512 set to a skylake build recovered only +0.9% of the 4.5% `native` holds. Its AMD64 default is already `AVX,AVX2`, and specifying the option *replaces* that default rather than extending it — an earlier run that omitted them measured below baseline. Details in the [comment below](https://github.com/Sanne/incus-spawn/pull/602#issuecomment-5452658656).
- **`x86-64-v4`** buys nothing and costs all non-AVX-512 hardware, including every AMD Zen 1–3 and Intel 12th–14th gen consumer chip. The numbered psABI levels never include AES.

## Not covered here

- **Apple Silicon / aarch64 is untested**, and `RuntimeCheckedCPUFeatures` defaults to *empty* on AArch64 — there is no runtime dispatch there at all. If GraalVM's aarch64 baseline omits the crypto extensions, those builds carry the same penalty with no fallback. One `bench/run.sh --load=maven` run on that hardware answers it.
- **The CLI is unchanged.** It has bulk-TLS paths too (`DownloadCache` tool tarballs, `SkillsCache`, the VM image download in `VmManager`), and the flag costs no binary size, so it is probably worth the same treatment — but I have not measured it, and the CLI's build is tuned for size.

## Testing

Reproduce with `bench/run.sh --load=maven` (from #600). Verified the gated build emits `target machine: skylake` on amd64 and that `native.march.args` resolves empty otherwise.

> Note: the first commit's message (`7810bd4`) contains an earlier, incorrect claim that `skylake` excludes no CPU that `x86-64-v3` didn't. That is corrected in `a6f7282` and in this description; prefer this text if squash-merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013CZ7v6giZGfaNaE3CV8gfN