### PR TITLE
Switch to -march=haswell, and correct figures measured through a saturated generator

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,13 +36,12 @@ Three Maven modules under a parent POM:
 
 - **`common`** (`incus-spawn-common`): shared code — Incus client, proxy config, image/tool definitions, configuration loading. Not a Quarkus app; uses the Jandex Maven plugin to produce a `META-INF/jandex.idx` so Quarkus discovers its CDI beans and `@RegisterForReflection` annotations from dependent modules.
 - **`cli`** (`incus-spawn`): the main CLI/TUI binary (`isx`). Depends on common. Native image: serial GC, `-Os` (size-optimized), `-H:-AllowVMInternalThreads`.
-- **`proxy`** (`incus-spawn-proxy`): the standalone MITM proxy binary (`isx-proxy`). Depends on common. Native image: G1 GC, `-O3` (throughput-optimized, enables ML-inferred PGO), and on x86_64 `-march=skylake`.
+- **`proxy`** (`incus-spawn-proxy`): the standalone MITM proxy binary (`isx-proxy`). Depends on common. Native image: G1 GC, `-O3` (throughput-optimized, enables ML-inferred PGO), and on x86_64 `-march=haswell`.
   The `-march` value is set by arch-gated Maven profiles in `proxy/pom.xml` (empty on aarch64, where an x86 `-march` would fail the build).
   GraalVM's default `-march=x86-64-v3` omits AES and CLMUL, so the image cannot use AES-NI/GHASH intrinsics and TLS falls back to software AES —
-  measured 65 MB/s vs 363 MB/s serving a cached Maven artifact. AES/CLMUL cost no reach (AES-NI predates v3 by three years); ADX does move the
-  floor to Broadwell (2014) / Zen (2017), which is accepted deliberately. Do not "upgrade" this to `x86-64-v4`: the numbered levels never include AES,
-  so v4 measures identically to v3 while dropping non-AVX-512 hardware.
-
+  measured 73 MB/s vs 960 MB/s serving a cached Maven artifact (~13x). `haswell` costs no hardware support: AES-NI predates the v3 baseline by three
+  years. `skylake` (+ADX) measures indistinguishably, so its narrowing is not worth taking. Do not "upgrade" this to `x86-64-v4`: the numbered levels
+  never include AES, so v4 measures identically to v3 while dropping non-AVX-512 hardware.
 Both `cli` and `proxy` are independent Quarkus applications that produce separate native binaries. When `isx-proxy` is not installed, `isx proxy start` falls back to running the proxy inline within the CLI process.
 
 ## Architecture

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -38,7 +38,7 @@ Three Maven modules under a parent POM:
 
 - **`common`** (`incus-spawn-common`): shared code — Incus client, proxy config, image/tool definitions, configuration loading. Not a Quarkus app; uses the Jandex Maven plugin to produce a bean index so Quarkus discovers its CDI beans from dependent modules.
 - **`cli`** (`incus-spawn`): the main CLI/TUI binary (`isx`). Depends on common. Native image: serial GC, `-Os` (size-optimized).
-- **`proxy`** (`incus-spawn-proxy`): the standalone MITM proxy binary (`isx-proxy`). Depends on common. Native image: G1 GC, `-O3` (throughput-optimized), and on x86_64 `-march=skylake` — see "Native image CPU baseline" below. When `isx-proxy` is not installed, `isx proxy start` falls back to running the proxy inline within the CLI process.
+- **`proxy`** (`incus-spawn-proxy`): the standalone MITM proxy binary (`isx-proxy`). Depends on common. Native image: G1 GC, `-O3` (throughput-optimized), and on x86_64 `-march=haswell` — see "Native image CPU baseline" below. When `isx-proxy` is not installed, `isx proxy start` falls back to running the proxy inline within the CLI process.
 
 ## Architecture
 
@@ -495,7 +495,7 @@ Host repos may use SSH URLs (`git@github.com:org/repo.git`) while container repo
 
 ### Native image CPU baseline
 
-The proxy is built with `-march=skylake` on x86_64, set by arch-gated Maven profiles in
+The proxy is built with `-march=haswell` on x86_64, set by arch-gated Maven profiles in
 `proxy/pom.xml` so aarch64 builds (Linux arm64, Apple Silicon) pass no `-march` at all —
 an x86 value there is a hard build failure.
 
