### PR TITLE
Build the CLI with -march=haswell on x86_64 too

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,9 @@ mvn package -Dnative -DskipTests           # GraalVM native binaries (isx + isx-
 Three Maven modules under a parent POM:
 
 - **`common`** (`incus-spawn-common`): shared code — Incus client, proxy config, image/tool definitions, configuration loading. Not a Quarkus app; uses the Jandex Maven plugin to produce a `META-INF/jandex.idx` so Quarkus discovers its CDI beans and `@RegisterForReflection` annotations from dependent modules.
-- **`cli`** (`incus-spawn`): the main CLI/TUI binary (`isx`). Depends on common. Native image: serial GC, `-Os` (size-optimized), `-H:-AllowVMInternalThreads`.
+- **`cli`** (`incus-spawn`): the main CLI/TUI binary (`isx`). Depends on common. Native image: serial GC, `-Os` (size-optimized), `-H:-AllowVMInternalThreads`,
+  and on x86_64 `-march=haswell` (arch-gated in `cli/pom.xml`, same as the proxy). It downloads tool tarballs and VM images over HTTPS, and the default
+  `x86-64-v3` omits AES/CLMUL: 79 MB/s vs ~3100 MB/s for AES-256-GCM. Binary size is byte-identical and startup ~11% faster, so it costs nothing here.
 - **`proxy`** (`incus-spawn-proxy`): the standalone MITM proxy binary (`isx-proxy`). Depends on common. Native image: G1 GC, `-O3` (throughput-optimized, enables ML-inferred PGO), and on x86_64 `-march=haswell`.
   The `-march` value is set by arch-gated Maven profiles in `proxy/pom.xml` (empty on aarch64, where an x86 `-march` would fail the build).
   GraalVM's default `-march=x86-64-v3` omits AES and CLMUL, so the image cannot use AES-NI/GHASH intrinsics and TLS falls back to software AES —

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -495,9 +495,9 @@ Host repos may use SSH URLs (`git@github.com:org/repo.git`) while container repo
 
 ### Native image CPU baseline
 
-The proxy is built with `-march=haswell` on x86_64, set by arch-gated Maven profiles in
-`proxy/pom.xml` so aarch64 builds (Linux arm64, Apple Silicon) pass no `-march` at all —
-an x86 value there is a hard build failure.
+Both binaries are built with `-march=haswell` on x86_64, set by arch-gated Maven profiles in
+`proxy/pom.xml` and `cli/pom.xml` so aarch64 builds (Linux arm64, Apple Silicon) pass no
+`-march` at all — an x86 value there is a hard build failure.
 
 GraalVM's default is `-march=x86-64-v3`, and the numbered psABI levels **do not include AES
 or CLMUL**. Without those the image cannot emit AES-NI/GHASH intrinsics, so TLS bulk
@@ -532,6 +532,21 @@ Two things that look like they should help and do not, both measured:
   operations, and its AMD64 default is already `AVX,AVX2`. Note the option *replaces* that
   default rather than extending it, so anything added must re-state `AVX,AVX2`.
 - **Raising to `x86-64-v4`** buys nothing and costs all non-AVX-512 hardware.
+
+### Why the CLI takes the same flag
+
+The CLI downloads tool tarballs and VM images over HTTPS (`DownloadCache`, `SkillsCache`,
+`VmManager`), all through the JDK's `HttpClient`, so it pays the same software-AES cost.
+Measured directly on AES-256-GCM in a native image from this toolchain: **79 MB/s at
+`x86-64-v3` vs ~3100 MB/s at `haswell`** — a 39x difference. At 79 MB/s a 384 MB tool tarball
+costs ~4.9s of CPU on crypto alone, so any link faster than ~630 Mbit/s makes the CLI
+crypto-bound rather than network-bound.
+
+The CLI's build is tuned for size and startup (`-Os`, serial GC), which is why `-O3` was
+rejected there at +131% size. `-march=haswell` costs neither: the binary is **byte-identical**
+(32,115,704 B either way) and startup is ~11% *faster* (median 3489 vs 3924 us over three
+interleaved rounds of 40 runs). The startup gain is unexplained; `haswell` adds CLMUL over
+`x86-64-v3` alongside AES, which backs the CRC32 intrinsic, but that is a hypothesis.
 
 Reproduce with `bench/run.sh --load=maven`. Use that harness rather than a shell loop of
 `curl`: process-spawn overhead caps such a loop around 550 req/s, which silently pins every

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -11,6 +11,11 @@
     <name>incus-spawn</name>
     <description>CLI tool for managing isolated Incus development environments</description>
 
