### PR TITLE
Fix NPE in isx doctor for suggestion-only remediations

### DIFF
--- a/cli/src/main/java/dev/incusspawn/command/DoctorCommand.java
+++ b/cli/src/main/java/dev/incusspawn/command/DoctorCommand.java
@@ -120,6 +120,10 @@ public class DoctorCommand extends BaseCommand {
 
     /** Prompt to apply a remediation (TTY), or print the suggestion when non-interactive. */
     private void applyOrSuggest(Remediation r) {
+        if (r.action() == null) {
+            System.out.println("     " + r.description());
+            return;
+        }
         var console = System.console();
         if (console == null) {
             System.out.println("     fix: " + r.description() + " (re-run in a terminal to apply)");


### PR DESCRIPTION
## Summary

- Fix NPE when applying suggestion-only remediations in `isx doctor`
- Remediations with a null action (e.g. "Run 'isx init' to configure") crashed with `Cannot invoke ... because ... action() is null` when the user confirmed "Apply now?"
- Now null-action remediations print the suggestion text without prompting

## Test plan

- [x] Run `isx doctor` with missing credentials, confirm the "Apply now?" prompt — should print the suggestion instead of crashing