@@ -503,41 +503,39 @@ GraalVM's default is `-march=x86-64-v3`, and the numbered psABI levels **do not 
 or CLMUL**. Without those the image cannot emit AES-NI/GHASH intrinsics, so TLS bulk
 encryption runs as software AES. Every byte through this proxy is AES-GCM encrypted on both
 legs — once to the client on a cache hit, twice on a miss (decrypt from upstream, re-encrypt
-to the client) — so that fallback dominates. Serving a cached 642 KB Maven artifact,
-measured on one host, same commit, Oracle GraalVM 25.3:
+to the client) — so that fallback dominates. Serving a cached 642 KB Maven artifact, measured
+with `bench/run.sh --load=maven`, same commit and host, Oracle GraalVM 25.3:
 
 | `-march` | Throughput | Note |
 |---|---|---|
-| `x86-64-v3` (GraalVM default) | 65 MB/s | no AES/CLMUL |
-| `x86-64-v4` | 65 MB/s | AVX-512 but still no AES — a trap |
-| `haswell` | 349 MB/s | v3 + AES + CLMUL |
-| **`skylake`** | **363 MB/s** | + ADX; what we ship |
-| `skylake-avx512` | 363 MB/s | no gain, +524 KB, excludes Zen 1–3 |
-| `native` | 383 MB/s | not portable |
+| `x86-64-v3` (GraalVM default) | 73 MB/s | no AES/CLMUL |
+| `x86-64-v4` | 73 MB/s | AVX-512 but still no AES — a trap |
+| **`haswell`** | **960 MB/s** | v3 + AES + CLMUL; what we ship |
+| `skylake` | 950 MB/s | + ADX; indistinguishable from haswell |
+| `native` | 1067 MB/s | not portable |
 
-`skylake` is `x86-64-v3` + AES + CLMUL + ADX, and the two halves differ in what they cost:
+That is a **~13x** difference, and `haswell` costs no hardware support whatsoever: AES-NI
+shipped in 2010, three years *before* the AVX2/BMI2 that `x86-64-v3` already demands, so
+every CPU able to run a v3 build already has it. Binary size is unchanged.
 
-- **AES and CLMUL cost no reach at all.** AES-NI shipped in 2010, three years *before* the
-  AVX2/BMI2 that `x86-64-v3` already demands, so every CPU able to run the previous binary
-  already has them.
-- **ADX does narrow the baseline.** It arrives with Intel Broadwell (2014) and AMD Zen
-  (2017), so Intel Haswell (2013-14) and AMD Excavator can run `x86-64-v3` code but not
-  this build.
-
-That narrowing is accepted deliberately, as a stable floor rather than something to
-re-evaluate each release. `haswell` would avoid it entirely and measures ~4% slower
-(349 MB/s vs 363 MB/s). Binary size is unchanged either way.
+`skylake` (haswell + ADX) was measured over three interleaved rounds and came out
+indistinguishable — 1530 vs 1514 req/s, with the ordering reversing between rounds. ADX buys
+nothing on this path, so there is no reason to accept its narrowing (it would drop Intel
+Haswell 2013-14 and AMD Excavator, which run v3 code).
 
 Two things that look like they should help and do not, both measured:
 
 - **`-H:RuntimeCheckedCPUFeatures` does not cover the crypto intrinsics.** Adding
-  `AES,CLMUL` to a v3 build left throughput at 65 MB/s, and adding `AVX512_VAES` to a
-  skylake build changed nothing. The AES-GCM intrinsic is selected at build time from
-  `-march`; runtime dispatch applies to a narrower set of operations. The ~5% that `native`
-  holds over `skylake` therefore cannot be captured portably.
+  `AES,CLMUL` to a v3 build left throughput unchanged, and adding the AVX-512 set to a
+  build with AES recovered only ~1 of the ~11 points `native` holds. The AES-GCM intrinsic
+  is selected at build time from `-march`; runtime dispatch applies to a narrower set of
+  operations, and its AMD64 default is already `AVX,AVX2`. Note the option *replaces* that
+  default rather than extending it, so anything added must re-state `AVX,AVX2`.
 - **Raising to `x86-64-v4`** buys nothing and costs all non-AVX-512 hardware.
 