+    <properties>
+<!-- Empty by default: -march values are architecture-specific, and passing an x86 one to an aarch64 build fails. Set only by the x86_64 profiles below. -->
+        <native.march.args/>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>dev.incusspawn</groupId>
@@ -162,6 +167,34 @@
     </build>
 
     <profiles>
+        <!--
+          GraalVM's default -march=x86-64-v3 omits AES and CLMUL, so the image cannot
+          use AES-NI/GHASH intrinsics: measured 79 MB/s vs ~3100 MB/s for AES-256-GCM
+          in a native image built by the same toolchain. The CLI downloads tool
+          tarballs and VM images over HTTPS (DownloadCache, SkillsCache, VmManager),
+          so that is a real cost on any link faster than ~630 Mbit/s. Binary size and
+          startup are unaffected, which is why this is worth taking on a build
+          otherwise tuned for size (-Os). See DESIGN.md "Native image CPU baseline".
+        -->
+        <profile>
+            <id>x86-march-amd64</id>
+            <activation>
+                <os><arch>amd64</arch></os>
+            </activation>
+            <properties>
+                <native.march.args>,-march=haswell</native.march.args>
+            </properties>
+        </profile>
+        <profile>
+            <!-- Same, for JVMs reporting os.arch as x86_64 (macOS Intel). -->
+            <id>x86-march-x86_64</id>
+            <activation>
+                <os><arch>x86_64</arch></os>
+            </activation>
+            <properties>
+                <native.march.args>,-march=haswell</native.march.args>
+            </properties>
+        </profile>
         <profile>
             <id>macos-native</id>
             <activation>
@@ -170,7 +203,7 @@
                 </property>
             </activation>
             <properties>
-                <quarkus.native.additional-build-args>--initialize-at-run-time=dev.incusspawn.Environment\,dev.incusspawn.RuntimeServices\,dev.tamboui.tui\,dev.tamboui.toolkit\,dev.tamboui.terminal\,dev.tamboui.capability\,dev.tamboui.error\,dev.tamboui.widget\,dev.tamboui.backend.panama,-H:+UnlockExperimentalVMOptions,-H:+SharedArenaSupport,--enable-native-access=ALL-UNNAMED,-Os,--gc=serial,--initialize-at-build-time=dev.tamboui.backend.panama.unix.PlatformConstants,-H:-ParseRuntimeOptions,-H:-UseContainerSupport,-H:-JNIExportSymbols,-H:-AllowVMInternalThreads,-R:MaxRAM=128m,-R:ActiveProcessorCount=2,-H:NativeLinkerOption=-sectcreate,-H:NativeLinkerOption=__TEXT,-H:NativeLinkerOption=__info_plist,-H:NativeLinkerOption=${macos.info.plist},--features=dev.incusspawn.graal.SyscallReachabilityFeature</quarkus.native.additional-build-args>
+                <quarkus.native.additional-build-args>--initialize-at-run-time=dev.incusspawn.Environment\,dev.incusspawn.RuntimeServices\,dev.tamboui.tui\,dev.tamboui.toolkit\,dev.tamboui.terminal\,dev.tamboui.capability\,dev.tamboui.error\,dev.tamboui.widget\,dev.tamboui.backend.panama,-H:+UnlockExperimentalVMOptions,-H:+SharedArenaSupport,--enable-native-access=ALL-UNNAMED,-Os,--gc=serial${native.march.args},--initialize-at-build-time=dev.tamboui.backend.panama.unix.PlatformConstants,-H:-ParseRuntimeOptions,-H:-UseContainerSupport,-H:-JNIExportSymbols,-H:-AllowVMInternalThreads,-R:MaxRAM=128m,-R:ActiveProcessorCount=2,-H:NativeLinkerOption=-sectcreate,-H:NativeLinkerOption=__TEXT,-H:NativeLinkerOption=__info_plist,-H:NativeLinkerOption=${macos.info.plist},--features=dev.incusspawn.graal.SyscallReachabilityFeature</quarkus.native.additional-build-args>
             </properties>
         </profile>
     </profiles>

