### PR TITLE
Fix btrfs pool creation speed and let CI exercise real isx init flow

### DIFF
--- a/.github/scripts/test-cow-branching.sh
+++ b/.github/scripts/test-cow-branching.sh
@@ -1,0 +1,182 @@
+#!/bin/bash
+# Integration test: branching a template must not duplicate its disk footprint.
+#
+# Collects multiple disk metrics before and after branching to distinguish
+# real data duplication from btrfs shared-block accounting:
+#
+#   - du -sm:          filesystem-reported size (on btrfs, counts shared/
+#                      referenced blocks per subvolume — can overcount)
+#   - pool space.used: actual bytes consumed on the backing device (the
+#                      ground truth for "did we use more disk?")
+#   - btrfs qgroup:    per-subvolume referenced (rfer) vs exclusive (excl)
+#                      bytes, when available
+#
+# Requires:
+#   - tpl-minimal already built
+#   - isx and incus on PATH
+#   - sudo access (for du and btrfs qgroup)
+#
+# Usage:
+#   .github/scripts/test-cow-branching.sh
+#   sg incus-admin -c "bash .github/scripts/test-cow-branching.sh"
+
+set -euo pipefail
+
+TESTS=0
+PASS=0
+FAIL=0
+
+assert_lt() {
+    local desc="$1" actual="$2" threshold="$3"
+    TESTS=$((TESTS + 1))
+    if [ "$actual" -lt "$threshold" ]; then
+        printf '  \033[32mPASS\033[0m  %s  (actual: %s)\n' "$desc" "$actual"
+        PASS=$((PASS + 1))
+    else
+        printf '  \033[31mFAIL\033[0m  %s  (actual: %s, threshold: %s)\n' \
+            "$desc" "$actual" "$threshold"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+to_mb() { echo $(( $1 / 1024 / 1024 )); }
+
+# Find which pool holds tpl-minimal.
+find_template_pool() {
+    for pool in $(incus storage list -f csv | cut -d, -f1); do
+        if incus storage volume list "$pool" -f csv 2>/dev/null \
+                | grep -q "^container,tpl-minimal,"; then
+            echo "$pool"
+            return
+        fi
+    done
+    echo ""
+}
+
+# Pool-level used bytes from the Incus API (ground truth).
+pool_used_bytes() {
+    incus query "/1.0/storage-pools/$1/resources" | jq '.space.used'
+}
+
+# du -sm of a directory (filesystem-reported, may overcount on btrfs).
+du_mb() {
+    sudo du -sm "$1" 2>/dev/null | cut -f1
+}
+
+# Dump btrfs qgroup info for all subvolumes on the pool mount.
+btrfs_qgroups() {
+    local mount="$1"
+    sudo btrfs filesystem sync "$mount" 2>/dev/null || true
+    sudo btrfs qgroup show -re --raw "$mount" 2>/dev/null
+}
+
+echo "========================================"
+echo " CoW branching integration tests"
+echo "========================================"
+echo ""
+
+POOL=$(find_template_pool)
+if [ -z "$POOL" ]; then
+    echo "  ERROR: tpl-minimal not found on any storage pool"
+    exit 1
+fi
+DRIVER=$(incus storage list -f csv | grep "^$POOL," | cut -d, -f2)
+CONTAINERS_DIR="/var/lib/incus/storage-pools/$POOL/containers"
+POOL_MOUNT="/var/lib/incus/storage-pools/$POOL"
+
+echo "  Pool:                $POOL"
+echo "  Driver:              $DRIVER"
+echo "  Pool containers dir: $CONTAINERS_DIR"
+echo ""
+
+# Show storage pools for context
+echo "--- Storage pools ---"
+incus storage list 2>/dev/null || true
+echo ""
+
+# --- 1. Measure template size ---
+echo "--- 1. Template disk usage ---"
+TPL_DIR="$CONTAINERS_DIR/tpl-minimal"
+if [ ! -d "$TPL_DIR" ]; then
+    echo "  ERROR: $TPL_DIR does not exist"
+    echo "  Available: $(sudo ls "$CONTAINERS_DIR" 2>/dev/null || echo '(none)')"
+    exit 1
+fi
+TPL_DU_MB=$(du_mb "$TPL_DIR")
+echo "  Template du -sm: ${TPL_DU_MB}MB"
+echo ""
+
+# --- 2. Collect all metrics before branching ---
+echo "--- 2. Metrics before branch ---"
+POOL_BEFORE=$(pool_used_bytes "$POOL")
+DU_BEFORE=$(du_mb "$CONTAINERS_DIR")
+echo "  Pool space.used:     $(to_mb "$POOL_BEFORE")MB  ($POOL_BEFORE bytes)"
+echo "  du -sm containers/:  ${DU_BEFORE}MB"
+
+if [ "$DRIVER" = "btrfs" ]; then
+    echo ""
+    echo "  btrfs qgroups (before):"
+    btrfs_qgroups "$POOL_MOUNT" || true
+fi
+echo ""
+
+# --- 3. Branch ---
+echo "--- 3. Branching ---"
+isx branch cow-test-branch --from tpl-minimal --no-start 2>&1
+echo ""
+
+# --- 4. Collect all metrics after branching ---
+echo "--- 4. Metrics after branch ---"
+POOL_AFTER=$(pool_used_bytes "$POOL")
+DU_AFTER=$(du_mb "$CONTAINERS_DIR")
+echo "  Pool space.used:     $(to_mb "$POOL_AFTER")MB  ($POOL_AFTER bytes)"
+echo "  du -sm containers/:  ${DU_AFTER}MB"
+
+if [ "$DRIVER" = "btrfs" ]; then
+    echo ""
+    echo "  btrfs qgroups (after):"
+    btrfs_qgroups "$POOL_MOUNT" || true
+fi
+echo ""
+
+# --- 5. Compute deltas ---
+echo "--- 5. Deltas ---"
+DU_DELTA=$((DU_AFTER - DU_BEFORE))
+POOL_DELTA=$((POOL_AFTER - POOL_BEFORE))
+if [ "$DU_DELTA" -lt 0 ]; then DU_DELTA=0; fi
+if [ "$POOL_DELTA" -lt 0 ]; then POOL_DELTA=0; fi
+POOL_DELTA_MB=$(to_mb "$POOL_DELTA")
+
+echo "  du -sm delta:          ${DU_DELTA}MB  (informational — overcounts on btrfs)"
+echo "  pool space.used delta: ${POOL_DELTA_MB}MB  ($POOL_DELTA bytes)"
+echo "  template du for ref:   ${TPL_DU_MB}MB"
+echo ""
+
+# The pool-level delta is the ground truth — it measures actual bytes
+# consumed on the backing device.  du overcounts on btrfs because it
+# reports referenced (shared) blocks per subvolume, so it is kept as
+# informational output only.
+#
+# On a CoW backend, pool delta should be small (metadata only).
+# On a dir backend, pool delta ≈ template size (full rsync copy).
+THRESHOLD=$((TPL_DU_MB / 5))
+if [ "$THRESHOLD" -lt 50 ]; then THRESHOLD=50; fi
+
+echo "--- 6. Assertions ---"
+assert_lt "Pool space.used overhead (${POOL_DELTA_MB}MB) under ${THRESHOLD}MB" \
+    "$POOL_DELTA_MB" "$THRESHOLD"
+
+echo ""
+
+# --- Cleanup ---
+echo "--- Cleanup ---"
+isx destroy cow-test-branch 2>&1
+
+echo ""
+echo "========================================"
+if [ "$FAIL" -gt 0 ]; then
+    echo " $PASS/$TESTS passed, $FAIL FAILED"
+    exit 1
+fi
+echo " All $TESTS tests passed"
+echo "========================================"

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -250,10 +250,6 @@ jobs:
           sudo apt-get install -y -qq incus btrfs-progs qemu-system-x86
           sudo usermod -aG incus-admin "$USER"
 
-          sg incus-admin -c "sudo incus admin init --minimal"
-          sudo chown -R "$USER:$USER" ~/.config/incus/
-          sg incus-admin -c "incus storage create cow btrfs size=5GiB"
-
       - name: Enable KVM
         run: |
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
@@ -291,7 +287,15 @@ jobs:
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Initialize isx
-        run: sg incus-admin -c "yes '' | isx init"
+        run: |
+          sg incus-admin -c "isx init </dev/null"
+          # isx init runs 'sudo incus admin init' which creates ~/.config/incus/
+          # owned by root; fix so the incus CLI works for subsequent steps.
+          sudo chown -R "$USER:$USER" ~/.config/incus/ 2>/dev/null || true
+          # admin init creates a 'default' dir pool; isx init adds a 'cow' btrfs
+          # pool but intentionally does not rewire the profile (isx doctor warns
+          # instead). Point the profile at cow so templates use CoW branching.
+          sg incus-admin -c "incus profile device set default root pool=cow"
 
       - name: Start MITM proxy
         run: |
@@ -424,10 +428,6 @@ jobs:
           sudo apt-get install -y -qq incus btrfs-progs qemu-system-x86
           sudo usermod -aG incus-admin "$USER"
 
-          sg incus-admin -c "sudo incus admin init --minimal"
-          sudo chown -R "$USER:$USER" ~/.config/incus/
-          sg incus-admin -c "incus storage create cow btrfs size=5GiB"
-
       - name: Enable KVM
         run: |
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
@@ -455,7 +455,15 @@ jobs:
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Initialize isx
-        run: sg incus-admin -c "yes '' | isx init"
+        run: |
+          sg incus-admin -c "isx init </dev/null"
+          # isx init runs 'sudo incus admin init' which creates ~/.config/incus/
+          # owned by root; fix so the incus CLI works for subsequent steps.
+          sudo chown -R "$USER:$USER" ~/.config/incus/ 2>/dev/null || true
+          # admin init creates a 'default' dir pool; isx init adds a 'cow' btrfs
+          # pool but intentionally does not rewire the profile (isx doctor warns
+          # instead). Point the profile at cow so templates use CoW branching.
+          sg incus-admin -c "incus profile device set default root pool=cow"
 
       - name: Start MITM proxy
         run: |
@@ -573,9 +581,10 @@ jobs:
           sg incus-admin -c "isx destroy test-podman" || true
           sg incus-admin -c "isx destroy test-vm" || true
 
-  # Regression: isx init must produce a working setup on a machine where Incus has never been
-  # initialized. The isx-integration-tests job above runs 'incus admin init --minimal' first,
-  # which populates the default profile — so it cannot catch init leaving that profile empty.
+  # Regression: isx init must produce a working setup on a machine where a pool exists but
+  # the default profile is empty. This can happen when a pool was created manually (or by a
+  # previous isx version) without 'incus admin init'. The isx-integration-tests jobs let
+  # isx init handle everything from scratch, so they cannot catch this case.
   # A pool without a default profile made every instance creation fail with
   # "Failed getting root disk: No root device could be found", and was self-latching: once a
   # pool existed, init reported "Incus already initialized" and skipped the repair forever.
@@ -599,8 +608,7 @@ jobs:
           sudo usermod -aG incus-admin "$USER"
 
           # Create ONLY the storage pool — no admin init. This reproduces the reported broken
-          # state exactly (pool present, default profile empty) and, as a side effect, avoids
-          # isx init building an unbounded btrfs loop file (timed out at 19min on CI).
+          # state exactly (pool present, default profile empty).
           sg incus-admin -c "incus storage create cow btrfs size=5GiB"
 
           echo "Default profile before isx init:"
@@ -636,7 +644,7 @@ jobs:
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Run isx init
-        run: sg incus-admin -c "yes '' | isx init"
+        run: sg incus-admin -c "isx init </dev/null"
 
       - name: Assert the default profile is usable
         run: |

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -340,6 +340,9 @@ jobs:
           sg incus-admin -c "isx build tpl-test-podman --yes"
           sg incus-admin -c "isx build tpl-test-vm --yes"
 
+      - name: Test CoW branching
+        run: sg incus-admin -c "bash .github/scripts/test-cow-branching.sh"
+
       - name: Test container
         run: |
           sg incus-admin -c "isx branch test-container --from tpl-minimal --no-start"
@@ -507,6 +510,9 @@ jobs:
           sg incus-admin -c "isx build tpl-minimal --yes"
           sg incus-admin -c "isx build tpl-test-podman --yes"
           sg incus-admin -c "isx build tpl-test-vm --yes"
+
+      - name: Test CoW branching
+        run: sg incus-admin -c "bash .github/scripts/test-cow-branching.sh"
 
       - name: Test container
         run: |

--- a/cli/src/main/java/dev/incusspawn/command/InitCommand.java
+++ b/cli/src/main/java/dev/incusspawn/command/InitCommand.java
@@ -1113,7 +1113,9 @@ public class InitCommand extends BaseCommand {
         if (!anyCow) {
             System.out.println("  No copy-on-write storage pool detected. Creating one...");
             runHostQuiet("sudo", "mkdir", "-p", "/var/lib/incus/disks");
-            var createResult = runHost("sudo", "incus", "storage", "create", "cow", "btrfs", "size=100GiB");
+            // -K: skip initial whole-device TRIM, which takes minutes on loopback/ext4.
+            var createResult = runHost("sudo", "incus", "storage", "create", "cow", "btrfs",
+                    "size=100GiB", "btrfs.create_options=-K");
             if (createResult == 0) {
                 System.out.println("  Created btrfs storage pool 'cow' (100 GiB, thin-provisioned).");
                 System.out.println("  Resize with: sudo incus storage set cow size=200GiB");


### PR DESCRIPTION
Adds the integration test for #641 / #644, plus fixes needed to make CI exercise the real `isx init` flow. Three commits (see commit messages for details):

1. **Skip initial TRIM when creating the btrfs loopback pool** — pass `btrfs.create_options=-K` to avoid the 5–20 min `fallocate(PUNCH_HOLE)` on loopback/ext4 (Ubuntu). No downside; runtime `discard=async` is unaffected.

2. **Remove explicit CoW pool creation from CI workflows** — let `isx init` handle setup from scratch. Adds CI-side workarounds for stdin piping, `~/.config/incus/` ownership, and profile pool rewiring.

3. **Add integration test for CoW branching disk overhead** — asserts pool overhead stays under 20% of template size after branching.