-Reproduce with `bench/run.sh --load=maven`.
+Reproduce with `bench/run.sh --load=maven`. Use that harness rather than a shell loop of
+`curl`: process-spawn overhead caps such a loop around 550 req/s, which silently pins every
+build faster than v3 to the same wrong number and hides the differences between them.
 
 ## Testing
 

--- a/docs/PERFORMANCE-NOTES.md
+++ b/docs/PERFORMANCE-NOTES.md
@@ -14,7 +14,7 @@ one as if it were the other is the easiest way to publish something false.
 |---|---|---|
 | `--load=constant` | `/health`, plain HTTP | 5,000 req/s tripwire; ~3% of that endpoint's capacity |
 | `--load=saturate` | `/health`, plain HTTP | ~166,000 req/s — **HTTP server core only** |
-| `--load=maven` | intercepted HTTPS, TLS + cached 642 KB artifact | **~116 req/s, ~73 MB/s** |
+| `--load=maven` | intercepted HTTPS, TLS + cached 642 KB artifact | **~1,530 req/s, ~960 MB/s** |
 
 **`--load=maven` is the one that describes the product.** It terminates TLS with a minted
 per-domain cert, routes by SNI, classifies the domain, hits the artifact cache and streams a
@@ -28,8 +28,8 @@ native image, `-O3` + G1 (the release configuration).
 
 | What | Figure | Conditions |
 |---|---|---|
-| Cached artifact serving | **~73 MB/s** (116 req/s × 642 KB) | 8–64 concurrent, 100% 2xx |
-| Cached artifact latency | **~11 ms** single client | 642 KB over TLS, cache hit |
+| Cached artifact serving | **~960 MB/s** (1,530 req/s × 642 KB) | 8–64 concurrent, 100% 2xx |
+| Cached artifact latency | **~2.8 ms** single client | 642 KB over TLS, cache hit (2.0 ms of it handshake) |
 | Cold artifact (upstream) | **~177 ms** | first fetch, network-bound |
 | HTTP server core | ~166,000 req/s, 90 µs p50 | `/health`, no TLS, no body |
 | Proxy idle memory | **~82 MB RSS** | after 2s settle |
@@ -39,36 +39,37 @@ native image, `-O3` + G1 (the release configuration).
 | Proxy binary | **85.8 MB** | `-O3`, G1 |
 
 The cache-hit story is the strongest honest claim available today: **a 642 KB dependency
-served in ~11 ms from local cache instead of ~177 ms from Maven Central** — a 16× latency
-improvement on repeat builds, which is what agent containers do constantly.
+served in ~2.8 ms from local cache instead of ~177 ms from Maven Central** — a ~60× latency
+improvement on repeat builds, which is what agent containers do constantly. Note ~2.0 ms of
+that 2.8 ms is the TLS handshake, so a client reusing its connection does better still.
 
 The proxy is also deliberately confined to **2 Vert.x event loops**
 (`quarkus.vertx.event-loops-pool-size=2`, `-R:ActiveProcessorCount=4`), so all of the above
 is achieved on two cores of a 32-core box. Efficiency-per-core is the framing, not raw
 throughput.
 
-## Known bottleneck: cached artifact throughput caps at ~70 MB/s
+## Resolved: the ~70 MB/s ceiling was software AES
 
-Confirmed three independent ways, all flat across concurrency:
+Earlier notes recorded cached artifact serving as capping at ~70 MB/s regardless of
+concurrency, and guessed at `serveCachedFile`'s disk streaming. That was wrong. The native
+image was built with GraalVM's default `-march=x86-64-v3`, which excludes AES and CLMUL, so
+TLS bulk encryption ran as software AES. Building with `-march=haswell` took the same code
+from 73 MB/s to 960 MB/s — see DESIGN.md "Native image CPU baseline".
 