--- a/cli/src/main/resources-filtered/application.properties
+++ b/cli/src/main/resources-filtered/application.properties
@@ -11,7 +11,7 @@ quarkus.native.auto-service-loader-registration=false
 quarkus.native.resources.includes=images/*.yaml,tools/*.yaml,git-remote-isx,dev/tamboui/tui/bindings/*.properties
 quarkus.native.additional-build-args=--initialize-at-run-time=dev.incusspawn.Environment\\,dev.incusspawn.RuntimeServices\\,dev.tamboui.tui\\,dev.tamboui.toolkit\\,dev.tamboui.terminal\\,dev.tamboui.capability\\,dev.tamboui.error\\,dev.tamboui.widget\\,dev.tamboui.backend.panama,\
   -H:+UnlockExperimentalVMOptions,-H:+SharedArenaSupport,--enable-native-access=ALL-UNNAMED,\
-  -Os,--gc=serial,\
+  -Os,--gc=serial${native.march.args},\
   --initialize-at-build-time=dev.tamboui.backend.panama.unix.PlatformConstants,\
   -H:-ParseRuntimeOptions,-H:-UseContainerSupport,-H:-JNIExportSymbols,-H:-AllowVMInternalThreads,\
   -R:MaxRAM=512m,-R:ActiveProcessorCount=2,\


### PR DESCRIPTION
Completes the `-march` work from #602/#606 by applying the same fix to the CLI. It costs nothing on either axis the CLI is tuned for, and measurably helps both HTTPS downloads and startup.

## The CLI pays the same cost

`DownloadCache`, `SkillsCache` and `VmManager` download tool tarballs and VM images over HTTPS through the JDK's `HttpClient`. GraalVM's default `-march=x86-64-v3` omits AES and CLMUL, so the image cannot emit AES-NI/GHASH intrinsics and TLS bulk encryption runs as software AES.

Measured directly on AES-256-GCM in a native image built by this toolchain (isolating the mechanism, no network in the path):

| build | AES-256-GCM |
|---|---|
| `x86-64-v3` | **79 MB/s** |
| `haswell` | **~3,100 MB/s** |

**39×**, reproducible across rounds. At 79 MB/s a 384 MB tool tarball costs ~4.9 s of CPU on crypto alone — so on any link faster than ~630 Mbit/s the CLI is crypto-bound, not network-bound.

## It costs the CLI nothing

The CLI's build is tuned for size and startup (`-Os`, serial GC) — which is why `-O3` was rejected at +131% size. `-march=haswell` is free on both, measured on the built binary:

| | `x86-64-v3` | `haswell` |
|---|---|---|
| Binary size | 32,115,704 B | **32,115,704 B** — byte-identical |
| Startup median | 3,924 µs | **3,489 µs** — ~11% faster |

Startup measured over three interleaved rounds of 40 runs each, so drift hits both variants equally:

| | round 1 | round 2 | round 3 |
|---|---|---|---|
| `x86-64-v3` | 3,912 | 3,944 | 3,917 µs |
| `haswell` | 3,505 | 3,488 | 3,474 µs |

**The startup gain is unexplained.** AES shouldn't affect startup; `haswell` also adds CLMUL over `x86-64-v3`, which backs the CRC32 intrinsic used in zip/jar handling. That is a hypothesis, not a verified cause — I am reporting it as measured, not as understood.

## Hardware support is unchanged

`haswell` is `x86-64-v3` + AES + CLMUL. AES-NI shipped in 2010, three years *before* the AVX2/BMI2 that `x86-64-v3` already demands, so this excludes no CPU that could run the current binary. Same reasoning as #606.

Gated by the same arch profiles as `proxy/pom.xml`: aarch64 builds pass no `-march` and are unchanged. The macOS profile duplicates the whole argument list and gets the same insertion; on Apple Silicon `os.arch` is `aarch64`, so neither profile activates and the value stays empty.

## One structural change

`cli/src/main/resources/application.properties` moves to `resources-filtered/` so Maven can substitute `${native.march.args}`, matching how the proxy module already works. The module already had `resources-filtered` wired up. The file contained no `${...}` tokens beforehand, so enabling filtering cannot expand anything unintended.

## Testing

`./mvnw -pl cli -am package -Dnative` emits `target machine: haswell` with `-Os` and serial GC preserved; both binaries run `--help` correctly.

Two test failures on my machine (`GhSetupTest`, `TemplateBuildIT`) reproduce identically on clean `main` — the first because this box has a real `gh` token, the second because it needs a `test-tpl-minimal` image that doesn't exist locally. Neither is related to this change; CI is green on both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013CZ7v6giZGfaNaE3CV8gfN