### PR TITLE
Replace bob's --yolo with --auto-approve

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,7 +381,7 @@ tools:
 default-action: bob
 ```
 
-Bob Shell requires an IBM API key ([create one here](https://bob.ibm.com/docs/ide/account/api-keys#create-an-api-key)). Run `isx init` to configure it — the real key stays on the host and the [MITM proxy](#credential-isolation) injects it transparently. Containers only hold a placeholder value. During `isx init` you'll be asked to accept the IBM license agreement; accepting pre-configures it in all containers so Bob Shell won't prompt again. The default action launches Bob with `--yolo` (auto-approve all tool calls); running `bob` manually in a shell uses normal approval mode.
+Bob Shell requires an IBM API key ([create one here](https://bob.ibm.com/docs/ide/account/api-keys#create-an-api-key)). Run `isx init` to configure it — the real key stays on the host and the [MITM proxy](#credential-isolation) injects it transparently. Containers only hold a placeholder value. During `isx init` you'll be asked to accept the IBM license agreement; accepting pre-configures it in all containers so Bob Shell won't prompt again. The default action launches Bob with `--auto-approve` (auto-approve all tool calls); running `bob` manually in a shell uses normal approval mode.
 
 ### Claude Code Skills
 

--- a/common/src/main/java/dev/incusspawn/tool/BobSetup.java
+++ b/common/src/main/java/dev/incusspawn/tool/BobSetup.java
@@ -45,7 +45,7 @@ public class BobSetup implements ToolSetup {
         var a = new ToolDef.ActionEntry();
         a.setLabel("Bob Shell");
         a.setType("shell");
-        a.setCommand("bob --yolo");
+        a.setCommand("bob --auto-approve");
         a.setAutoReturn(true);
         return List.of(a);
     }


### PR DESCRIPTION
Because Bob reports this:

  (ℹ) --yolo is deprecated. Use --auto-approve instead. Enabling auto-approve.