-- single `curl`: 58 MB/s
-- parallel `curl` (OpenSSL), 8 and 32 concurrent: 65 MB/s — **identical at both**
-- Hyperfoil, 8/32/64 concurrent: 73 / 72 / 72 MB/s
-
-Throughput stays pinned while latency scales linearly (p50 60 ms at 8 concurrent → 545 ms at
-64), which is the signature of a hard serialisation point. For AES-GCM on hardware with
-AES-NI this is roughly an order of magnitude low, and the load generator is ruled out (curl
-with OpenSSL hits the same wall). The suspect is how `serveCachedFile` streams from disk.
-
-Practical impact: a build pulling 500 MB of cached dependencies spends ~7 s minimum on proxy
-egress. Worth its own issue; not a #590 concern.
+A profile of the fixed build shows nothing left to chase on this path: the single event loop
+is idle more than half the time while serving over 1 GB/s, and its working time is socket
+writes plus TLS encryption, both irreducible. The blocking pool is idle during serving
+entirely (its only samples are one-time keystore construction at startup).
 
 ## GraalVM 25.2 → 25.3 (issue #590)
 
 Same commit, same host, both toolchains from the release builder images.
 
 **On the real path (`--load=maven`): no measurable difference.** Four runs with the order
-counterbalanced, 100% 2xx throughout:
+counterbalanced, 100% 2xx throughout. Note these were taken *before* the `-march` fix, so
+software AES was saturating the event loop throughout — which is itself why there was nothing
+for a better inliner to improve. Worth re-running on a build where crypto is not the
+bottleneck:
 
 | Rung | 25.2 | 25.2b | 25.3 | 25.3b |
 |---|---|---|---|---|
@@ -108,6 +109,11 @@ perceive 216 µs, and 41 MB is a real download and disk cost for users.
   only interleaved A/B within one session is trustworthy.
 - **Single-run RSS and tail latency are noise.** Anything under ~5% needs repetition with
   the run order counterbalanced.
+- **Do not measure with a shell loop of `curl`.** One process spawn per request caps such a
+  loop near 550 req/s. Against a slow server it agrees with a real load generator, which
+  makes it look trustworthy; against a fast one it silently pins every build to the same
+  number and hides the differences between them. Every figure on this page that was once
+  wrong was wrong for this reason. Use `bench/run.sh`.
 - **Closed-loop latency is a function of concurrency.** p50 at 64 concurrent and p50 at 8
   concurrent describe the same server at the same throughput. Quote the pair, never the
   flattering half.

--- a/proxy/pom.xml
+++ b/proxy/pom.xml
@@ -159,19 +159,20 @@
           GraalVM's default -march=x86-64-v3 does NOT include AES or CLMUL, so the
           native image cannot use AES-NI/GHASH intrinsics and TLS bulk encryption
           falls back to software AES. Since every byte through this proxy is
-          AES-GCM encrypted on both legs, that costs ~5x: measured 65 MB/s at v3
-          vs 363 MB/s at skylake serving a cached Maven artifact.
+          AES-GCM encrypted on both legs, that costs ~13x: measured 73 MB/s at v3
+          vs 960 MB/s at haswell serving a cached Maven artifact.
 
-          skylake is v3 + AES + CLMUL + ADX. The AES and CLMUL half costs no reach
-          at all: AES-NI shipped in 2010, three years before the AVX2/BMI2 that v3
-          already requires. ADX does narrow the baseline — it arrives with Broadwell
-          (2014) and AMD Zen (2017), so Intel Haswell (2013-14) and AMD Excavator
-          run v3 code but not this. That narrowing is accepted deliberately, as a
-          stable floor we do not want to revisit; haswell would avoid it and
-          measures ~4% slower (349 MB/s).
+          haswell is v3 + AES + CLMUL, and costs no reach at all: AES-NI shipped in
+          2010, three years before the AVX2/BMI2 that v3 already requires, so every
+          CPU able to run a v3 build already has it.
+
+          skylake (haswell + ADX) was measured and is indistinguishable — 1530 vs
+          1514 req/s over three interleaved rounds, with the ordering reversing
+          between rounds. ADX buys nothing here, so there is no reason to pay its
+          narrowing (it would drop Intel Haswell 2013-14 and AMD Excavator).
 
           Do NOT "upgrade" this to x86-64-v4: the numbered levels never include
