### PR TITLE
Move skills to ~/.agents/skills with Claude Code symlink

### DIFF
--- a/cli/src/main/java/dev/incusspawn/command/BuildCommand.java
+++ b/cli/src/main/java/dev/incusspawn/command/BuildCommand.java
@@ -2133,11 +2133,14 @@ public class BuildCommand extends BaseCommand {
         incus.deviceRemove(container, DNF_CACHE_DEVICE);
     }
 
-    /** Global skills directory for Claude Code inside the container. */
-    private static final String SKILLS_DIR = "/home/agentuser/.claude/skills";
+    /** Agent home directory inside the container, shared across agents. */
+    private static final String AGENTS_DIR = "/home/agentuser/.agents";
+
+    /** Global skills directory inside the container, shared across agents. */
+    private static final String SKILLS_DIR = AGENTS_DIR + "/skills";
 
     /**
-     * Install Claude Code skills declared in the image definition.
+     * Install agent skills declared in the image definition.
      * Fetches SKILL.md files on the host and writes them directly into the container.
      * Deduplicates against skills already declared by ancestor images.
      */
@@ -2183,9 +2186,8 @@ public class BuildCommand extends BaseCommand {
                 throw new BuildFailedException();
             }
         }
-
-        // Fix ownership so agentuser owns the skills directory
-        container.exec("chown", "-R", "agentuser:agentuser", SKILLS_DIR);
+        // Fix ownership so agentuser owns the agents / skills directories
+        container.exec("chown", "-R", "agentuser:agentuser", AGENTS_DIR);
     }
 
     /** A fetched skill ready to be written into the container. */

--- a/common/src/main/java/dev/incusspawn/tool/ClaudeSetup.java
+++ b/common/src/main/java/dev/incusspawn/tool/ClaudeSetup.java
@@ -116,9 +116,15 @@ public class ClaudeSetup implements ToolSetup {
     @Override
     public void install(Container c, java.util.Map<String, String> resolvedParams) {
         installBinary(c);
+        linkSkillsDir(c);
         var claude = SpawnConfig.load().getClaude();
         syncGcloudStub(c, claude);
         configureSettings(c, claude, resolvedParams);
+    }
+
+    private void linkSkillsDir(Container c) {
+        c.sh("mkdir -p /home/agentuser/.agents/skills /home/agentuser/.claude"
+                + " && ln -sfn /home/agentuser/.agents/skills /home/agentuser/.claude/skills");
     }
 
     @Override


### PR DESCRIPTION
Since we are adding more and more different tools that can leverage the skills ... 
Skills are now installed to the agent-agnostic ~/.agents/skills/ directory (which most other agents seem to honour) so they're discoverable by any agent, not just Claude Code. When the `claude` tool is installed, a symlink `~/.claude/skills -> ~/.agents/skills` is created so Claude Code still finds them.