### PR TITLE
Recreate the zmx socket directory before starting an instance

### DIFF
--- a/cli/src/main/java/dev/incusspawn/command/InstancePrep.java
+++ b/cli/src/main/java/dev/incusspawn/command/InstancePrep.java
@@ -1,6 +1,5 @@
 package dev.incusspawn.command;
 
-import dev.incusspawn.config.HostResourceSetup;
 import dev.incusspawn.config.NetworkMode;
 import dev.incusspawn.incus.BridgeSubnetCheck;
 import dev.incusspawn.incus.FirewallDetector;
@@ -60,7 +59,7 @@ public class InstancePrep {
         // Start if stopped, or restart VMs with unresponsive agent
         if ("Stopped".equalsIgnoreCase(incus.getInstanceStatus(name))) {
             System.out.println("Starting " + name + "...");
-            HostResourceSetup.removeStaleDevices(incus, name);
+            InstanceLifecycle.prepareHostDevicesForStart(incus, name);
             incus.start(name);
             incus.waitForReady(name);
             if (ipFixed && incus.isVm(name)) {
@@ -69,6 +68,7 @@ public class InstancePrep {
         } else if (incus.isVm(name) && !incus.shellExec(name, "echo", "ready").success()) {
             System.out.println("VM agent not responding, restarting " + name + "...");
             incus.forceStop(name);
+            InstanceLifecycle.prepareHostDevicesForStart(incus, name);
             incus.start(name);
             incus.waitForReady(name);
             if (ipFixed) {
@@ -119,7 +119,7 @@ public class InstancePrep {
     private static void fixCaMismatch(IncusClient incus, String container) {
         // Ensure the container is running so we can push the cert
         if ("Stopped".equalsIgnoreCase(incus.getInstanceStatus(container))) {
-            HostResourceSetup.removeStaleDevices(incus, container);
+            InstanceLifecycle.prepareHostDevicesForStart(incus, container);
             incus.start(container);
             incus.waitForReady(container);
         }

--- a/cli/src/main/java/dev/incusspawn/command/ListCommand.java
+++ b/cli/src/main/java/dev/incusspawn/command/ListCommand.java
@@ -1631,6 +1631,12 @@ public class ListCommand extends BaseCommand {
                 try {
                     InstanceLifecycle.removeHostIntegration(renameSourceName);
                     AutoRemoteService.addRemotes(incus, newName, msg -> {});
+                    // The zmx device still points at the old name's directory,
+                    // which removeHostIntegration just deleted — re-point it.
+                    if (ZmxSocketForward.isZmxInstalled(
+                            incus.configGet(newName, Metadata.BUILD_SOURCE))) {
+                        ZmxSocketForward.configure(incus, newName);
+                    }
                     if (InstanceLifecycle.hasSshCapability(incus, newName)) {
                         SshKeyManager.addHostEntry(newName);
                     }
@@ -4987,7 +4993,7 @@ public class ListCommand extends BaseCommand {
 
     private void fixCaMismatchIfNeeded(String containerName) {
         if ("Stopped".equalsIgnoreCase(incus.getInstanceStatus(containerName))) {
-            HostResourceSetup.removeStaleDevices(incus, containerName);
+            InstanceLifecycle.prepareHostDevicesForStart(incus, containerName);
             incus.start(containerName);
             incus.waitForReady(containerName);
         }
@@ -5001,7 +5007,7 @@ public class ListCommand extends BaseCommand {
     private void shellInto(String name, String commandOverride) {
         if ("Stopped".equalsIgnoreCase(incus.getInstanceStatus(name))) {
             System.out.println("Starting " + name + "...");
-            HostResourceSetup.removeStaleDevices(incus, name);
+            InstanceLifecycle.prepareHostDevicesForStart(incus, name);
             incus.start(name);
             incus.waitForReady(name);
             if (vmIpFixApplied) {
@@ -5010,6 +5016,7 @@ public class ListCommand extends BaseCommand {
         } else if (incus.isVm(name) && !incus.shellExec(name, "echo", "ready").success()) {
             System.out.println("VM agent not responding, restarting " + name + "...");
             incus.forceStop(name);
+            InstanceLifecycle.prepareHostDevicesForStart(incus, name);
             incus.start(name);
             incus.waitForReady(name);
             if (vmIpFixApplied) {

--- a/common/src/main/java/dev/incusspawn/config/HostResourceSetup.java
+++ b/common/src/main/java/dev/incusspawn/config/HostResourceSetup.java
@@ -2,6 +2,7 @@ package dev.incusspawn.config;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.incusspawn.Environment;
 import dev.incusspawn.incus.Container;
@@ -142,7 +143,13 @@ public final class HostResourceSetup {
      * Removes disk devices whose host source path no longer exists.
      */
     public static void removeStaleDevices(IncusClient incus, String container) {
-        var hrJson = incus.configGet(container, Metadata.HOST_RESOURCES);
+        removeStaleDevices(incus, container, incus.instanceMetadata(container));
+    }
+
+    /** As above, reading the host-resource list from an already-fetched instance. */
+    public static void removeStaleDevices(IncusClient incus, String container,
+                                          JsonNode instanceMetadata) {
+        var hrJson = instanceMetadata.path("config").path(Metadata.HOST_RESOURCES).asText("");
         var resources = deserialize(hrJson);
         for (var hr : resources) {
             if ("copy".equals(hr.getMode())) continue;

--- a/common/src/main/java/dev/incusspawn/incus/IncusClient.java
+++ b/common/src/main/java/dev/incusspawn/incus/IncusClient.java
@@ -1518,6 +1518,28 @@ public class IncusClient {
     }
 
     /**
+     * The instance's own representation — {@code config} and {@code devices}
+     * as stored, without profile expansion.  Callers that need several fields
+     * read them from this one response instead of paying a round-trip per
+     * field (see {@link #deviceSource}).
+     * A rejected request (any non-2xx response) yields a missing node, so
+     * every field reads as absent; a transport failure still throws
+     * {@link IncusException}.
+     */
+    public JsonNode instanceMetadata(String name) {
+        return http().get("/1.0/instances/" + name).body().path("metadata");
+    }
+
+    /**
+     * Host source of a device as {@link #instanceMetadata} reports it, or ""
+     * when the instance declares no such device (profile-inherited devices
+     * are not part of that representation).
+     */
+    public static String deviceSource(JsonNode instanceMetadata, String deviceName) {
+        return instanceMetadata.path("devices").path(deviceName).path("source").asText("");
+    }
+
+    /**
      * Remove a device from a container/VM.
      * Uses a read-modify-write via GET + PUT because Incus PATCH cannot remove devices
      * (null values are rejected with 400, empty objects with 500).

--- a/common/src/main/java/dev/incusspawn/lifecycle/InstanceLifecycle.java
+++ b/common/src/main/java/dev/incusspawn/lifecycle/InstanceLifecycle.java
@@ -267,6 +267,20 @@ public final class InstanceLifecycle {
     }
 
     /**
+     * Repair host-side devices before starting an instance.  Both a
+     * host-resource source that has disappeared and a missing zmx socket
+     * directory otherwise fail Incus start validation with
+     * {@code Missing source path}.
+     */
+    public static void prepareHostDevicesForStart(IncusClient incus, String name) {
+        // Both repairs read the same instance, so fetch it once: start has to
+        // stay as cheap as it was before the repairs existed.
+        var instance = incus.instanceMetadata(name);
+        HostResourceSetup.removeStaleDevices(incus, name, instance);
+        ZmxSocketForward.ensureHostDirForStart(incus, name, instance);
+    }
+
+    /**
      * Apply host resource devices and (for instances) add git remotes.
      */
     public static void integrateWithHost(IncusClient incus, String name, InstanceType instanceType) {

--- a/common/src/main/java/dev/incusspawn/lifecycle/ZmxSocketForward.java
+++ b/common/src/main/java/dev/incusspawn/lifecycle/ZmxSocketForward.java
@@ -1,6 +1,6 @@
 package dev.incusspawn.lifecycle;
 
-import dev.incusspawn.Environment;
+import com.fasterxml.jackson.databind.JsonNode;
 import dev.incusspawn.config.BuildSource;
 import dev.incusspawn.config.HostResourceSetup;
 import dev.incusspawn.incus.IncusClient;
@@ -60,9 +60,12 @@ public final class ZmxSocketForward {
      * that zmx may have cleaned up.</p>
      */
     public static void configure(IncusClient incus, String name) {
+        configure(incus, name, hostZmxDir());
+    }
+
+    static void configure(IncusClient incus, String name, Path zmxDir) {
         if (Platform.isMacOS()) return;
 
-        var zmxDir = hostZmxDir();
         var containerDir = zmxDir.resolve(CONTAINERS_SUBDIR).resolve(name);
         try {
             Files.createDirectories(containerDir);
@@ -79,6 +82,45 @@ public final class ZmxSocketForward {
         incus.deviceAdd(name, DEVICE_NAME, "disk", args.toArray(String[]::new));
 
         ensureSymlink(zmxDir, name);
+    }
+
+    /**
+     * Restore the host side of the {@code zmx-sockets} device before start.
+     *
+     * <p>The host zmx dir normally lives under {@code XDG_RUNTIME_DIR}, a
+     * tmpfs wiped on reboot or logout, and a rename leaves the device
+     * pointing at the old (already deleted) directory.  Either way Incus
+     * refuses to start the instance with {@code Missing source path}.</p>
+     *
+     * <p>Costs a single stat while the directory is there; the repair reuses
+     * {@link #configure}, which also re-points a source left behind by a
+     * rename.</p>
+     *
+     * @param instanceMetadata the instance as fetched by
+     *        {@link IncusClient#instanceMetadata} — shared with the other
+     *        pre-start repairs so a start pays for only one round-trip
+     */
+    public static void ensureHostDirForStart(IncusClient incus, String name,
+                                             JsonNode instanceMetadata) {
+        ensureHostDirForStart(incus, name, hostZmxDir(), instanceMetadata);
+    }
+
+    static void ensureHostDirForStart(IncusClient incus, String name, Path zmxDir,
+                                      JsonNode instanceMetadata) {
+        if (Platform.isMacOS()) return;
+
+        var source = IncusClient.deviceSource(instanceMetadata, DEVICE_NAME);
+        if (source.isEmpty()) return; // no device — nothing to repair
+
+        // Healthy only if the device points at this name's directory and that
+        // directory is there: a source left over from a rename can still exist
+        // (it may belong to another instance by now), and the right directory
+        // can exist while the device points elsewhere.  Anything else is
+        // handed to configure(), which is idempotent.
+        var containerDir = zmxDir.resolve(CONTAINERS_SUBDIR).resolve(name).toAbsolutePath();
+        if (source.equals(containerDir.toString()) && Files.isDirectory(containerDir)) return;
+
+        configure(incus, name, zmxDir);
     }
 
     /**

--- a/common/src/test/java/dev/incusspawn/lifecycle/ZmxSocketForwardTest.java
+++ b/common/src/test/java/dev/incusspawn/lifecycle/ZmxSocketForwardTest.java
@@ -1,0 +1,180 @@
+package dev.incusspawn.lifecycle;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.incusspawn.Platform;
+import dev.incusspawn.incus.IncusClient;
+import dev.incusspawn.incus.Metadata;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.ArgumentCaptor;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Host-side repair of the {@code zmx-sockets} disk device.  The device source
+ * lives on a tmpfs that disappears on reboot/logout, and Incus refuses to
+ * start an instance whose disk source is missing, so the repair has to happen
+ * before every start — without slowing the common case down.
+ */
+class ZmxSocketForwardTest {
+
+    private static final String DEVICE = "zmx-sockets";
+    private static final String NAME = "demo";
+    private static final ObjectMapper JSON = new ObjectMapper();
+
+    @TempDir
+    Path zmxDir;
+
+    private IncusClient incus;
+
+    @BeforeEach
+    void setUp() {
+        assumeFalse(Platform.isMacOS(), "host socket sharing is Linux-only");
+        incus = mock(IncusClient.class);
+    }
+
+    private Path containerDir() {
+        return zmxDir.resolve("containers").resolve(NAME);
+    }
+
+    private Path symlink() {
+        return zmxDir.resolve("isx-" + NAME);
+    }
+
+    /** An instance as {@code IncusClient.instanceMetadata} returns it. */
+    private JsonNode instanceWithZmxDevice(String source) {
+        var metadata = JSON.createObjectNode();
+        metadata.putObject("devices").putObject(DEVICE)
+                .put("type", "disk")
+                .put("source", source);
+        return metadata;
+    }
+
+    @Test
+    void ensureHostDirForStart_directoryPresent_touchesNothing() throws IOException {
+        Files.createDirectories(containerDir());
+
+        ZmxSocketForward.ensureHostDirForStart(incus, NAME, zmxDir,
+                instanceWithZmxDevice(containerDir().toAbsolutePath().toString()));
+
+        // The healthy path must cost a single stat and no Incus call at all,
+        // or every start pays for the repair.
+        verifyNoInteractions(incus);
+    }
+
+    @Test
+    void ensureHostDirForStart_noZmxDevice_createsNothing() {
+        ZmxSocketForward.ensureHostDirForStart(incus, NAME, zmxDir, JSON.createObjectNode());
+
+        assertFalse(Files.exists(containerDir()),
+                "instances without the device must not get a stray directory");
+        assertFalse(Files.exists(symlink()));
+        verifyNoInteractions(incus);
+    }
+
+    @Test
+    void ensureHostDirForStart_wipedTmpfs_recreatesDirectoryAndSymlink() throws IOException {
+        ZmxSocketForward.ensureHostDirForStart(incus, NAME, zmxDir,
+                instanceWithZmxDevice(containerDir().toAbsolutePath().toString()));
+
+        assertTrue(Files.isDirectory(containerDir()));
+        assertTrue(Files.isSymbolicLink(symlink()));
+        assertEquals(Path.of("containers", NAME, "isx"), Files.readSymbolicLink(symlink()));
+        assertEquals("source=" + containerDir().toAbsolutePath(), deviceAddArgs().get(0));
+    }
+
+    @Test
+    void ensureHostDirForStart_staleSourceAfterRename_repointsDevice() {
+        var oldDir = zmxDir.resolve("containers").resolve("previous-name");
+
+        ZmxSocketForward.ensureHostDirForStart(incus, NAME, zmxDir,
+                instanceWithZmxDevice(oldDir.toString()));
+
+        assertTrue(Files.isDirectory(containerDir()));
+        verify(incus).devicesRemoveAll(NAME, List.of(DEVICE));
+        assertEquals("source=" + containerDir().toAbsolutePath(), deviceAddArgs().get(0));
+    }
+
+    /**
+     * The directory for this name exists but the device still points at the
+     * one a rename left behind: Incus would fail start validation, so the
+     * present directory must not be taken as proof of health.
+     */
+    @Test
+    void ensureHostDirForStart_rightDirectoryWrongSource_repointsDevice() throws IOException {
+        Files.createDirectories(containerDir());
+        var oldDir = zmxDir.resolve("containers").resolve("previous-name");
+
+        ZmxSocketForward.ensureHostDirForStart(incus, NAME, zmxDir,
+                instanceWithZmxDevice(oldDir.toString()));
+
+        assertEquals("source=" + containerDir().toAbsolutePath(), deviceAddArgs().get(0));
+    }
+
+    /**
+     * A stale source that still exists on disk — the old name was recreated
+     * since — would otherwise let the instance start against another
+     * instance's sockets.
+     */
+    @Test
+    void ensureHostDirForStart_staleSourceStillOnDisk_repointsDevice() throws IOException {
+        var oldDir = zmxDir.resolve("containers").resolve("previous-name");
+        Files.createDirectories(oldDir);
+
+        ZmxSocketForward.ensureHostDirForStart(incus, NAME, zmxDir,
+                instanceWithZmxDevice(oldDir.toString()));
+
+        assertTrue(Files.isDirectory(containerDir()));
+        assertEquals("source=" + containerDir().toAbsolutePath(), deviceAddArgs().get(0));
+    }
+
+    @Test
+    void configure_addsDiskDeviceForContainerZmxDir() throws IOException {
+        ZmxSocketForward.configure(incus, NAME, zmxDir);
+
+        assertTrue(Files.isDirectory(containerDir()));
+        assertEquals(Path.of("containers", NAME, "isx"), Files.readSymbolicLink(symlink()));
+        verify(incus).devicesRemoveAll(NAME, List.of(DEVICE));
+        assertEquals(
+                List.of("source=" + containerDir().toAbsolutePath(),
+                        "path=/home/agentuser/.zmx",
+                        "shift=true"),
+                deviceAddArgs());
+    }
+
+    /**
+     * The pre-start hook runs both repairs — a host-resource source that
+     * vanished and the zmx directory — off a single instance fetch, since
+     * either one failing start validation is what it exists to prevent.
+     */
+    @Test
+    void prepareHostDevicesForStart_bothRepairsShareOneFetch() {
+        // A name no real host directory can collide with: this call resolves
+        // the zmx dir from the environment, unlike the tests above.
+        var name = "wiring-" + java.util.UUID.randomUUID();
+        var instance = JSON.createObjectNode();
+        instance.putObject("config").put(Metadata.HOST_RESOURCES, "");
+        when(incus.instanceMetadata(name)).thenReturn(instance);
+
+        InstanceLifecycle.prepareHostDevicesForStart(incus, name);
+
+        verify(incus).instanceMetadata(name);
+        verifyNoMoreInteractions(incus);
+    }
+
+    private List<String> deviceAddArgs() {
+        var args = ArgumentCaptor.forClass(String[].class);
+        verify(incus).deviceAdd(eq(NAME), eq(DEVICE), eq("disk"), args.capture());
+        return List.of(args.getValue());
+    }
+}


### PR DESCRIPTION
## The bug

An instance built with the `zmx` tool carries a `zmx-sockets` disk device whose host source is `\$XDG_RUNTIME_DIR/zmx/containers/<name>`. That path is on a tmpfs, so a reboot or logout removes it and Incus refuses to start the instance:

```
Error: Operation failed: Failed start validation for device "zmx-sockets": Missing source path "/run/user/1000/zmx/containers/isx-proxydiagnosis" for disk "zmx-sockets"
```

Nothing recreated the directory: `ZmxSocketForward.configure()` runs only at branch creation, and the existing pre-start repair (`HostResourceSetup.removeStaleDevices`) only covers host-resource devices. Every zmx instance was therefore unstartable after a reboot, permanently, until the directory was recreated by hand.

A TUI rename reached the same dead end from the other side: `removeHostIntegration` deletes the old name's directory while the renamed instance's device still points at it.

## The fix

`ZmxSocketForward.ensureHostDirForStart` stats the directory before start; if it is gone *and* the instance declares the device, it calls `configure()` — which recreates the directory, re-points a source left stale by a rename, and restores the `isx-<name>` symlink. Wired into `InstanceLifecycle.prepareHostDevicesForStart`, which replaces the four existing `removeStaleDevices` calls plus the two "VM agent not responding → forceStop + start" branches that had no repair at all. The TUI rename path now re-points the device itself, so it stops leaving one dangling.

## Start stays as cheap as it was

Both repairs read the same instance, so `prepareHostDevicesForStart` fetches it once through the new `IncusClient.instanceMetadata` and passes the node to both (`removeStaleDevices` gained an overload that reads `host-resources` from it instead of its own `configGet`). **Net Incus round-trips added: zero** — start prep makes exactly the one GET it already made. Once the directory exists, the entire check is a single `stat`; two tests pin that (`verifyNoInteractions(incus)` on the healthy path, and exactly one fetch for the whole hook).

## Testing

- New `ZmxSocketForwardTest`, 6 cases: healthy directory → no Incus calls; no device → no stray directory; wiped tmpfs → directory + symlink recreated; stale source after rename → device re-pointed; `configure` device args; single-fetch wiring.
- `mvn verify -DskipITs` green apart from two pre-existing `GhSetupTest` failures ("Could not determine git identity from GitHub token"), which fail identically on a clean tree.
- Verified on a real host: deleted the socket directory, then `isx shell <instance>` recreated it plus the symlink and started the container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VvRDAcPQNSSKW7bzMvUwE3