-          AES, so v4 measures identically to v3 (65 MB/s) while dropping all
+          AES, so v4 measures identically to v3 (73 MB/s) while dropping all
           non-AVX-512 hardware.
         -->
         <profile>
@@ -180,7 +181,7 @@
                 <os><arch>amd64</arch></os>
             </activation>
             <properties>
-                <native.march.args>,-march=skylake</native.march.args>
+                <native.march.args>,-march=haswell</native.march.args>
             </properties>
         </profile>
         <profile>
@@ -190,7 +191,7 @@
                 <os><arch>x86_64</arch></os>
             </activation>
             <properties>
-                <native.march.args>,-march=skylake</native.march.args>
+                <native.march.args>,-march=haswell</native.march.args>
             </properties>
         </profile>
         <profile>


### PR DESCRIPTION
Follow-up to #602, which shipped correct *direction* with wrong *numbers* — and, because of those numbers, the wrong `-march`.

## What was wrong

#602's measurements came from a shell loop of `curl`, one process spawn per request. That caps the generator near 550 req/s.

The trap is that it looked validated: against the broken `x86-64-v3` build the proxy really was the bottleneck, so curl agreed with Hyperfoil (65 vs 73 MB/s) and seemed trustworthy. But every build with *working* AES was fast enough to hit the generator's ceiling instead of its own, so they all piled up around the same number and their differences vanished.

## Corrected numbers

Re-measured with `bench/run.sh --load=maven` (merged in #600), same commit and host, serving a cached 642 KB Maven artifact:

| `-march` | #602 (curl) | corrected (Hyperfoil) |
|---|---|---|
| `x86-64-v3` | 65 MB/s | **73 MB/s** |
| `haswell` | 349 MB/s | **960 MB/s** |
| `skylake` | 363 MB/s | **950 MB/s** |
| `native` | 383 MB/s | **1067 MB/s** |

The fix is worth **~13×**, not the 5.6× documented. The v3 baseline was the only figure that was right.

## Why this changes the choice to `haswell`

`skylake` was chosen because it measured ~4% faster than `haswell`. Through the real harness they are **indistinguishable** — 1530 vs 1514 req/s across three interleaved rounds, with the ordering *reversing* between rounds:

| | round 1 | round 2 | round 3 | mean |
|---|---|---|---|---|
| `haswell` | 1540.6 | 1533.0 | 1516.7 | 1530 |
| `skylake` | 1507.7 | 1515.7 | 1518.8 | 1514 |

ADX buys nothing on this path, so there is no reason to accept its narrowing. `skylake` would drop Intel Haswell (2013–14) and AMD Excavator; `haswell` excludes **nothing** an `x86-64-v3` build could run, because AES-NI shipped in 2010, three years before the AVX2/BMI2 that v3 already demands.

So `haswell` is strictly better here: same throughput, wider hardware support, same binary size.

## docs/PERFORMANCE-NOTES.md

This had the worst of it, and it is the file explicitly written as raw material for a landing page:

- Headline cached-artifact figure understated the proxy by ~13× (`~73 MB/s` → `~960 MB/s`).
- Still carried "**Known bottleneck:** cached artifact throughput caps at ~70 MB/s" as an open mystery, when that *was* this bug. Replaced with a resolved section.
- Single-client cached latency corrected from 11 ms to **2.8 ms** (2.0 ms of which is the TLS handshake), making the cache-vs-upstream story ~60× rather than 16×.
- Flags that the 25.2-vs-25.3 comparison in #590 was run before this fix, so software AES was saturating the event loop throughout — which is itself why there was nothing for a better inliner to improve. Worth re-running; I would not expect the null result to change.

## Methodology note

Both DESIGN.md and the notes now record why not to measure with a `curl` loop, since the failure mode is specifically that it looks correct when validated against a slow server. Every figure on that page that was ever wrong was wrong for this reason.

## Testing

`./mvnw -pl proxy -am package -Dnative` emits `target machine: haswell`; arch gating unchanged, so aarch64 still passes no `-march`. Numbers above are three interleaved rounds per variant via `bench/run.sh --load=maven`, 100% 2xx throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013CZ7v6giZGfaNaE3CV8gfN